### PR TITLE
Add api.anthropic.com to standard-pr proxy allowlist

### DIFF
--- a/src/main/policy-templates.ts
+++ b/src/main/policy-templates.ts
@@ -18,9 +18,13 @@ export const standardPrTemplate: PolicyTemplate = {
   network: {
     access: "filtered",
     allowedDomains: [
+      // Claude Code API backend — required for the agent to function
+      "api.anthropic.com",
+      // GitHub (code hosting, API, uploads)
       "github.com",
       "api.github.com",
       "uploads.github.com",
+      // Package registries
       "registry.npmjs.org",
       "crates.io",
       "static.crates.io",


### PR DESCRIPTION
## Summary
- The `standard-pr` policy template's proxy allowlist was missing `api.anthropic.com`, causing Claude Code's API calls to be blocked with `403 Forbidden` — the agent silently stops responding.
- Adds `api.anthropic.com` as a passthrough (no TLS inspection) in the allowed domains list.

## Test plan
- [x] Start a session with the `standard-pr` template and verify Claude Code can reach its API backend
- [x] Verify other allowed domains (GitHub, npm, etc.) still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)