### PR TITLE
Phase 6: Dataset loader for replay sessions

### DIFF
--- a/docs/milestones/deterministic-test-agent/plan.md
+++ b/docs/milestones/deterministic-test-agent/plan.md
@@ -30,10 +30,10 @@ This plan breaks the [design](design.md) into concrete, sequentially-executable 
   - [x] 5.2 Implement `applyScaffold()` to create stub files and directories
   - [x] 5.3 Handle `Edit` inputs: seed files with `old_string` content
   - [x] 5.4 Write `scripts/test-scaffold.ts` — scaffold a real dataset session, verify file tree
-- [ ] **[Phase 6: Dataset Loader](#phase-6-dataset-loader)**
-  - [ ] 6.1 Create `src/main/dataset-loader.ts` — parse JSONL, group by session, sort by timestamp
-  - [ ] 6.2 Add session listing and summary statistics
-  - [ ] 6.3 Verify: loader parses all 11,491 records, groups into 296 sessions
+- [x] **[Phase 6: Dataset Loader](#phase-6-dataset-loader)**
+  - [x] 6.1 Create `src/main/dataset-loader.ts` — parse JSONL, group by session, sort by timestamp
+  - [x] 6.2 Add session listing and summary statistics
+  - [x] 6.3 Verify: loader parses all 11,491 records, groups into 296 sessions
 - [ ] **[Phase 7: Test Harness — Single Session](#phase-7-test-harness--single-session)**
   - [ ] 7.1 Create `scripts/replay-test.ts` with CLI arg parsing
   - [ ] 7.2 Implement single-session orchestration: load → scaffold → spawn → prompt → collect → teardown

--- a/scripts/test-dataset-loader.ts
+++ b/scripts/test-dataset-loader.ts
@@ -1,0 +1,70 @@
+/**
+ * Test harness for the dataset loader.
+ *
+ * Loads the full dataset, verifies session count, record count,
+ * and sorting within sessions.
+ *
+ * Usage: npx tsx scripts/test-dataset-loader.ts
+ */
+import { join } from "node:path";
+import { loadDataset, datasetSummary, listSessions } from "../src/main/dataset-loader.js";
+
+const datasetPath = join(process.cwd(), "data", "tool-use-dataset.jsonl");
+
+let exitCode = 0;
+
+function check(label: string, condition: boolean) {
+  if (condition) {
+    console.log(`✓ ${label}`);
+  } else {
+    console.error(`✗ ${label}`);
+    exitCode = 1;
+  }
+}
+
+try {
+  // Load dataset
+  console.log("Loading dataset...");
+  const sessions = await loadDataset(datasetPath);
+  const summary = datasetSummary(sessions);
+
+  console.log(`Sessions: ${summary.sessionCount}`);
+  console.log(`Records: ${summary.recordCount}`);
+  console.log(`Tools: ${JSON.stringify(summary.toolDistribution)}`);
+
+  // Verify expected counts
+  check("Session count is 296", summary.sessionCount === 296);
+  check("Record count is 11491", summary.recordCount === 11491);
+
+  // Verify all sessions have at least one call
+  let emptyCount = 0;
+  for (const [, calls] of sessions) {
+    if (calls.length === 0) emptyCount++;
+  }
+  check("No empty sessions", emptyCount === 0);
+
+  // Verify tool distribution has expected tools
+  const expectedTools = ["Read", "Write", "Edit", "Bash", "Grep", "Glob"];
+  for (const tool of expectedTools) {
+    check(`Tool "${tool}" present in distribution`, tool in summary.toolDistribution);
+  }
+
+  // Test listSessions
+  console.log("\nTesting listSessions...");
+  const list = await listSessions(datasetPath);
+  check("listSessions count matches", list.length === summary.sessionCount);
+  check("listSessions entries have callCount > 0", list.every((s) => s.callCount > 0));
+  check("listSessions entries have tools", list.every((s) => s.tools.length > 0));
+  check("listSessions entries have project", list.every((s) => s.project.length > 0));
+
+  // Print a few examples
+  console.log(`\nFirst 3 sessions:`);
+  for (const s of list.slice(0, 3)) {
+    console.log(`  ${s.sessionId} (${s.project}): ${s.callCount} calls, tools: ${s.tools.join(", ")}`);
+  }
+} catch (err) {
+  console.error("Error:", err);
+  exitCode = 1;
+}
+
+process.exitCode = exitCode;

--- a/src/main/dataset-loader.ts
+++ b/src/main/dataset-loader.ts
@@ -1,0 +1,126 @@
+import { createReadStream } from "node:fs";
+import { createInterface } from "node:readline";
+import type { ReplayToolCall } from "./types.js";
+
+interface DatasetRecord {
+  id: number;
+  tool: string;
+  input: Record<string, unknown>;
+  outcome: string;
+  error_type?: string;
+  project: string;
+  session: string;
+  is_subagent: boolean;
+  permission_mode: string;
+  timestamp_relative: number;
+}
+
+function toReplayToolCall(record: DatasetRecord): ReplayToolCall {
+  return {
+    id: record.id,
+    tool: record.tool,
+    input: record.input,
+    original_outcome: record.outcome,
+  };
+}
+
+/**
+ * Load the dataset and group records by session.
+ * Returns a Map from session ID to sorted tool-call array.
+ */
+export async function loadDataset(
+  datasetPath: string,
+): Promise<Map<string, ReplayToolCall[]>> {
+  const sessions = new Map<string, { calls: ReplayToolCall[]; timestamps: number[] }>();
+
+  const rl = createInterface({
+    input: createReadStream(datasetPath, "utf-8"),
+    crlfDelay: Infinity,
+  });
+
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    const record = JSON.parse(line) as DatasetRecord;
+    let session = sessions.get(record.session);
+    if (!session) {
+      session = { calls: [], timestamps: [] };
+      sessions.set(record.session, session);
+    }
+    session.calls.push(toReplayToolCall(record));
+    session.timestamps.push(record.timestamp_relative);
+  }
+
+  // Sort each session's tool calls by timestamp_relative
+  const result = new Map<string, ReplayToolCall[]>();
+  for (const [sessionId, { calls, timestamps }] of sessions) {
+    const indices = calls.map((_, i) => i);
+    indices.sort((a, b) => timestamps[a] - timestamps[b]);
+    result.set(sessionId, indices.map((i) => calls[i]));
+  }
+
+  return result;
+}
+
+export interface SessionInfo {
+  sessionId: string;
+  project: string;
+  callCount: number;
+  tools: string[];
+}
+
+/**
+ * List sessions with basic metadata.
+ * Requires a second pass over the raw dataset to extract project info.
+ */
+export async function listSessions(
+  datasetPath: string,
+): Promise<SessionInfo[]> {
+  const sessionMap = new Map<string, { project: string; callCount: number; tools: Set<string> }>();
+
+  const rl = createInterface({
+    input: createReadStream(datasetPath, "utf-8"),
+    crlfDelay: Infinity,
+  });
+
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    const record = JSON.parse(line) as DatasetRecord;
+    let info = sessionMap.get(record.session);
+    if (!info) {
+      info = { project: record.project, callCount: 0, tools: new Set() };
+      sessionMap.set(record.session, info);
+    }
+    info.callCount++;
+    info.tools.add(record.tool);
+  }
+
+  return Array.from(sessionMap.entries()).map(([sessionId, info]) => ({
+    sessionId,
+    project: info.project,
+    callCount: info.callCount,
+    tools: [...info.tools].sort(),
+  }));
+}
+
+/**
+ * Get summary statistics for the loaded dataset.
+ */
+export function datasetSummary(
+  sessions: Map<string, ReplayToolCall[]>,
+): { sessionCount: number; recordCount: number; toolDistribution: Record<string, number> } {
+  let recordCount = 0;
+  const toolDistribution: Record<string, number> = {};
+
+  for (const calls of sessions.values()) {
+    recordCount += calls.length;
+    for (const call of calls) {
+      toolDistribution[call.tool] = (toolDistribution[call.tool] ?? 0) + 1;
+    }
+  }
+
+  return {
+    sessionCount: sessions.size,
+    recordCount,
+    toolDistribution,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `src/main/dataset-loader.ts` with three exports:
  - `loadDataset(path)` — streams JSONL, groups records by session ID, sorts each session by `timestamp_relative`
  - `listSessions(path)` — returns per-session metadata (project, call count, tools used)
  - `datasetSummary(sessions)` — aggregate stats (session count, record count, tool distribution)
- Add `scripts/test-dataset-loader.ts` test harness

## Test plan
- [x] `npx tsc -p tsconfig.node.json --noEmit` — clean
- [x] `npx tsx scripts/test-dataset-loader.ts` — all checks pass:
  - 296 sessions, 11491 records
  - No empty sessions
  - All expected tools (Read, Write, Edit, Bash, Grep, Glob) present
  - `listSessions` count matches, all entries have project/callCount/tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)