### PR TITLE
Add Prettier with CI enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,18 @@ on:
     branches: [main]
 
 jobs:
+  format:
+    name: Prettier
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run format:check
+
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+node_modules/
+out/
+dist/
+*.json

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/docs/history/application-layer-policies/design.md
+++ b/docs/history/application-layer-policies/design.md
@@ -107,6 +107,7 @@ The shim is a standalone executable placed on the agent's `PATH` as `gh`. When i
 ### Implementation Language
 
 The shim is implemented as a **compiled executable** (TypeScript compiled to a single-file Node.js script via `esbuild`, invoked as `node /path/to/gh-shim.js`). Alternatively, it could be a simple shell script for lower overhead, but TypeScript gives us:
+
 - Shared types with the rest of the codebase
 - Easier argument parsing (the `gh` CLI grammar is non-trivial)
 - JSON policy file reading/writing
@@ -120,64 +121,64 @@ The shim evaluates each invocation against this policy matrix. The default is **
 
 #### `gh pr` subcommands
 
-| Subcommand | Policy | Conditions |
-|---|---|---|
-| `pr create` | **Allow** | Only if `canCreatePr` is true. Capture PR number from output. |
-| `pr edit` | **Allow** | Only for `ownedPrNumber`. Deny if targeting a different PR. |
-| `pr view` | **Allow** | Any PR (read-only). |
-| `pr list` | **Allow** | Read-only. |
-| `pr status` | **Allow** | Read-only. |
-| `pr checks` | **Allow** | Any PR (read-only). |
-| `pr diff` | **Allow** | Any PR (read-only). |
-| `pr comment` | **Allow** | Only for `ownedPrNumber`. |
-| `pr checkout` | **Deny** | The agent should work in its worktree, not switch to another PR's branch. |
-| `pr close` | **Deny** | Destructive. |
-| `pr merge` | **Deny** | Destructive. |
-| `pr ready` | **Allow** | Only for `ownedPrNumber`. |
-| `pr reopen` | **Deny** | Operates on closed PRs the agent doesn't own. |
-| `pr review` | **Deny** | The agent shouldn't be reviewing PRs. |
-| `pr lock` / `pr unlock` | **Deny** | Administrative. |
-| `pr update-branch` | **Allow** | Only for `ownedPrNumber`. |
+| Subcommand              | Policy    | Conditions                                                                |
+| ----------------------- | --------- | ------------------------------------------------------------------------- |
+| `pr create`             | **Allow** | Only if `canCreatePr` is true. Capture PR number from output.             |
+| `pr edit`               | **Allow** | Only for `ownedPrNumber`. Deny if targeting a different PR.               |
+| `pr view`               | **Allow** | Any PR (read-only).                                                       |
+| `pr list`               | **Allow** | Read-only.                                                                |
+| `pr status`             | **Allow** | Read-only.                                                                |
+| `pr checks`             | **Allow** | Any PR (read-only).                                                       |
+| `pr diff`               | **Allow** | Any PR (read-only).                                                       |
+| `pr comment`            | **Allow** | Only for `ownedPrNumber`.                                                 |
+| `pr checkout`           | **Deny**  | The agent should work in its worktree, not switch to another PR's branch. |
+| `pr close`              | **Deny**  | Destructive.                                                              |
+| `pr merge`              | **Deny**  | Destructive.                                                              |
+| `pr ready`              | **Allow** | Only for `ownedPrNumber`.                                                 |
+| `pr reopen`             | **Deny**  | Operates on closed PRs the agent doesn't own.                             |
+| `pr review`             | **Deny**  | The agent shouldn't be reviewing PRs.                                     |
+| `pr lock` / `pr unlock` | **Deny**  | Administrative.                                                           |
+| `pr update-branch`      | **Allow** | Only for `ownedPrNumber`.                                                 |
 
 #### `gh issue` subcommands
 
-| Subcommand | Policy |
-|---|---|
-| `issue view` | **Allow** (read-only) |
-| `issue list` | **Allow** (read-only) |
-| `issue status` | **Allow** (read-only) |
-| `issue create` | **Deny** |
-| `issue edit` | **Deny** |
-| `issue close` | **Deny** |
-| `issue comment` | **Deny** |
-| `issue delete` | **Deny** |
-| All other `issue` subcommands | **Deny** |
+| Subcommand                    | Policy                |
+| ----------------------------- | --------------------- |
+| `issue view`                  | **Allow** (read-only) |
+| `issue list`                  | **Allow** (read-only) |
+| `issue status`                | **Allow** (read-only) |
+| `issue create`                | **Deny**              |
+| `issue edit`                  | **Deny**              |
+| `issue close`                 | **Deny**              |
+| `issue comment`               | **Deny**              |
+| `issue delete`                | **Deny**              |
+| All other `issue` subcommands | **Deny**              |
 
 #### Other `gh` top-level commands
 
-| Command | Policy | Notes |
-|---|---|---|
-| `repo view` | **Allow** | Read-only metadata. |
-| `repo clone` | **Deny** | Agent should work in its worktree. |
-| `release list` / `release view` | **Allow** | Read-only. |
-| `release create` / `release edit` / `release delete` | **Deny** | Destructive. |
-| `search` | **Allow** | Read-only. |
-| `api` | **Evaluate** | See [gh api handling](#gh-api-handling) below. |
-| `auth` | **Deny** | Agent should not modify auth state. |
-| `config` | **Deny** | Agent should not modify gh config. |
-| `gist` | **Deny** | Publishing content outside the repo. |
-| `codespace` | **Deny** | Infrastructure. |
-| `ssh-key` / `gpg-key` | **Deny** | Credential management. |
-| `secret` / `variable` | **Deny** | Repository settings. |
-| `label` | **Deny** | Repository settings. |
-| `extension` | **Deny** | Installing extensions could be a vector. |
-| `run view` / `run list` | **Allow** | Read-only CI status. |
-| `run cancel` / `run rerun` / `run delete` / `run watch` | **Deny** | CI operations. |
-| `workflow view` / `workflow list` | **Allow** | Read-only. |
-| `workflow run` / `workflow enable` / `workflow disable` | **Deny** | CI operations. |
-| `browse` | **Allow** | Opens a URL in the terminal; harmless. |
-| `status` | **Allow** | Read-only cross-repo status. |
-| All other commands | **Deny** | Default deny. |
+| Command                                                 | Policy       | Notes                                          |
+| ------------------------------------------------------- | ------------ | ---------------------------------------------- |
+| `repo view`                                             | **Allow**    | Read-only metadata.                            |
+| `repo clone`                                            | **Deny**     | Agent should work in its worktree.             |
+| `release list` / `release view`                         | **Allow**    | Read-only.                                     |
+| `release create` / `release edit` / `release delete`    | **Deny**     | Destructive.                                   |
+| `search`                                                | **Allow**    | Read-only.                                     |
+| `api`                                                   | **Evaluate** | See [gh api handling](#gh-api-handling) below. |
+| `auth`                                                  | **Deny**     | Agent should not modify auth state.            |
+| `config`                                                | **Deny**     | Agent should not modify gh config.             |
+| `gist`                                                  | **Deny**     | Publishing content outside the repo.           |
+| `codespace`                                             | **Deny**     | Infrastructure.                                |
+| `ssh-key` / `gpg-key`                                   | **Deny**     | Credential management.                         |
+| `secret` / `variable`                                   | **Deny**     | Repository settings.                           |
+| `label`                                                 | **Deny**     | Repository settings.                           |
+| `extension`                                             | **Deny**     | Installing extensions could be a vector.       |
+| `run view` / `run list`                                 | **Allow**    | Read-only CI status.                           |
+| `run cancel` / `run rerun` / `run delete` / `run watch` | **Deny**     | CI operations.                                 |
+| `workflow view` / `workflow list`                       | **Allow**    | Read-only.                                     |
+| `workflow run` / `workflow enable` / `workflow disable` | **Deny**     | CI operations.                                 |
+| `browse`                                                | **Allow**    | Opens a URL in the terminal; harmless.         |
+| `status`                                                | **Allow**    | Read-only cross-repo status.                   |
+| All other commands                                      | **Deny**     | Default deny.                                  |
 
 ### `gh api` Handling
 
@@ -197,20 +198,20 @@ gh api <endpoint> [--method <METHOD>] [-X <METHOD>] [flags]
 
 The shim maps `(method, endpoint_pattern)` to allow/deny using the same logic as the subcommand table:
 
-| Method | Endpoint Pattern | Policy | Equivalent |
-|---|---|---|---|
-| GET | `/repos/{owner}/{repo}` | Allow | Repo metadata |
-| GET | `/repos/{owner}/{repo}/pulls` | Allow | `pr list` |
-| GET | `/repos/{owner}/{repo}/pulls/{number}` | Allow | `pr view` |
-| POST | `/repos/{owner}/{repo}/pulls` | Allow if `canCreatePr` | `pr create` |
-| PATCH | `/repos/{owner}/{repo}/pulls/{ownedPr}` | Allow | `pr edit` |
-| PATCH | `/repos/{owner}/{repo}/pulls/{otherPr}` | Deny | Editing another PR |
-| PUT | `/repos/{owner}/{repo}/pulls/{number}/merge` | Deny | `pr merge` |
-| GET | `/repos/{owner}/{repo}/issues` | Allow | `issue list` |
-| GET | `/repos/{owner}/{repo}/issues/{number}` | Allow | `issue view` |
-| POST | `/repos/{owner}/{repo}/issues` | Deny | `issue create` |
-| DELETE | `*` | Deny | Any deletion |
-| * | `*` | Deny | Default deny |
+| Method | Endpoint Pattern                             | Policy                 | Equivalent         |
+| ------ | -------------------------------------------- | ---------------------- | ------------------ |
+| GET    | `/repos/{owner}/{repo}`                      | Allow                  | Repo metadata      |
+| GET    | `/repos/{owner}/{repo}/pulls`                | Allow                  | `pr list`          |
+| GET    | `/repos/{owner}/{repo}/pulls/{number}`       | Allow                  | `pr view`          |
+| POST   | `/repos/{owner}/{repo}/pulls`                | Allow if `canCreatePr` | `pr create`        |
+| PATCH  | `/repos/{owner}/{repo}/pulls/{ownedPr}`      | Allow                  | `pr edit`          |
+| PATCH  | `/repos/{owner}/{repo}/pulls/{otherPr}`      | Deny                   | Editing another PR |
+| PUT    | `/repos/{owner}/{repo}/pulls/{number}/merge` | Deny                   | `pr merge`         |
+| GET    | `/repos/{owner}/{repo}/issues`               | Allow                  | `issue list`       |
+| GET    | `/repos/{owner}/{repo}/issues/{number}`      | Allow                  | `issue view`       |
+| POST   | `/repos/{owner}/{repo}/issues`               | Deny                   | `issue create`     |
+| DELETE | `*`                                          | Deny                   | Any deletion       |
+| \*     | `*`                                          | Deny                   | Default deny       |
 
 The `{owner}/{repo}` in patterns is matched against the session's `repo` field. Requests targeting other repos are denied.
 
@@ -238,8 +239,8 @@ interface ParsedGhCommand {
   positionalArgs: string[];
   /** Parsed flags relevant to policy decisions */
   flags: {
-    repo?: string;        // -R, --repo
-    method?: string;      // --method, -X (for gh api)
+    repo?: string; // -R, --repo
+    method?: string; // --method, -X (for gh api)
   };
 }
 ```
@@ -367,10 +368,10 @@ During session teardown, remove the hooks directory alongside the existing polic
 
 New variables added to the agent's environment:
 
-| Variable | Value | Purpose |
-|---|---|---|
-| `BOUNCER_GITHUB_POLICY` | `/tmp/glitterball-sandbox/{sessionId}-github-policy.json` | Policy state file path for the `gh` shim |
-| `BOUNCER_REAL_GH` | Output of `which gh` at session start | Path to the real `gh` binary for proxying |
+| Variable                | Value                                                     | Purpose                                   |
+| ----------------------- | --------------------------------------------------------- | ----------------------------------------- |
+| `BOUNCER_GITHUB_POLICY` | `/tmp/glitterball-sandbox/{sessionId}-github-policy.json` | Policy state file path for the `gh` shim  |
+| `BOUNCER_REAL_GH`       | Output of `which gh` at session start                     | Path to the real `gh` binary for proxying |
 
 These are added to the `env` passed to `spawn()`, alongside the existing `ANTHROPIC_API_KEY` etc.
 
@@ -402,6 +403,7 @@ export interface SessionSummary {
 ### Cleanup
 
 Session teardown adds:
+
 - Remove hooks directory: `rm -rf /tmp/glitterball-sandbox/{sessionId}-hooks/`
 - Remove policy state file: `rm -f /tmp/glitterball-sandbox/{sessionId}-github-policy.json`
 - Unset `core.hooksPath` in worktree config (before worktree removal, to avoid stale config if removal fails)
@@ -425,18 +427,18 @@ The `gh` shim and git hooks produce structured log output that the Session Manag
 ```typescript
 export type SessionUpdate =
   // ... existing types ...
-  | {
-      sessionId: string;
-      type: "policy-event";
-      event: PolicyEvent;
-    };
+  {
+    sessionId: string;
+    type: 'policy-event';
+    event: PolicyEvent;
+  };
 
 export interface PolicyEvent {
   timestamp: number;
-  tool: "gh" | "git";
-  operation: string;       // e.g., "pr create", "push refs/heads/main"
-  decision: "allow" | "deny";
-  reason?: string;         // Human-readable reason for deny
+  tool: 'gh' | 'git';
+  operation: string; // e.g., "pr create", "push refs/heads/main"
+  decision: 'allow' | 'deny';
+  reason?: string; // Human-readable reason for deny
 }
 ```
 
@@ -461,32 +463,32 @@ The existing `standard-pr` template gains GitHub policy defaults:
 
 ```typescript
 export const standardPrTemplate: PolicyTemplate = {
-  id: "standard-pr",
-  name: "Standard PR",
-  description: "Read-write worktree, standard toolchains, GitHub PR-scoped access",
+  id: 'standard-pr',
+  name: 'Standard PR',
+  description: 'Read-write worktree, standard toolchains, GitHub PR-scoped access',
   filesystem: {
-    worktreeAccess: "read-write",
+    worktreeAccess: 'read-write',
     additionalWritableDirs: [],
     additionalReadOnlyDirs: [],
   },
-  network: { access: "none" },
+  network: { access: 'none' },
   env: {
     additional: [],
     exclude: [],
   },
-  safehouseIntegrations: ["all-agents"],
+  safehouseIntegrations: ['all-agents'],
   github: {
     // repo, allowedPushRefs, ownedPrNumber are set per-session
     // These are template defaults indicating that GitHub policy is active
-    repo: "",                   // Populated at session creation
-    allowedPushRefs: [],        // Populated at session creation
-    ownedPrNumber: null,        // Set after PR creation
+    repo: '', // Populated at session creation
+    allowedPushRefs: [], // Populated at session creation
+    ownedPrNumber: null, // Set after PR creation
     canCreatePr: true,
   },
 };
 ```
 
-The `repo` and `allowedPushRefs` fields are populated by the Session Manager from the worktree's git remote and branch name. The template declares *intent* (GitHub policy is active); the Session Manager fills in the *specifics*.
+The `repo` and `allowedPushRefs` fields are populated by the Session Manager from the worktree's git remote and branch name. The template declares _intent_ (GitHub policy is active); the Session Manager fills in the _specifics_.
 
 ### Templates Without GitHub Policy
 

--- a/docs/history/application-layer-policies/findings.md
+++ b/docs/history/application-layer-policies/findings.md
@@ -57,6 +57,7 @@ End-to-end validation confirmed that the application-layer policy system works: 
 ### Shim architecture
 
 The esbuild bundle approach is strictly better than tsx-at-runtime:
+
 - **Faster startup**: No tsx/esbuild initialization overhead per `gh` invocation
 - **Sandbox-compatible**: No `process.cwd()` calls, no module resolution from worktree
 - **Self-contained**: Single JS file with no external dependencies
@@ -69,6 +70,7 @@ The `gh-shim-wrapper.sh` template from the original design was removed. The wrap
 Allow events from the gh shim are not currently visible in the UI policy log — only deny events appear. This is an acceptable trade-off: deny events are the security-relevant ones. Allow events from the pre-push hook still appear (git hooks write to the push caller's stderr, not captured as tool output).
 
 Future options for allow-event observability:
+
 - Write to a dedicated log file that the session manager watches
 - Use fd 3 as a log channel (requires session manager to open it)
 - Parse the agent's ACP tool call stream for `gh` invocations
@@ -76,6 +78,7 @@ Future options for allow-event observability:
 ### Dev vs. production shim path
 
 The session manager resolves the shim source path based on `app.isPackaged`:
+
 - Dev: `src/main/gh-shim.ts` (bundled by esbuild at runtime)
 - Prod: `dist/main/gh-shim.js` (pre-built by electron-vite)
 
@@ -83,15 +86,15 @@ The esbuild bundle step at session creation handles dev mode. For production, th
 
 ## Test Coverage
 
-| Test suite | Count | CI |
-|---|---|---|
-| `test:github-policy` | 15 | Yes |
-| `test:gh-shim` | 89 | Yes |
-| `test:hooks` | 10 | Yes |
-| `test:app-layer-policy` | 14 | Yes |
-| `test:policy-event-parser` | 14 | Yes |
-| `test:policy-sandbox` | 3 | Yes |
-| **Total** | **145** | |
+| Test suite                 | Count   | CI  |
+| -------------------------- | ------- | --- |
+| `test:github-policy`       | 15      | Yes |
+| `test:gh-shim`             | 89      | Yes |
+| `test:hooks`               | 10      | Yes |
+| `test:app-layer-policy`    | 14      | Yes |
+| `test:policy-event-parser` | 14      | Yes |
+| `test:policy-sandbox`      | 3       | Yes |
+| **Total**                  | **145** |     |
 
 All tests pass in CI (Ubuntu) and locally (macOS).
 

--- a/docs/history/application-layer-policies/plan.md
+++ b/docs/history/application-layer-policies/plan.md
@@ -77,9 +77,9 @@ export interface GitHubPolicy {
 /** Logged when the gh shim or git hook allows/denies an operation. */
 export interface PolicyEvent {
   timestamp: number;
-  tool: "gh" | "git";
+  tool: 'gh' | 'git';
   operation: string;
-  decision: "allow" | "deny";
+  decision: 'allow' | 'deny';
   reason?: string;
 }
 ```
@@ -108,7 +108,7 @@ Update `SessionUpdate` — add the `policy-event` variant:
 ```typescript
 export type SessionUpdate =
   // ... existing variants ...
-  | { sessionId: string; type: "policy-event"; event: PolicyEvent };
+  { sessionId: string; type: 'policy-event'; event: PolicyEvent };
 ```
 
 **Verify**: `npm run typecheck` passes.
@@ -120,12 +120,12 @@ export type SessionUpdate =
 This module handles GitHub remote detection and policy state file I/O.
 
 ```typescript
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-import { readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
-import { POLICY_DIR } from "./sandbox.js";
-import type { GitHubPolicy } from "./types.js";
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { POLICY_DIR } from './sandbox.js';
+import type { GitHubPolicy } from './types.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -134,36 +134,37 @@ const execFileAsync = promisify(execFile);
  * Parses the origin remote URL (HTTPS or SSH format).
  * Returns null if no GitHub remote is found.
  */
-export async function detectGitHubRepo(cwd: string): Promise<string | null>
+export async function detectGitHubRepo(cwd: string): Promise<string | null>;
 
 /**
  * Build a GitHubPolicy for a new session.
  */
-export function buildSessionPolicy(repo: string, branch: string): GitHubPolicy
+export function buildSessionPolicy(repo: string, branch: string): GitHubPolicy;
 
 /**
  * Path to the policy state file for a session.
  */
-export function policyStatePath(sessionId: string): string
+export function policyStatePath(sessionId: string): string;
 
 /**
  * Write the policy state file. Called at session creation and
  * updated by the gh shim after PR creation.
  */
-export async function writePolicyState(sessionId: string, policy: GitHubPolicy): Promise<void>
+export async function writePolicyState(sessionId: string, policy: GitHubPolicy): Promise<void>;
 
 /**
  * Read the policy state file. Called by the gh shim on each invocation.
  */
-export async function readPolicyState(path: string): Promise<GitHubPolicy>
+export async function readPolicyState(path: string): Promise<GitHubPolicy>;
 
 /**
  * Clean up the policy state file for a session.
  */
-export async function cleanupPolicyState(sessionId: string): Promise<void>
+export async function cleanupPolicyState(sessionId: string): Promise<void>;
 ```
 
 Implementation notes:
+
 - `detectGitHubRepo`: run `git -C <cwd> remote get-url origin`, parse the URL. Handle both `https://github.com/owner/repo.git` and `git@github.com:owner/repo.git` formats. Strip trailing `.git`. Return `null` if the remote doesn't match GitHub.
 - `buildSessionPolicy`: returns `{ repo, allowedPushRefs: [branch], ownedPrNumber: null, canCreatePr: true }`.
 - `policyStatePath`: returns `join(POLICY_DIR, \`${sessionId}-github-policy.json\`)`.
@@ -179,8 +180,8 @@ Add the `github` field to `standardPrTemplate`:
 export const standardPrTemplate: PolicyTemplate = {
   // ... existing fields ...
   github: {
-    repo: "",              // Populated per-session
-    allowedPushRefs: [],   // Populated per-session
+    repo: '', // Populated per-session
+    allowedPushRefs: [], // Populated per-session
     ownedPrNumber: null,
     canCreatePr: true,
   },
@@ -196,6 +197,7 @@ The other two templates (`research-only`, `permissive`) remain unchanged — no 
 **New file**: `scripts/test-github-policy.ts`
 
 A standalone test script (consistent with the project's existing `scripts/test-*.ts` pattern) that:
+
 1. Calls `detectGitHubRepo` on the Bouncer repo itself (should return `dherman/bouncer` or similar)
 2. Tests URL parsing for HTTPS, SSH, and non-GitHub remotes
 3. Tests `buildSessionPolicy` output
@@ -250,26 +252,23 @@ export interface ParsedGhCommand {
  * Parse gh CLI arguments into a structured command.
  * Only extracts policy-relevant information; all other flags pass through.
  */
-export function parseGhArgs(args: string[]): ParsedGhCommand
+export function parseGhArgs(args: string[]): ParsedGhCommand;
 
 // --- Policy Evaluation ---
 
 export type PolicyDecision =
-  | { action: "allow" }
-  | { action: "allow-and-capture-pr" }
-  | { action: "deny"; reason: string };
+  | { action: 'allow' }
+  | { action: 'allow-and-capture-pr' }
+  | { action: 'deny'; reason: string };
 
 /**
  * Evaluate a parsed gh command against the session policy.
  */
-export function evaluatePolicy(
-  parsed: ParsedGhCommand,
-  policy: GitHubPolicy,
-): PolicyDecision
+export function evaluatePolicy(parsed: ParsedGhCommand, policy: GitHubPolicy): PolicyDecision;
 
 // --- Main (standalone entry point) ---
 
-async function main(): Promise<void>
+async function main(): Promise<void>;
 ```
 
 ### Step 2.2: Implement the subcommand parser
@@ -286,6 +285,7 @@ The parser processes `argv` (everything after the shim's own invocation, i.e., w
 6. For `api` command: extract `--method` / `-X` flag value; detect `-f` / `-F` / `--field` / `--raw-field` presence (implies POST)
 
 Edge cases to handle:
+
 - `gh pr view` (no positional args — operates on current branch's PR)
 - `gh pr view 42` (PR number as positional arg)
 - `gh pr create --title "foo" --body "bar"` (flags interspersed)
@@ -301,27 +301,24 @@ Edge cases to handle:
 Implements the [subcommand policy table](design.md#subcommand-policy-table) from the design doc. The function is a series of match clauses:
 
 ```typescript
-export function evaluatePolicy(
-  parsed: ParsedGhCommand,
-  policy: GitHubPolicy,
-): PolicyDecision {
+export function evaluatePolicy(parsed: ParsedGhCommand, policy: GitHubPolicy): PolicyDecision {
   const { command, subcommand, positionalArgs } = parsed;
 
   // Global help/version — always allow
-  if (command === "--help" || command === "--version") {
-    return { action: "allow" };
+  if (command === '--help' || command === '--version') {
+    return { action: 'allow' };
   }
 
   switch (command) {
-    case "pr":
+    case 'pr':
       return evaluatePrPolicy(subcommand, positionalArgs, parsed.flags, policy);
-    case "issue":
+    case 'issue':
       return evaluateIssuePolicy(subcommand);
-    case "api":
+    case 'api':
       return evaluateApiPolicy(positionalArgs, parsed.flags, policy);
     // ... other commands ...
     default:
-      return { action: "deny", reason: `command '${command}' is not allowed` };
+      return { action: 'deny', reason: `command '${command}' is not allowed` };
   }
 }
 ```
@@ -352,6 +349,7 @@ interface ApiEndpointMatch {
 ```
 
 The endpoint parser handles:
+
 - Absolute paths: `/repos/owner/repo/pulls/42`
 - Placeholder paths: `/repos/{owner}/{repo}/pulls` (gh expands `{owner}` and `{repo}`)
 - The `graphql` shorthand
@@ -388,6 +386,7 @@ PR number capture from `gh pr create` output: `gh pr create` prints a URL like `
 The shim needs to run as a standalone Node.js script outside the Electron context. Since the project uses electron-vite (Vite/Rollup), add a small build step.
 
 **Option A**: Use `tsx` at runtime (simpler, already a dev dependency):
+
 - The shim wrapper script is a shell script:
   ```bash
   #!/bin/bash
@@ -396,6 +395,7 @@ The shim needs to run as a standalone Node.js script outside the Electron contex
 - Pro: no build step. Con: slower startup (~100ms for tsx), and tsx must be accessible in the sandbox.
 
 **Option B**: Bundle with esbuild (add as dev dependency):
+
 - `npm install -D esbuild`
 - Add `scripts/build-gh-shim.ts` that calls esbuild to produce `out/gh-shim.js`
 - The wrapper script: `#!/bin/bash\nexec node /path/to/out/gh-shim.js "$@"`
@@ -420,6 +420,7 @@ The Session Manager replaces `__NODE__` and `__GH_SHIM_TS__` with actual paths a
 Test the exported functions (`parseGhArgs`, `evaluatePolicy`) directly — no subprocess needed.
 
 **Parser tests:**
+
 - `["pr", "create", "--title", "foo"]` → `{ command: "pr", subcommand: "create", ... }`
 - `["pr", "view", "42"]` → positionalArgs includes `"42"`
 - `["pr", "edit", "--title", "new", "42"]` → positional `"42"` extracted despite flags
@@ -430,6 +431,7 @@ Test the exported functions (`parseGhArgs`, `evaluatePolicy`) directly — no su
 - `["pr", "--help"]` → `command === "pr"`, subcommand === "--help"` (pass through to real gh)
 
 **Policy evaluation tests** — for each row in the subcommand policy table, one test case:
+
 - `pr create` with `canCreatePr: true` → `allow-and-capture-pr`
 - `pr create` with `canCreatePr: false` → `deny`
 - `pr edit 42` with `ownedPrNumber: 42` → `allow`
@@ -462,18 +464,18 @@ Add to `package.json` scripts: `"test:gh-shim": "tsx scripts/test-gh-shim.ts"`.
 **New file**: `src/main/hooks.ts`
 
 ```typescript
-import { mkdir, writeFile, chmod, rm } from "node:fs/promises";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-import { join } from "node:path";
-import { POLICY_DIR } from "./sandbox.js";
+import { mkdir, writeFile, chmod, rm } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { join } from 'node:path';
+import { POLICY_DIR } from './sandbox.js';
 
 const execFileAsync = promisify(execFile);
 
 /**
  * Path to the hooks directory for a session.
  */
-export function hooksDir(sessionId: string): string
+export function hooksDir(sessionId: string): string;
 
 /**
  * Install the pre-push hook for a session.
@@ -484,18 +486,16 @@ export async function installHooks(
   sessionId: string,
   worktreePath: string,
   policyFilePath: string,
-): Promise<void>
+): Promise<void>;
 
 /**
  * Remove the hooks directory and unset core.hooksPath.
  */
-export async function cleanupHooks(
-  sessionId: string,
-  worktreePath: string,
-): Promise<void>
+export async function cleanupHooks(sessionId: string, worktreePath: string): Promise<void>;
 ```
 
 Implementation notes:
+
 - `hooksDir`: returns `join(POLICY_DIR, \`${sessionId}-hooks\`)`.
 - `installHooks`:
   1. `mkdir` the hooks directory
@@ -574,7 +574,7 @@ if (template?.github && worktree) {
     await writePolicyState(id, githubPolicy);
     await installHooks(id, workingDir, policyStatePath(id));
   } else {
-    console.warn("No GitHub remote detected — skipping application-layer policy");
+    console.warn('No GitHub remote detected — skipping application-layer policy');
   }
 }
 session.githubPolicy = githubPolicy;
@@ -595,7 +595,7 @@ if (githubPolicy) {
     BOUNCER_REAL_GH: realGhPath,
   };
   // Prepend shim bin dir to PATH
-  shimEnv.PATH = `${shimBinDir}:${process.env.PATH ?? ""}`;
+  shimEnv.PATH = `${shimBinDir}:${process.env.PATH ?? ''}`;
 }
 ```
 
@@ -608,7 +608,7 @@ Update the `spawn` call to merge `shimEnv`:
 
 ```typescript
 const agentProcess = spawn(cmd, args, {
-  stdio: ["pipe", "pipe", "pipe"],
+  stdio: ['pipe', 'pipe', 'pipe'],
   env: { ...process.env, ...env, ...shimEnv },
   cwd,
 });
@@ -634,15 +634,15 @@ Add cleanup before the existing worktree removal:
 // Clean up application-layer policy artifacts
 if (session.githubPolicy && session.worktree) {
   await cleanupHooks(sessionId, session.worktree.path).catch((err) =>
-    console.warn(`Failed to clean up hooks for session ${sessionId}:`, err)
+    console.warn(`Failed to clean up hooks for session ${sessionId}:`, err),
   );
 }
 if (session.githubPolicy) {
   await cleanupPolicyState(sessionId).catch((err) =>
-    console.warn(`Failed to clean up policy state for session ${sessionId}:`, err)
+    console.warn(`Failed to clean up policy state for session ${sessionId}:`, err),
   );
   await cleanupGhShim(sessionId).catch((err) =>
-    console.warn(`Failed to clean up gh shim for session ${sessionId}:`, err)
+    console.warn(`Failed to clean up gh shim for session ${sessionId}:`, err),
   );
 }
 ```
@@ -709,7 +709,7 @@ Add to `package.json` scripts: `"test:app-layer-policy": "tsx scripts/test-app-l
 **New file**: `src/main/policy-event-parser.ts`
 
 ```typescript
-import type { PolicyEvent } from "./types.js";
+import type { PolicyEvent } from './types.js';
 
 /**
  * Attempt to parse a stderr line as a Bouncer policy event.
@@ -721,7 +721,7 @@ import type { PolicyEvent } from "./types.js";
  *   [bouncer:git] DENY push to refs/heads/main — reason text
  *   [bouncer:git] ALLOW push to refs/heads/bouncer/abc123
  */
-export function parsePolicyEvent(line: string): PolicyEvent | null
+export function parsePolicyEvent(line: string): PolicyEvent | null;
 ```
 
 ### Step 5.2: Integrate into stderr capture
@@ -729,8 +729,9 @@ export function parsePolicyEvent(line: string): PolicyEvent | null
 **File**: `src/main/session-manager.ts` — the stderr `data` handler (line ~271).
 
 Currently:
+
 ```typescript
-agentProcess.stderr?.on("data", (data: Buffer) => {
+agentProcess.stderr?.on('data', (data: Buffer) => {
   collectedStderr += data.toString();
   process.stderr.write(data);
 });
@@ -739,22 +740,22 @@ agentProcess.stderr?.on("data", (data: Buffer) => {
 Add line-by-line parsing:
 
 ```typescript
-let stderrBuffer = "";
-agentProcess.stderr?.on("data", (data: Buffer) => {
+let stderrBuffer = '';
+agentProcess.stderr?.on('data', (data: Buffer) => {
   const chunk = data.toString();
   collectedStderr += chunk;
   process.stderr.write(data);
 
   // Parse policy events from complete lines
   stderrBuffer += chunk;
-  const lines = stderrBuffer.split("\n");
-  stderrBuffer = lines.pop() ?? ""; // Keep incomplete last line in buffer
+  const lines = stderrBuffer.split('\n');
+  stderrBuffer = lines.pop() ?? ''; // Keep incomplete last line in buffer
   for (const line of lines) {
     const event = parsePolicyEvent(line);
     if (event) {
-      this.emit("session-update", {
+      this.emit('session-update', {
         sessionId: id,
-        type: "policy-event",
+        type: 'policy-event',
         event,
       });
     }
@@ -772,8 +773,8 @@ After evaluating the policy, write to stderr:
 function logDecision(parsed: ParsedGhCommand, decision: PolicyDecision): void {
   const op = [parsed.command, parsed.subcommand, ...parsed.positionalArgs]
     .filter(Boolean)
-    .join(" ");
-  if (decision.action === "deny") {
+    .join(' ');
+  if (decision.action === 'deny') {
     process.stderr.write(`[bouncer:gh] DENY ${op} — ${decision.reason}\n`);
   } else {
     process.stderr.write(`[bouncer:gh] ALLOW ${op}\n`);
@@ -819,8 +820,9 @@ Add parser tests to `scripts/test-gh-shim.ts` (or a new `scripts/test-policy-eve
 Add state for policy events (alongside the existing `violationsBySession`):
 
 ```typescript
-const [policyEventsBySession, setPolicyEventsBySession] =
-  useState<Map<string, PolicyEvent[]>>(new Map());
+const [policyEventsBySession, setPolicyEventsBySession] = useState<Map<string, PolicyEvent[]>>(
+  new Map(),
+);
 ```
 
 Add a case in `handleUpdate`:
@@ -853,6 +855,7 @@ interface Props {
 ```
 
 Merge and sort both lists by timestamp. Render with visual differentiation:
+
 - Policy allow events: green check mark or similar
 - Policy deny events: red X
 - Sandbox violations: existing shield icon
@@ -868,6 +871,7 @@ If `session.githubRepo` is set, show it under the session entry (e.g., "dherman/
 ### Step 6.4: Visual verification
 
 Run the Electron app (`npm run dev`), create a `standard-pr` session against a repo with a GitHub remote, and verify:
+
 - The session shows the GitHub repo name
 - Policy events appear when the agent runs `gh` commands
 - Denied operations show a clear reason
@@ -907,6 +911,7 @@ Create a disposable test repo on GitHub (e.g., `dherman/bouncer-sandbox-test`) w
 ### Step 7.4: Document findings
 
 Write results and any issues discovered to `docs/milestones/application-layer-policies/findings.md` (following the pattern from earlier milestones if one exists). Note:
+
 - Any `gh` subcommands the agent tried that weren't in the policy table
 - Any false denials (legitimate operations incorrectly blocked)
 - UX quality of the error messages — did the agent understand and adapt?
@@ -918,39 +923,39 @@ Write results and any issues discovered to `docs/milestones/application-layer-po
 
 ### New Files
 
-| File | Purpose |
-|---|---|
-| `src/main/github-policy.ts` | GitHubPolicy logic, remote detection, state file I/O |
-| `src/main/gh-shim.ts` | `gh` shim: parser, policy engine, entry point |
-| `src/main/gh-shim-wrapper.sh` | Shell wrapper template for the shim |
-| `src/main/hooks.ts` | Git hook installation and cleanup |
-| `src/main/policy-event-parser.ts` | Stderr log line → PolicyEvent parser |
-| `scripts/test-github-policy.ts` | Tests for remote detection, policy state I/O |
-| `scripts/test-gh-shim.ts` | Tests for parser, policy evaluation, API matching |
-| `scripts/test-hooks.ts` | Tests for hook installation and ref enforcement |
-| `scripts/test-app-layer-policy.ts` | Integration test for full session lifecycle |
+| File                               | Purpose                                              |
+| ---------------------------------- | ---------------------------------------------------- |
+| `src/main/github-policy.ts`        | GitHubPolicy logic, remote detection, state file I/O |
+| `src/main/gh-shim.ts`              | `gh` shim: parser, policy engine, entry point        |
+| `src/main/gh-shim-wrapper.sh`      | Shell wrapper template for the shim                  |
+| `src/main/hooks.ts`                | Git hook installation and cleanup                    |
+| `src/main/policy-event-parser.ts`  | Stderr log line → PolicyEvent parser                 |
+| `scripts/test-github-policy.ts`    | Tests for remote detection, policy state I/O         |
+| `scripts/test-gh-shim.ts`          | Tests for parser, policy evaluation, API matching    |
+| `scripts/test-hooks.ts`            | Tests for hook installation and ref enforcement      |
+| `scripts/test-app-layer-policy.ts` | Integration test for full session lifecycle          |
 
 ### Modified Files
 
-| File | Changes |
-|---|---|
-| `src/main/types.ts` | Add `GitHubPolicy`, `PolicyEvent`, update `PolicyTemplate`, `SessionSummary`, `SessionUpdate` |
-| `src/main/policy-templates.ts` | Add `github` field to `standard-pr` template |
-| `src/main/session-manager.ts` | GitHub policy setup in `createSession`, cleanup in `closeSession`, stderr parsing, `SessionState` extension, `summarize` update |
-| `src/main/index.ts` | No changes expected (IPC passes through generically) |
-| `src/renderer/src/App.tsx` | Handle `policy-event` updates, pass to `SandboxLog` |
-| `src/renderer/src/components/SandboxLog.tsx` | Accept and display policy events alongside violations |
-| `src/renderer/src/components/SessionList.tsx` | Show GitHub repo and PR number |
-| `package.json` | New test scripts |
+| File                                          | Changes                                                                                                                         |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `src/main/types.ts`                           | Add `GitHubPolicy`, `PolicyEvent`, update `PolicyTemplate`, `SessionSummary`, `SessionUpdate`                                   |
+| `src/main/policy-templates.ts`                | Add `github` field to `standard-pr` template                                                                                    |
+| `src/main/session-manager.ts`                 | GitHub policy setup in `createSession`, cleanup in `closeSession`, stderr parsing, `SessionState` extension, `summarize` update |
+| `src/main/index.ts`                           | No changes expected (IPC passes through generically)                                                                            |
+| `src/renderer/src/App.tsx`                    | Handle `policy-event` updates, pass to `SandboxLog`                                                                             |
+| `src/renderer/src/components/SandboxLog.tsx`  | Accept and display policy events alongside violations                                                                           |
+| `src/renderer/src/components/SessionList.tsx` | Show GitHub repo and PR number                                                                                                  |
+| `package.json`                                | New test scripts                                                                                                                |
 
 ### Not Modified
 
-| File | Reason |
-|---|---|
-| `src/main/sandbox.ts` | Safehouse integration unchanged |
-| `src/main/policy-sandbox.ts` | `policyToSandboxConfig` unchanged (GitHub policy is orthogonal to Seatbelt config) |
-| `src/main/policy-registry.ts` | Registry logic unchanged (templates still registered the same way) |
-| `src/main/worktree-manager.ts` | Worktree creation unchanged |
-| `src/main/sandbox-monitor.ts` | Seatbelt monitoring unchanged |
-| `src/agents/replay-agent.ts` | Replay agent unchanged (doesn't interact with gh/git in ways that need policy) |
-| `src/preload/index.ts` | Generic IPC bridge, no changes needed |
+| File                           | Reason                                                                             |
+| ------------------------------ | ---------------------------------------------------------------------------------- |
+| `src/main/sandbox.ts`          | Safehouse integration unchanged                                                    |
+| `src/main/policy-sandbox.ts`   | `policyToSandboxConfig` unchanged (GitHub policy is orthogonal to Seatbelt config) |
+| `src/main/policy-registry.ts`  | Registry logic unchanged (templates still registered the same way)                 |
+| `src/main/worktree-manager.ts` | Worktree creation unchanged                                                        |
+| `src/main/sandbox-monitor.ts`  | Seatbelt monitoring unchanged                                                      |
+| `src/agents/replay-agent.ts`   | Replay agent unchanged (doesn't interact with gh/git in ways that need policy)     |
+| `src/preload/index.ts`         | Generic IPC bridge, no changes needed                                              |

--- a/docs/history/container-migration/design.md
+++ b/docs/history/container-migration/design.md
@@ -10,14 +10,15 @@ Migrate the sandbox primitive from macOS Seatbelt (via agent-safehouse) to OrbSt
 
 M5 implemented CLI wrappers (`gh` shim, git hooks) for application-layer policy enforcement on Seatbelt. These work but have known bypass paths that containers close:
 
-| Bypass | How it works today | How containers close it |
-|---|---|---|
-| Agent invokes real `gh` via absolute path | Real `gh` exists on host, accessible via `/opt/homebrew/bin/gh` etc. | Real `gh` binary doesn't exist in the container — the shim *is* `gh` |
-| Agent deletes or modifies git hooks | Hook files are writable on the host filesystem | Hooks directory mounted read-only |
-| Agent unsets `core.hooksPath` in git config | Agent can write to `.git/config` in the worktree | System-level gitconfig mounted read-only; worktree `.git/config` can be constrained |
-| Agent uses `--no-verify` to skip hooks | Git respects this flag regardless of hook presence | Not closed until M7 (network proxy), but container removes alternative tools |
+| Bypass                                      | How it works today                                                   | How containers close it                                                             |
+| ------------------------------------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Agent invokes real `gh` via absolute path   | Real `gh` exists on host, accessible via `/opt/homebrew/bin/gh` etc. | Real `gh` binary doesn't exist in the container — the shim _is_ `gh`                |
+| Agent deletes or modifies git hooks         | Hook files are writable on the host filesystem                       | Hooks directory mounted read-only                                                   |
+| Agent unsets `core.hooksPath` in git config | Agent can write to `.git/config` in the worktree                     | System-level gitconfig mounted read-only; worktree `.git/config` can be constrained |
+| Agent uses `--no-verify` to skip hooks      | Git respects this flag regardless of hook presence                   | Not closed until M7 (network proxy), but container removes alternative tools        |
 
 Beyond hardening, containers provide:
+
 - **Cross-platform support**: Docker runs on macOS, Linux, Windows (Seatbelt is macOS-only)
 - **Reproducible environments**: Same image = identical toolchain across sessions
 - **No carveout problem**: Build up from a known-good base instead of subtracting from the host
@@ -89,14 +90,16 @@ WORKDIR /workspace
 ```
 
 Design decisions:
+
 - **`docker/sandbox-templates:claude-code`** as base: Docker's official Claude Code sandbox image. Includes Node.js, Python 3, Go, Git, and essential dev tools. arm64-native (runs natively on Apple Silicon via OrbStack). This is a production-quality multi-toolchain base — we extend rather than build from scratch.
 - **Rust added via rustup**: The base image doesn't include Rust, but many of the projects Bouncer targets use Node.js + Rust. Adding Rust (with rust-analyzer, rustfmt, clippy) makes the image viable for polyglot agent workflows without requiring per-session image variants.
-- **Real `gh` binary removed**: The base image ships `gh`, which we explicitly remove. The shim is bind-mounted as `/usr/local/bin/gh` at container start (bind mount shadows the path), and the binary removal ensures no fallback exists at alternative paths. The shim *is* `gh` inside the container.
+- **Real `gh` binary removed**: The base image ships `gh`, which we explicitly remove. The shim is bind-mounted as `/usr/local/bin/gh` at container start (bind mount shadows the path), and the binary removal ensures no fallback exists at alternative paths. The shim _is_ `gh` inside the container.
 - **No `curl`/`wget` removal**: The base image includes these (useful for Rust/toolchain operations), and removing them is not a security boundary — the agent can use Node.js `fetch`. Fully closed by M7's network proxy.
 - **Non-root `agent` user**: Inherited from the base image. Defense in depth — the agent shouldn't need root.
 - **No carveout problem**: Unlike Seatbelt (where safehouse must enumerate host paths for every toolchain), we start with a known-good environment. The container has its own copies of everything. Adding a toolchain means updating the Dockerfile, not discovering and whitelisting a dozen host paths.
 
 **Image build and caching**:
+
 - Image built at app startup if not present (or on version change)
 - Tagged as `glitterball-agent:v{version}` where version comes from `package.json`
 - Rebuild on Dockerfile change (content hash check)
@@ -127,7 +130,7 @@ export interface ContainerConfig {
   /** Command to run */
   command: string[];
   /** Network mode (default: "none" for M6; "bridge" when M7 adds proxy) */
-  networkMode: "none" | "bridge" | "host";
+  networkMode: 'none' | 'bridge' | 'host';
 }
 ```
 
@@ -151,6 +154,7 @@ export async function cleanupOrphanContainers(activeSessionIds: Set<string>): Pr
 ```
 
 **`ContainerHandle`** provides:
+
 - `stdin: Writable` / `stdout: Readable` / `stderr: Readable` — stdio streams for ACP
 - `pid: number` — container PID (for monitoring)
 - `containerId: string` — Docker container ID
@@ -181,18 +185,18 @@ docker run -i --rm \
 
 The mount strategy maps the current Seatbelt config concepts (writable dirs, read-only dirs, env passthrough) to container bind mounts.
 
-| Host Path | Container Path | Mode | Purpose |
-|---|---|---|---|
-| Worktree (`/tmp/glitterball-worktrees/{id}`) | `/workspace` | read-write | Agent's working directory |
-| Git common dir (parent repo's `.git`) | Resolved at runtime | read-write | Linked worktree refs/metadata |
-| Git hooks dir (`/tmp/glitterball-sandbox/{id}-hooks`) | `/etc/bouncer/hooks` | **read-only** | Pre-push hook (tamper-proof) |
-| `gh` shim script | `/usr/local/bin/gh` | **read-only** | Policy-enforcing GitHub CLI |
-| `gh` shim Node.js bundle | `/usr/local/lib/bouncer/gh-shim.js` | **read-only** | Shim implementation |
-| GitHub policy state | `/etc/bouncer/github-policy.json` | read-write | Shim reads/updates PR state |
-| System gitconfig | `/etc/gitconfig` | **read-only** | `core.hooksPath`, credential helper |
-| User's `~/.ssh` | `/home/agent/.ssh` | **read-only** | Git SSH authentication |
-| Agent binary (`claude-agent-acp`) | `/usr/local/lib/agent/` | **read-only** | ACP agent entry point |
-| App `node_modules` | `/usr/local/lib/node_modules/` | **read-only** | Agent dependencies |
+| Host Path                                             | Container Path                      | Mode          | Purpose                             |
+| ----------------------------------------------------- | ----------------------------------- | ------------- | ----------------------------------- |
+| Worktree (`/tmp/glitterball-worktrees/{id}`)          | `/workspace`                        | read-write    | Agent's working directory           |
+| Git common dir (parent repo's `.git`)                 | Resolved at runtime                 | read-write    | Linked worktree refs/metadata       |
+| Git hooks dir (`/tmp/glitterball-sandbox/{id}-hooks`) | `/etc/bouncer/hooks`                | **read-only** | Pre-push hook (tamper-proof)        |
+| `gh` shim script                                      | `/usr/local/bin/gh`                 | **read-only** | Policy-enforcing GitHub CLI         |
+| `gh` shim Node.js bundle                              | `/usr/local/lib/bouncer/gh-shim.js` | **read-only** | Shim implementation                 |
+| GitHub policy state                                   | `/etc/bouncer/github-policy.json`   | read-write    | Shim reads/updates PR state         |
+| System gitconfig                                      | `/etc/gitconfig`                    | **read-only** | `core.hooksPath`, credential helper |
+| User's `~/.ssh`                                       | `/home/agent/.ssh`                  | **read-only** | Git SSH authentication              |
+| Agent binary (`claude-agent-acp`)                     | `/usr/local/lib/agent/`             | **read-only** | ACP agent entry point               |
+| App `node_modules`                                    | `/usr/local/lib/node_modules/`      | **read-only** | Agent dependencies                  |
 
 **Git common dir handling**: Linked worktrees store refs and metadata in the parent repo's `.git` directory. The worktree manager already resolves this path and validates it's under the project dir. In the container, we mount it at the same relative position so git can find it. The existing `gitCommonDir` validation (ensuring it's under the project root) prevents sandbox escape via symlinked common dirs.
 
@@ -205,10 +209,11 @@ The mount strategy maps the current Seatbelt config concepts (writable dirs, rea
 The session manager's `createSession` flow changes to support both sandbox backends:
 
 ```typescript
-type SandboxBackend = "safehouse" | "container" | "none";
+type SandboxBackend = 'safehouse' | 'container' | 'none';
 ```
 
 **Backend selection logic**:
+
 1. If Docker is available → use `"container"`
 2. Else if safehouse is available → use `"safehouse"` (fallback)
 3. Else → `"none"` (unsandboxed, with warning)
@@ -218,20 +223,21 @@ This preserves the existing safehouse path for development on machines without D
 **Changes to `resolveAgentCommand`**: For the container backend, the function returns a `SpawnConfig` where `cmd` is `"docker"` and `args` is the `docker run` invocation. The ACP connection setup (stdio piping, ndJson stream, ClientSideConnection) remains identical — the agent's stdin/stdout are transparently tunneled through Docker.
 
 **Changes to `resolveClaudeCodeCommand`**:
+
 ```typescript
 function resolveClaudeCodeCommand(
   cwd: string,
-  sandboxConfig: SandboxConfig | null,    // Seatbelt path
+  sandboxConfig: SandboxConfig | null, // Seatbelt path
   containerConfig: ContainerConfig | null, // Container path
 ): SpawnConfig {
   if (containerConfig) {
     return buildDockerRunCommand(containerConfig);
   }
   if (sandboxConfig) {
-    const args = buildSafehouseArgs(sandboxConfig, ["node", binPath]);
-    return { cmd: "safehouse", args, cwd };
+    const args = buildSafehouseArgs(sandboxConfig, ['node', binPath]);
+    return { cmd: 'safehouse', args, cwd };
   }
-  return { cmd: "node", args: [binPath], cwd };
+  return { cmd: 'node', args: [binPath], cwd };
 }
 ```
 
@@ -270,7 +276,7 @@ export interface ContainerPolicy {
     readOnly: boolean;
   }>;
   /** Network mode override (default: "none") */
-  networkMode?: "none" | "bridge";
+  networkMode?: 'none' | 'bridge';
   /** Additional packages to install (triggers image variant) */
   additionalPackages?: string[];
 }
@@ -312,6 +318,7 @@ Seatbelt violations are currently detected by parsing the macOS unified log (`lo
 **Recommended approach for M6**: Start with (4) — filesystem permission errors surface naturally through ACP tool call results, and the policy event parser already captures `gh` shim and git hook denials. This provides sufficient observability for the milestone. Seccomp audit logging (2) can be added later if we need visibility into blocked operations that don't surface through ACP.
 
 **Changes to `SandboxMonitor`**: The existing class becomes backend-aware:
+
 - For safehouse: existing unified log parsing (unchanged)
 - For containers: monitors Docker events + stderr policy events (already implemented in M5)
 - The `PolicyEvent` type and `parsePolicyEvent()` function work unchanged — they parse the same stderr format regardless of whether the agent runs under Seatbelt or in a container
@@ -321,6 +328,7 @@ Seatbelt violations are currently detected by parsing the macOS unified log (`lo
 The M5 `gh` shim (`src/main/gh-shim.ts`) needs minor changes for the container environment:
 
 **Path changes**: The shim currently references host paths for policy state (`BOUNCER_GITHUB_POLICY`) and the real `gh` binary (`BOUNCER_REAL_GH`). In the container:
+
 - `BOUNCER_GITHUB_POLICY` points to `/etc/bouncer/github-policy.json` (bind-mounted)
 - `BOUNCER_REAL_GH` is **not set** — there is no real `gh` binary. The shim must handle this case: if `BOUNCER_REAL_GH` is unset, the shim uses Node.js `fetch` to call the GitHub API directly for allowed operations, rather than proxying through `gh`.
 
@@ -328,11 +336,11 @@ This is a meaningful change to the shim's architecture. Today, the shim acts as 
 
 **Options for the container `gh` shim**:
 
-| Approach | Pros | Cons |
-|---|---|---|
-| **A: Direct API calls via `fetch`** | No external dependencies; shim is self-contained | Must reimplement `gh` output formats; only a subset of `gh` commands are needed |
-| **B: Install real `gh` at a hidden path** | Shim architecture unchanged; full `gh` compatibility | Partially defeats the purpose — agent could discover the hidden binary |
-| **C: Two-phase shim** | Gate + API for common ops; fallback warning for unsupported ops | Moderate complexity; covers the realistic use case |
+| Approach                                  | Pros                                                            | Cons                                                                            |
+| ----------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| **A: Direct API calls via `fetch`**       | No external dependencies; shim is self-contained                | Must reimplement `gh` output formats; only a subset of `gh` commands are needed |
+| **B: Install real `gh` at a hidden path** | Shim architecture unchanged; full `gh` compatibility            | Partially defeats the purpose — agent could discover the hidden binary          |
+| **C: Two-phase shim**                     | Gate + API for common ops; fallback warning for unsupported ops | Moderate complexity; covers the realistic use case                              |
 
 **Recommended: Approach A (direct API calls) for the common operations, with a clear error for unsupported commands.**
 
@@ -341,6 +349,7 @@ The agent realistically uses a small subset of `gh` commands: `pr create`, `pr v
 This approach also means the shim's API calling logic is **exactly** what M7's network proxy will need to understand. Building it now creates a reusable policy engine.
 
 **Implementation sketch**:
+
 ```typescript
 // In the shim, after policy check passes:
 if (process.env.BOUNCER_REAL_GH) {
@@ -353,6 +362,7 @@ if (process.env.BOUNCER_REAL_GH) {
 ```
 
 The `callGitHubApi` function maps `gh` subcommands to REST API calls:
+
 - `gh pr create` → `POST /repos/{owner}/{repo}/pulls`
 - `gh pr view {n}` → `GET /repos/{owner}/{repo}/pulls/{n}`
 - `gh pr edit {n}` → `PATCH /repos/{owner}/{repo}/pulls/{n}`
@@ -368,10 +378,12 @@ Output formatting should match `gh` defaults (JSON where possible, since that's 
 Git operations require careful configuration in the container:
 
 **Authentication**: Two paths:
+
 1. **HTTPS with token** (preferred): Set `GH_TOKEN` env var. Configure credential helper in the mounted gitconfig: `credential.https://github.com.helper=!node /usr/local/lib/bouncer/gh-credential-helper.js`. This is a small script that echoes the token — simpler than depending on `gh auth git-credential` (which requires the real `gh` binary).
 2. **SSH**: Mount `~/.ssh` read-only. SSH agent forwarding requires `SSH_AUTH_SOCK` to be accessible, which doesn't work across the container boundary. Instead, mount the SSH key directly and configure `GIT_SSH_COMMAND` to use it without passphrase prompting (or rely on the key being unencrypted / agent-forwarded via OrbStack's integration).
 
 **Gitconfig layering**:
+
 ```
 /etc/gitconfig (read-only, Bouncer-managed):
   core.hooksPath = /etc/bouncer/hooks
@@ -389,35 +401,39 @@ The system gitconfig being read-only means the agent can't unset `core.hooksPath
 ### Phase 9: Networking
 
 **M6 network posture**: `--network none` by default for `standard-pr` policy. This means:
+
 - No outbound network access from the container
 - `git push` over HTTPS won't work directly from inside the container
 
 **The network gap**: With `--network none`, the agent can't `git push` or `npm install`. This is too restrictive for practical use. Options:
 
-| Approach | Description | M6 feasibility |
-|---|---|---|
-| **A: `--network none` + host-side execution** | Agent's `git push` is intercepted and executed on the host | High complexity; breaks ACP's execution model |
-| **B: `--network bridge` with no proxy** | Agent has full network access | Defeats network isolation; no better than Seatbelt |
-| **C: `--network bridge` with DNS-based filtering** | Allow only specific domains via container DNS config | Moderate; provides basic domain allowlisting |
-| **D: `--network bridge`, defer proxy to M7** | Full network in M6; proxy in M7 | Simple; accepts that M6 doesn't improve network posture |
+| Approach                                           | Description                                                | M6 feasibility                                          |
+| -------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------- |
+| **A: `--network none` + host-side execution**      | Agent's `git push` is intercepted and executed on the host | High complexity; breaks ACP's execution model           |
+| **B: `--network bridge` with no proxy**            | Agent has full network access                              | Defeats network isolation; no better than Seatbelt      |
+| **C: `--network bridge` with DNS-based filtering** | Allow only specific domains via container DNS config       | Moderate; provides basic domain allowlisting            |
+| **D: `--network bridge`, defer proxy to M7**       | Full network in M6; proxy in M7                            | Simple; accepts that M6 doesn't improve network posture |
 
 **Recommended: Approach D** — use `--network bridge` (default Docker networking) for M6. The primary value of M6 is filesystem isolation (hardening CLI wrappers), not network isolation. Network enforcement is M7's scope. Attempting DNS-based filtering in M6 would be half-measure that delays the milestone without providing a real security boundary.
 
 For `standard-pr` sessions that don't need arbitrary network access, the practical network usage is:
+
 - `git push` to `github.com` (HTTPS)
 - `gh` API calls to `api.github.com` (handled by the shim, which makes the call from inside the container)
 - Potentially `npm install` / package registry access
 
-All of these require network access. M7 constrains *which* network access is allowed.
+All of these require network access. M7 constrains _which_ network access is allowed.
 
 ### Phase 10: Testing Strategy
 
 **Unit tests**:
+
 - `container.ts`: Mock `docker` CLI, test config generation, mount path resolution
 - `policy-container.ts`: Test policy template → container config conversion
 - `gh-shim.ts`: Test direct API call path (no `BOUNCER_REAL_GH`)
 
 **Integration tests** (require OrbStack):
+
 - Container lifecycle: start, attach stdio, stop, remove
 - Bind mount verification: read-write worktree, read-only hooks/shim
 - ACP over container stdio: send message → receive response
@@ -427,10 +443,12 @@ All of these require network access. M7 constrains *which* network access is all
 - Orphan cleanup: containers from crashed sessions are cleaned up
 
 **Regression tests**:
+
 - All M5 policy enforcement tests pass in the container environment
 - Replay agent works in container (deterministic test coverage)
 
 **Manual validation**:
+
 - Claude Code session in container: full PR workflow (create branch → commit → push → create PR → iterate)
 - Verify read-only mounts: agent cannot modify hooks, shim, or system gitconfig
 - Verify `gh` bypass is closed: no real `gh` binary (removed from base image + shim bind-mounted)
@@ -438,12 +456,14 @@ All of these require network access. M7 constrains *which* network access is all
 ## Implementation Phases
 
 ### Phase A: Foundation (container lifecycle + image)
+
 1. Create `docker/agent.Dockerfile`
 2. Implement `src/main/container.ts` (image build, container spawn/stop/cleanup)
 3. Add `isDockerAvailable()` check
 4. Integration test: spawn container, verify stdio piping
 
 ### Phase B: Session Manager integration
+
 5. Add `SandboxBackend` type and selection logic
 6. Implement `policy-container.ts` (policy template → container config)
 7. Update `resolveAgentCommand` for container backend
@@ -451,22 +471,26 @@ All of these require network access. M7 constrains *which* network access is all
 9. Integration test: echo agent in container via ACP
 
 ### Phase C: Mount strategy + git configuration
+
 10. Implement bind mount generation (worktree, common dir, hooks, shim, gitconfig)
 11. Generate read-only system gitconfig with `core.hooksPath` and credential helper
 12. Implement `gh-credential-helper.js` (token echo for git HTTPS auth)
 13. Integration test: git commit + push from container
 
 ### Phase D: `gh` shim direct API mode
+
 14. Add `callGitHubApi()` to `gh-shim.ts` for container path
 15. Implement API call mapping for the `gh` subcommand subset (`pr create/view/edit/list`, `issue list/view`, `api`)
 16. Integration test: `gh pr create`, `gh pr view` without real `gh` binary
 
 ### Phase E: Sandbox monitoring + UI
+
 17. Update `SandboxMonitor` for container backend (Docker events + stderr)
 18. Update `SessionSummary` to indicate sandbox backend (`sandboxBackend: "safehouse" | "container" | "none"`)
 19. UI: display container status (image, container ID) in session details
 
 ### Phase F: End-to-end validation
+
 20. Full Claude Code PR workflow in container
 21. Replay agent regression suite in container
 22. Safehouse fallback path still works
@@ -474,29 +498,29 @@ All of these require network access. M7 constrains *which* network access is all
 
 ## Files Changed
 
-| File | Change |
-|---|---|
-| `docker/agent.Dockerfile` | **New** — agent container image |
-| `src/main/container.ts` | **New** — container lifecycle management |
-| `src/main/policy-container.ts` | **New** — policy template → container config |
-| `src/main/gh-credential-helper.ts` | **New** — token-based git credential helper for containers |
-| `src/main/session-manager.ts` | **Modified** — sandbox backend selection, container spawn path |
-| `src/main/gh-shim.ts` | **Modified** — direct API call path when `BOUNCER_REAL_GH` unset |
-| `src/main/sandbox-monitor.ts` | **Modified** — backend-aware monitoring |
-| `src/main/types.ts` | **Modified** — `ContainerPolicy`, `SandboxBackend`, updated `SessionSummary` |
-| `src/main/policy-templates.ts` | **Modified** — add `container` config to templates |
-| `src/main/index.ts` | **Modified** — image build at startup, Docker availability check |
+| File                               | Change                                                                       |
+| ---------------------------------- | ---------------------------------------------------------------------------- |
+| `docker/agent.Dockerfile`          | **New** — agent container image                                              |
+| `src/main/container.ts`            | **New** — container lifecycle management                                     |
+| `src/main/policy-container.ts`     | **New** — policy template → container config                                 |
+| `src/main/gh-credential-helper.ts` | **New** — token-based git credential helper for containers                   |
+| `src/main/session-manager.ts`      | **Modified** — sandbox backend selection, container spawn path               |
+| `src/main/gh-shim.ts`              | **Modified** — direct API call path when `BOUNCER_REAL_GH` unset             |
+| `src/main/sandbox-monitor.ts`      | **Modified** — backend-aware monitoring                                      |
+| `src/main/types.ts`                | **Modified** — `ContainerPolicy`, `SandboxBackend`, updated `SessionSummary` |
+| `src/main/policy-templates.ts`     | **Modified** — add `container` config to templates                           |
+| `src/main/index.ts`                | **Modified** — image build at startup, Docker availability check             |
 
 ## Risks and Mitigations
 
-| Risk | Likelihood | Impact | Mitigation |
-|---|---|---|---|
-| OrbStack not installed on user's machine | Medium | Session falls back to safehouse or unsandboxed | Graceful degradation with warning; safehouse path preserved |
-| Container startup latency impacts UX | Low | OrbStack is fast (~500ms), but could be slower with image pull | Build image at app startup; cache aggressively |
-| Agent binary path resolution differs in container | Medium | ESM imports fail if `node_modules` tree isn't mounted correctly | Mount entire `node_modules` tree read-only (same approach as safehouse) |
-| `gh` shim direct API mode has lower fidelity than real `gh` | Medium | Agent gets unexpected output format, retries | Match `gh` JSON output format for the supported subset; clear error for unsupported commands |
-| Git common dir mount leaks access to parent repo | Low | Agent could read/write parent repo files | Existing validation ensures common dir is under project root |
-| Docker socket access from container | Low | Agent could escape via Docker socket | Docker socket is never mounted; `--network none` or `--network bridge` without socket |
+| Risk                                                        | Likelihood | Impact                                                          | Mitigation                                                                                   |
+| ----------------------------------------------------------- | ---------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| OrbStack not installed on user's machine                    | Medium     | Session falls back to safehouse or unsandboxed                  | Graceful degradation with warning; safehouse path preserved                                  |
+| Container startup latency impacts UX                        | Low        | OrbStack is fast (~500ms), but could be slower with image pull  | Build image at app startup; cache aggressively                                               |
+| Agent binary path resolution differs in container           | Medium     | ESM imports fail if `node_modules` tree isn't mounted correctly | Mount entire `node_modules` tree read-only (same approach as safehouse)                      |
+| `gh` shim direct API mode has lower fidelity than real `gh` | Medium     | Agent gets unexpected output format, retries                    | Match `gh` JSON output format for the supported subset; clear error for unsupported commands |
+| Git common dir mount leaks access to parent repo            | Low        | Agent could read/write parent repo files                        | Existing validation ensures common dir is under project root                                 |
+| Docker socket access from container                         | Low        | Agent could escape via Docker socket                            | Docker socket is never mounted; `--network none` or `--network bridge` without socket        |
 
 ## Open Questions
 

--- a/docs/history/container-migration/plan.md
+++ b/docs/history/container-migration/plan.md
@@ -40,7 +40,7 @@ This plan breaks M6 into phases, each delivering a testable increment. Phases ar
   - [x] 5.5 Add `generatePrePushHookForContainer()` to `hooks.ts`
   - [x] 5.6 Update `closeSession` and `cleanupOrphans` for container artifacts
   - [x] 5.7 Test: full agent session in container with policy enforcement
-- [x] **[Phase 6: `gh` Shim Direct API Mode](#phase-6-gh-shim-direct-api-mode)** *(parallel with Phases 3-5)*
+- [x] **[Phase 6: `gh` Shim Direct API Mode](#phase-6-gh-shim-direct-api-mode)** _(parallel with Phases 3-5)_
   - [x] 6.1 Relax `BOUNCER_REAL_GH` requirement in shim entry point
   - [x] 6.2 Add dispatch branch: real gh vs. direct API
   - [x] 6.3 Implement `executeViaApi()` with `fetch`
@@ -71,12 +71,14 @@ This plan breaks M6 into phases, each delivering a testable increment. Phases ar
 ### New files
 
 **`docker/agent.Dockerfile`**
+
 - `FROM docker/sandbox-templates:claude-code`
 - Remove the real `gh` binary (`rm -f $(which gh)`)
 - Install Rust toolchain via `rustup` (stable + rust-analyzer, rustfmt, clippy)
 - Switch to non-root `agent` user, set `WORKDIR /workspace`
 
 **`src/main/container.ts`** — container lifecycle module (partial — image management only in this phase)
+
 - `isDockerAvailable(): Promise<boolean>` — runs `docker info` and caches the result. Same pattern as `isSafehouseAvailable()` in `sandbox.ts`.
 - `ensureAgentImage(): Promise<string>` — builds the image if missing or stale:
   - Read `docker/agent.Dockerfile` content and compute a hash
@@ -89,17 +91,20 @@ This plan breaks M6 into phases, each delivering a testable increment. Phases ar
 ### Changes to existing files
 
 **`src/main/index.ts`** — kick off image build at startup
+
 - After `createWindow()`, call `ensureAgentImage()` in the background (fire-and-forget with error logging). This pre-warms the image so the first `createSession` doesn't block on a Docker build.
 - Import `isDockerAvailable` and log availability at startup.
 
 **`electron.vite.config.ts`** (or `electron-builder` config) — include `docker/` in packaged app resources so the Dockerfile is available at runtime.
 
 ### Testing
+
 - Manual: run `docker build` with the Dockerfile, verify the image contains node, git, rust (`rustc --version`), no `gh` binary (`which gh` returns nothing).
 - Script (`scripts/test-container-image.sh`): build image, `docker run --rm glitterball-agent:<tag> node --version`, `docker run --rm glitterball-agent:<tag> rustc --version`, `docker run --rm glitterball-agent:<tag> which gh` (should fail).
 - Unit: mock `execFile` calls in `container.ts` to test `isDockerAvailable()` and `ensureAgentImage()` logic (hash check, build-if-missing).
 
 ### Exit criteria
+
 - `npm run dev` starts the app, logs Docker availability and image build status.
 - The agent image builds successfully and contains the expected toolchains.
 - No `gh` binary is discoverable anywhere in the image filesystem.
@@ -115,15 +120,17 @@ This plan breaks M6 into phases, each delivering a testable increment. Phases ar
 Add the container spawn and teardown functions:
 
 **`ContainerHandle` interface**:
+
 ```typescript
 interface ContainerHandle {
-  process: ChildProcess;   // the `docker run` process
-  containerId: string;     // container name (glitterball-{sessionId})
-  kill(): void;            // docker stop + rm
+  process: ChildProcess; // the `docker run` process
+  containerId: string; // container name (glitterball-{sessionId})
+  kill(): void; // docker stop + rm
 }
 ```
 
 **`buildDockerRunArgs(config: ContainerConfig): string[]`**:
+
 - Constructs the `docker run -i --rm --name glitterball-{sessionId}` argument list
 - Maps `config.mounts` to `-v host:container[:ro]` flags
 - Maps `config.env` to `-e KEY=VALUE` flags
@@ -133,24 +140,28 @@ interface ContainerHandle {
 - Returns the full args array (not including `"docker"` itself)
 
 **`spawnContainer(config: ContainerConfig): ContainerHandle`**:
+
 - Calls `spawn("docker", buildDockerRunArgs(config), { stdio: ["pipe", "pipe", "pipe"] })`
 - Wraps in a `ContainerHandle`
 - `kill()` calls `process.kill()` then `docker rm -f glitterball-{sessionId}` as cleanup
 
 **`removeContainer(sessionId: string): Promise<void>`**:
+
 - `docker rm -f glitterball-{sessionId}` — idempotent, safe to call on already-stopped containers
 
 **`cleanupOrphanContainers(activeSessionIds: Set<string>): Promise<void>`**:
+
 - `docker ps -a --filter name=glitterball- --format '{{.Names}}'`
 - For each container whose session ID isn't in `activeSessionIds`, call `removeContainer`
 
 ### New type in `src/main/types.ts`
 
 ```typescript
-export type SandboxBackend = "safehouse" | "container" | "none";
+export type SandboxBackend = 'safehouse' | 'container' | 'none';
 ```
 
 Add to `SessionSummary`:
+
 ```typescript
 sandboxBackend: SandboxBackend;
 ```
@@ -158,6 +169,7 @@ sandboxBackend: SandboxBackend;
 ### Testing
 
 Integration test script (`scripts/test-container-spawn.sh`):
+
 - Build the agent image (from Phase 1)
 - Spawn a simple echo container: `docker run -i --rm glitterball-agent:<tag> cat`
 - Write to stdin, read from stdout, verify echo
@@ -166,6 +178,7 @@ Integration test script (`scripts/test-container-spawn.sh`):
 Unit test for `buildDockerRunArgs`: verify mount flags, env vars, network mode, working dir are correctly generated for various `ContainerConfig` inputs.
 
 ### Exit criteria
+
 - `spawnContainer` returns a handle whose `process.stdin`/`process.stdout` work for bidirectional communication
 - `removeContainer` is idempotent
 - `cleanupOrphanContainers` finds and removes stale containers
@@ -179,21 +192,24 @@ Unit test for `buildDockerRunArgs`: verify mount flags, env vars, network mode, 
 ### Changes to `src/main/session-manager.ts`
 
 **Backend selection** — add to `createSession`, after resolving the policy template:
+
 ```typescript
 const dockerAvailable = await isDockerAvailable();
 const safehouseAvailable = await isSafehouseAvailable();
-const backend: SandboxBackend =
-  dockerAvailable ? "container" :
-  safehouseAvailable ? "safehouse" :
-  "none";
+const backend: SandboxBackend = dockerAvailable
+  ? 'container'
+  : safehouseAvailable
+    ? 'safehouse'
+    : 'none';
 ```
 
 Store `backend` on `SessionState`:
+
 ```typescript
 interface SessionState {
   // ... existing fields ...
   sandboxBackend: SandboxBackend;
-  containerId: string | null;  // set when backend === "container"
+  containerId: string | null; // set when backend === "container"
 }
 ```
 
@@ -207,9 +223,9 @@ function resolveAgentCommand(
   containerConfig: ContainerConfig | null,
   worktreePath?: string,
 ): SpawnConfig {
-  if (agentType === "echo") {
+  if (agentType === 'echo') {
     if (containerConfig) {
-      return { cmd: "docker", args: buildDockerRunArgs(containerConfig) };
+      return { cmd: 'docker', args: buildDockerRunArgs(containerConfig) };
     }
     return resolveEchoAgentCommand();
   }
@@ -232,11 +248,13 @@ Call `ensureAgentImage()` before first session creation (block on it if needed, 
 ### Testing
 
 Manual: create an echo agent session in the UI. Verify:
+
 - Session shows as "container" sandbox backend
 - Messages round-trip through ACP
 - Closing the session removes the container (`docker ps -a` shows no stale containers)
 
 ### Exit criteria
+
 - Echo agent works identically whether running natively, via safehouse, or in a container.
 - ACP streaming (text chunks, tool calls) works over container stdio.
 - Session close cleans up the container.
@@ -273,6 +291,7 @@ export function policyToContainerConfig(
 ```
 
 Implementation:
+
 - Standard mounts (always present):
   - Worktree → `/workspace` (rw or ro based on `template.filesystem.worktreeAccess`)
   - Git common dir → same absolute path inside container (rw, follows worktree access mode). The path must match because git stores the absolute path to the common dir in the worktree's `.git` file.
@@ -302,11 +321,15 @@ A tiny Node.js script that acts as a git credential helper. Used inside the cont
 // Used in container gitconfig: credential.https://github.com.helper=!node /usr/local/lib/bouncer/gh-credential-helper.js
 
 const input = await readStdin();
-if (!input.includes("host=github.com")) process.exit(0);
+if (!input.includes('host=github.com')) process.exit(0);
 
 const token = process.env.GH_TOKEN;
-if (!token) { process.exit(1); }
-process.stdout.write(`protocol=https\nhost=github.com\nusername=x-access-token\npassword=${token}\n\n`);
+if (!token) {
+  process.exit(1);
+}
+process.stdout.write(
+  `protocol=https\nhost=github.com\nusername=x-access-token\npassword=${token}\n\n`,
+);
 ```
 
 ### New function: `generateGitconfig()`
@@ -323,6 +346,7 @@ export function generateGitconfig(opts: {
 ```
 
 Generates the content for `/etc/gitconfig`:
+
 ```ini
 [core]
     hooksPath = /etc/bouncer/hooks
@@ -338,11 +362,12 @@ The gitconfig file is written to `/tmp/glitterball-sandbox/{sessionId}-gitconfig
 ### Changes to `src/main/types.ts`
 
 Add `ContainerPolicy` to `PolicyTemplate`:
+
 ```typescript
 export interface ContainerPolicy {
   image?: string;
   additionalMounts?: Array<{ hostPath: string; containerPath: string; readOnly: boolean }>;
-  networkMode?: "none" | "bridge";
+  networkMode?: 'none' | 'bridge';
 }
 ```
 
@@ -355,6 +380,7 @@ Add `container: {}` to `standardPrTemplate` (uses defaults — bridge network, s
 ### Testing
 
 Unit tests for `policyToContainerConfig`:
+
 - Standard PR template → verify mount list (worktree rw, hooks ro, shim ro, gitconfig ro, etc.)
 - Template without `github` → verify no hooks/shim/gitconfig mounts
 - Read-only worktree template → verify worktree mounted ro
@@ -364,6 +390,7 @@ Unit test for `generateGitconfig`: verify output contains `core.hooksPath`, cred
 Unit test for `gh-credential-helper.ts`: mock stdin with github.com host, verify output format.
 
 ### Exit criteria
+
 - `policyToContainerConfig` produces correct mount lists for all three policy templates.
 - System gitconfig sets `core.hooksPath` and credential helper.
 - Credential helper outputs valid git credential protocol.
@@ -401,6 +428,7 @@ exec node /usr/local/lib/bouncer/gh-shim.js "$@"
 This is written to `/tmp/glitterball-sandbox/{id}-container-gh-wrapper` on the host and bind-mounted to `/usr/local/bin/gh:ro` in the container.
 
 **Env changes for container path**:
+
 - `BOUNCER_GITHUB_POLICY=/etc/bouncer/github-policy.json` (container path, not host path)
 - `BOUNCER_REAL_GH` is **not set** (triggers direct API mode in the shim — see Phase 6)
 - `GH_TOKEN`, `ANTHROPIC_API_KEY` passed through as env vars
@@ -409,6 +437,7 @@ This is written to `/tmp/glitterball-sandbox/{id}-container-gh-wrapper` on the h
 **Env passthrough simplification**: On safehouse, we manually enumerate env vars to forward (`envPassthrough`). In the container, only vars explicitly set via `-e` are visible — a simpler model. Pass `ANTHROPIC_API_KEY`, `GH_TOKEN`, `BOUNCER_GITHUB_POLICY`, `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, `GIT_COMMITTER_EMAIL`, and `NODE_PATH`.
 
 **Changes to `resolveClaudeCodeCommand` and `resolveReplayAgentCommand`**:
+
 - Add container path: when `containerConfig` is present, return `{ cmd: "docker", args: buildDockerRunArgs(containerConfig) }`
 - The agent binary path inside the container: `/usr/local/lib/agent/index.js`
 
@@ -428,6 +457,7 @@ The pre-push hook needs a small change for the container path. The `ALLOWED_REFS
 ### Testing
 
 Integration test script (`scripts/test-container-agent.sh`):
+
 1. Build the agent image
 2. Create a git repo with a GitHub remote
 3. Start a replay agent session with `standard-pr` policy in a container
@@ -441,6 +471,7 @@ Integration test script (`scripts/test-container-agent.sh`):
 Manual: run a Claude Code session in the UI, do a simple task, verify agent can code and commit.
 
 ### Exit criteria
+
 - Claude Code agent starts in a container, speaks ACP, can edit files and run commands.
 - `gh` shim is mounted at `/usr/local/bin/gh` and enforces policy.
 - Git hooks are mounted read-only at `/etc/bouncer/hooks` and enforce push restrictions.
@@ -461,6 +492,7 @@ This phase is what makes the container `gh` shim functional for allowed operatio
 ### Changes to `src/main/gh-shim.ts`
 
 **Entry point change** — relax the `BOUNCER_REAL_GH` requirement:
+
 ```typescript
 // Before (M5):
 if (!policyPath || !realGh) { ... exit(1) }
@@ -471,8 +503,9 @@ const realGh = process.env.BOUNCER_REAL_GH; // may be undefined in container
 ```
 
 **Dispatch change** — after policy evaluation:
+
 ```typescript
-if (decision.action === "deny") {
+if (decision.action === 'deny') {
   // unchanged — log and exit
 }
 
@@ -501,41 +534,50 @@ async function executeViaApi(
 **API endpoint mapping** — a function per supported command:
 
 `gh pr create --title T --body B --base main --head branch`:
+
 - `POST /repos/{owner}/{repo}/pulls` with `{ title, body, base, head }`
 - Extract `--title`, `--body`, `--base`, `--head` flags from `parsed.rawArgs`
 - Response: print the PR URL to stdout (same as real `gh`)
 - If `decision.action === "allow-and-capture-pr"`: extract PR number from response, update policy state
 
 `gh pr view [number]`:
+
 - `GET /repos/{owner}/{repo}/pulls/{number}`
 - Format output as JSON (agent-friendly)
 
 `gh pr edit [number] [--title T] [--body B]`:
+
 - `PATCH /repos/{owner}/{repo}/pulls/{number}` with provided fields
 
 `gh pr list`:
+
 - `GET /repos/{owner}/{repo}/pulls`
 - Format as JSON array
 
 `gh issue list`:
+
 - `GET /repos/{owner}/{repo}/issues`
 - Format as JSON array
 
 `gh issue view [number]`:
+
 - `GET /repos/{owner}/{repo}/issues/{number}`
 - Format as JSON
 
 `gh api <endpoint> [-X METHOD] [-f key=value]`:
+
 - Direct HTTP request to `https://api.github.com{endpoint}`
 - Method from `-X`/`--method` flag
 - Body from `-f`/`--field` flags (JSON-encoded)
 
 **Unsupported commands**: For commands that pass policy evaluation but aren't in the API mapping (edge case — most denied commands never reach this point), print a clear error:
+
 ```
 error: 'gh {command} {subcommand}' is not available in this sandbox environment
 ```
 
 **Flag parsing for API mode**: The shim already parses policy-relevant flags (`-R`, `--repo`, `-X`, `--method`). For API mode, we also need:
+
 - `--title`, `--body`, `--base`, `--head` (for `pr create/edit`)
 - `-f`, `--field`, `-F`, `--raw-field` (for `api`)
 - `--json`, `--jq` (for output formatting — pass-through for API mode since we return JSON by default)
@@ -549,12 +591,14 @@ Add these to the flag parser. Keep it simple — we only need the flags that map
 ### Testing
 
 Unit tests (can run without Docker):
+
 - Test `executeViaApi` with mocked `fetch` for each supported command
 - Test PR creation → policy state update
 - Test unsupported command → clear error message
 - Test flag extraction for `--title`, `--body`, `--base`, `--head`
 
 Integration tests (require GitHub token):
+
 - Run the shim (without `BOUNCER_REAL_GH`) against a test repo
 - `gh pr list` → returns JSON array
 - `gh issue list` → returns JSON array
@@ -562,6 +606,7 @@ Integration tests (require GitHub token):
 - `gh pr create` → creates PR, captures number, updates policy state
 
 ### Exit criteria
+
 - The shim works in both modes: proxy-to-real-gh (host) and direct-API (container).
 - All commands listed in the design doc's API mapping work.
 - PR creation captures the PR number and updates policy state (same behavior as M5).
@@ -597,6 +642,7 @@ export class ContainerMonitor extends EventEmitter<SandboxMonitorEvents> {
 ```
 
 For M6, the `ContainerMonitor` is lightweight — it's mainly a placeholder. The real violation detection comes from:
+
 - Policy events (stderr parsing — already works, unchanged)
 - Filesystem permission errors (surface via ACP tool call failures — no code change needed)
 - Container lifecycle events (OOM, unexpected exit — from Docker events stream)
@@ -609,17 +655,19 @@ For M6, the `ContainerMonitor` is lightweight — it's mainly a placeholder. The
 ### Changes to `src/main/types.ts`
 
 Update `SessionSummary`:
+
 ```typescript
 export interface SessionSummary {
   // ... existing fields ...
   sandboxBackend: SandboxBackend; // "safehouse" | "container" | "none"
-  containerId: string | null;     // Docker container ID when backend=container
+  containerId: string | null; // Docker container ID when backend=container
 }
 ```
 
 ### Changes to renderer
 
 **`SessionList.tsx`**: Show sandbox backend indicator next to each session:
+
 - Container: "Container" badge
 - Safehouse: "Seatbelt" badge
 - None: "Unsandboxed" warning
@@ -635,12 +683,14 @@ No changes needed — `SessionSummary` is passed through IPC and the new fields 
 ### Testing
 
 Manual: create sessions with and without Docker available. Verify:
+
 - Container sessions show "Container" badge
 - Safehouse fallback shows "Seatbelt" badge
 - Policy events display correctly for both backends
 - OOM-killed container shows up as a session error
 
 ### Exit criteria
+
 - UI clearly indicates which sandbox backend each session uses.
 - Policy events work identically for both backends.
 - Container lifecycle events (unexpected exit, OOM) surface as session errors.
@@ -654,6 +704,7 @@ Manual: create sessions with and without Docker available. Verify:
 ### Validation checklist
 
 **Claude Code PR workflow in container**:
+
 - [ ] Create session with `standard-pr` policy
 - [ ] Agent can read and edit files in the worktree
 - [ ] Agent can run `npm install`, `npm test`, etc.
@@ -669,14 +720,17 @@ Manual: create sessions with and without Docker available. Verify:
 - [ ] Session close removes the container and all host artifacts
 
 **Replay agent regression**:
+
 - [ ] All replay sessions from the test dataset pass in containers
 - [ ] Policy enforcement results match safehouse baseline
 
 **Safehouse fallback**:
+
 - [ ] With Docker unavailable, sessions fall back to safehouse
 - [ ] All M5 tests pass in safehouse mode (no regressions)
 
 **Orphan cleanup**:
+
 - [ ] Kill the app mid-session, restart — orphan containers are cleaned up
 - [ ] Orphan worktrees, policy files, hooks, shim dirs are cleaned up (existing behavior)
 
@@ -688,6 +742,7 @@ Manual: create sessions with and without Docker available. Verify:
 - Ensure `scripts/test-*` scripts cover both container and safehouse paths
 
 ### Exit criteria
+
 - All items in the validation checklist pass.
 - Roadmap updated.
 - No stale TODO comments.
@@ -726,13 +781,13 @@ Phase 6 (`gh` shim API mode) can be developed in parallel with Phases 3-5. It ha
 
 After each phase merges, verify:
 
-| After Phase | Check |
-|---|---|
-| Phase 1 | Image builds, contains expected toolchains, no `gh` binary |
-| Phase 2 | stdio works through `docker run -i`, container cleanup is reliable |
-| Phase 3 | ACP protocol works over container stdio (text streaming, tool calls) |
-| Phase 4 | Mount strategy is correct (rw/ro), gitconfig is valid, credential helper works |
-| Phase 5 | Full agent session works in container, policy enforcement matches safehouse |
-| Phase 6 | Shim API mode handles the common `gh` commands, PR capture works |
-| Phase 7 | UI reflects backend correctly, monitoring captures relevant events |
-| Phase 8 | Everything works together, no regressions, roadmap updated |
+| After Phase | Check                                                                          |
+| ----------- | ------------------------------------------------------------------------------ |
+| Phase 1     | Image builds, contains expected toolchains, no `gh` binary                     |
+| Phase 2     | stdio works through `docker run -i`, container cleanup is reliable             |
+| Phase 3     | ACP protocol works over container stdio (text streaming, tool calls)           |
+| Phase 4     | Mount strategy is correct (rw/ro), gitconfig is valid, credential helper works |
+| Phase 5     | Full agent session works in container, policy enforcement matches safehouse    |
+| Phase 6     | Shim API mode handles the common `gh` commands, PR capture works               |
+| Phase 7     | UI reflects backend correctly, monitoring captures relevant events             |
+| Phase 8     | Everything works together, no regressions, roadmap updated                     |

--- a/docs/history/deterministic-test-agent/design.md
+++ b/docs/history/deterministic-test-agent/design.md
@@ -17,7 +17,7 @@ Build a reproducible testing system for sandbox policies by replaying real tool-
 - LLM-based agents or any network-dependent agent behavior (the replay is purely deterministic)
 - Application-layer policy enforcement (Milestone 5) — we measure what the OS sandbox allows/blocks, not git-semantic or API-semantic constraints
 - Modifying policy templates based on findings (that's a follow-up task informed by this milestone's data)
-- Replay fidelity for tool *results* — we care about whether the operation was allowed, not whether it produced the right output
+- Replay fidelity for tool _results_ — we care about whether the operation was allowed, not whether it produced the right output
 - UI for browsing batch validation results (CLI/JSON output is sufficient)
 
 ---
@@ -32,7 +32,7 @@ Milestone 2 ([findings](../../history/seatbelt-sandbox/findings.md)) validated t
 
 2. **Temp directory access is broad.** Safehouse's `--enable=all-agents` grants write access to temp directories, and worktrees live in temp. Filesystem write restrictions within temp are not enforceable at the OS level.
 
-These findings mean the current policy templates (`standard-pr`, `research-only`, `permissive`) differ primarily in *declared intent* rather than *enforced behavior*. Milestone 4 quantifies this gap: given real-world tool-use patterns, what fraction of operations does each policy *actually* constrain?
+These findings mean the current policy templates (`standard-pr`, `research-only`, `permissive`) differ primarily in _declared intent_ rather than _enforced behavior_. Milestone 4 quantifies this gap: given real-world tool-use patterns, what fraction of operations does each policy _actually_ constrain?
 
 ### Why a Replay Agent
 
@@ -50,7 +50,7 @@ The dataset ([`data/tool-use-dataset.jsonl`](../../data/tool-use-dataset.jsonl))
 {
   "id": 1,
   "tool": "Read",
-  "input": {"file_path": "{project}/src/index.ts"},
+  "input": { "file_path": "{project}/src/index.ts" },
   "outcome": "approved",
   "project": "project-01",
   "session": "session-001",
@@ -61,6 +61,7 @@ The dataset ([`data/tool-use-dataset.jsonl`](../../data/tool-use-dataset.jsonl))
 ```
 
 Key properties relevant to replay:
+
 - **Anonymized paths**: `{project}`, `{home}`, `{user}` placeholders replace real paths. The replay agent must de-anonymize these to worktree-relative paths.
 - **Tool inputs only**: Tool results are excluded from the dataset. The replay agent doesn't need them — it executes the operation and observes whether the sandbox allows it.
 - **Session grouping**: Records are grouped by `session` and ordered by `timestamp_relative`, giving us sequential replay order.
@@ -116,7 +117,7 @@ Key properties relevant to replay:
 
 ### Key Design Decision: Execute Inside the Sandbox
 
-The replay agent doesn't *simulate* what the sandbox would do — it actually runs the operations inside a real sandbox. This means:
+The replay agent doesn't _simulate_ what the sandbox would do — it actually runs the operations inside a real sandbox. This means:
 
 - **No sandbox model to maintain**: We don't need to reason about SBPL rules. The kernel enforces them.
 - **Ground truth**: If a `Read` call returns EPERM, we know the policy blocks it. No false assumptions.
@@ -193,7 +194,7 @@ interface ReplayToolCall {
   id: number;
   tool: string;
   input: Record<string, unknown>;
-  original_outcome: string;  // from dataset: approved/rejected/error
+  original_outcome: string; // from dataset: approved/rejected/error
 }
 ```
 
@@ -203,27 +204,27 @@ interface ReplayToolCall {
 interface ReplayResult {
   id: number;
   tool: string;
-  replay_outcome: "allowed" | "blocked" | "skipped" | "error";
-  error_message?: string;    // EPERM message, sandbox violation detail
-  original_outcome: string;  // for comparison
+  replay_outcome: 'allowed' | 'blocked' | 'skipped' | 'error';
+  error_message?: string; // EPERM message, sandbox violation detail
+  original_outcome: string; // for comparison
 }
 ```
 
 **Tool execution strategy** — the replay agent maps each tool name to an actual operation:
 
-| Tool | Replay Action | Can Be Blocked By Sandbox? |
-|------|--------------|---------------------------|
-| `Read` | `fs.readFile(path)` | Yes — path outside sandbox boundary |
-| `Write` | `fs.writeFile(path, placeholder)` | Yes — write to read-only or restricted path |
-| `Edit` | `fs.readFile(path)` then `fs.writeFile(path, modified)` | Yes — same as Write |
-| `Bash` | `child_process.execSync(command)` | Yes — commands touching restricted paths/network |
-| `Grep` | `fs.readFile(path)` (simplified to read access check) | Yes — path restrictions |
-| `Glob` | `fs.readdir(path)` (simplified to read access check) | Yes — path restrictions |
-| `WebFetch` | `fetch(url)` or skip if network blocked | Yes — network-deny policy |
-| `WebSearch` | Skip (no local equivalent) | N/A |
-| `TodoWrite` | No-op (in-memory only) | No |
-| `Task`/`Agent` | Skip (subagent spawning) | N/A |
-| MCP tools | Skip (no MCP servers in replay) | N/A |
+| Tool           | Replay Action                                           | Can Be Blocked By Sandbox?                       |
+| -------------- | ------------------------------------------------------- | ------------------------------------------------ |
+| `Read`         | `fs.readFile(path)`                                     | Yes — path outside sandbox boundary              |
+| `Write`        | `fs.writeFile(path, placeholder)`                       | Yes — write to read-only or restricted path      |
+| `Edit`         | `fs.readFile(path)` then `fs.writeFile(path, modified)` | Yes — same as Write                              |
+| `Bash`         | `child_process.execSync(command)`                       | Yes — commands touching restricted paths/network |
+| `Grep`         | `fs.readFile(path)` (simplified to read access check)   | Yes — path restrictions                          |
+| `Glob`         | `fs.readdir(path)` (simplified to read access check)    | Yes — path restrictions                          |
+| `WebFetch`     | `fetch(url)` or skip if network blocked                 | Yes — network-deny policy                        |
+| `WebSearch`    | Skip (no local equivalent)                              | N/A                                              |
+| `TodoWrite`    | No-op (in-memory only)                                  | No                                               |
+| `Task`/`Agent` | Skip (subagent spawning)                                | N/A                                              |
+| MCP tools      | Skip (no MCP servers in replay)                         | N/A                                              |
 
 **Path de-anonymization**:
 
@@ -239,6 +240,7 @@ function deanonymizePath(path: string, context: ReplayContext): string {
 **Bash command handling**:
 
 Bash commands require special care:
+
 - De-anonymize paths in the command string
 - Execute via `child_process.execSync` with a short timeout (5 seconds)
 - Capture exit code and stderr
@@ -247,6 +249,7 @@ Bash commands require special care:
 - Commands referencing `{host}` (anonymized URLs) → `skipped` (can't replay network calls)
 
 **Skipping rules**:
+
 - Tool is `WebSearch`, `Task`, `Agent`, `TodoWrite`, `EnterPlanMode`, `ExitPlanMode`, `ToolSearch`, `Skill`, `AskUserQuestion`, or any MCP tool → `skipped`
 - Bash command contains `{host}` → `skipped`
 - Input references paths that can't be de-anonymized → `skipped`
@@ -256,7 +259,7 @@ Bash commands require special care:
 **Add `"replay"` to `AgentType`** (`src/main/types.ts`):
 
 ```typescript
-export type AgentType = "echo" | "claude-code" | "replay";
+export type AgentType = 'echo' | 'claude-code' | 'replay';
 ```
 
 **Add `resolveReplayAgentCommand()`** to `session-manager.ts`, following the same pattern as `resolveEchoAgentCommand()`. The replay agent script path: `src/agents/replay-agent.ts` (dev) / `dist/agents/replay-agent.js` (prod).
@@ -275,8 +278,8 @@ Before replaying a session, the worktree needs a minimal file structure so that 
 
 ```typescript
 interface ScaffoldPlan {
-  files: Map<string, string>;     // relative path → content
-  directories: Set<string>;       // relative paths to mkdir -p
+  files: Map<string, string>; // relative path → content
+  directories: Set<string>; // relative paths to mkdir -p
 }
 
 function buildScaffoldPlan(toolCalls: ReplayToolCall[]): ScaffoldPlan;
@@ -327,6 +330,7 @@ for each session in dataset:
 ```
 
 **The harness reuses existing infrastructure**:
+
 - `WorktreeManager` for worktree lifecycle
 - `PolicyTemplateRegistry` for policy lookup
 - `policyToSandboxConfig()` for sandbox config generation
@@ -353,16 +357,19 @@ interface ReplayReport {
     blocked: number;
     skipped: number;
     error: number;
-    allowedRate: number;     // allowed / (allowed + blocked)
-    falseBlockRate: number;  // blocked calls that were "approved" in original
+    allowedRate: number; // allowed / (allowed + blocked)
+    falseBlockRate: number; // blocked calls that were "approved" in original
   };
-  byTool: Record<string, {
-    total: number;
-    allowed: number;
-    blocked: number;
-    skipped: number;
-    error: number;
-  }>;
+  byTool: Record<
+    string,
+    {
+      total: number;
+      allowed: number;
+      blocked: number;
+      skipped: number;
+      error: number;
+    }
+  >;
   sessions: SessionReplayResult[];
 }
 
@@ -387,6 +394,7 @@ interface SessionReplayResult {
 The replay agent should be selectable in the Glitter Ball UI as a third agent type. This is primarily for interactive debugging — the batch harness is the main workflow.
 
 **Changes**:
+
 - `NewSessionDialog`: Add "Replay" option to agent type selector
 - When `replay` is selected, prompt for a session ID (text input) to replay
 - Session manager loads that session's tool calls from the dataset and sends them as the first prompt
@@ -405,6 +413,7 @@ The current dataset has anonymized paths but no session-level metadata. For real
 The tool calls themselves tell us what files the session touched. The scaffold step (Component 3) already extracts these paths. No dataset changes needed — the scaffolder builds the file structure on-the-fly from the session's own tool calls.
 
 This is sufficient because:
+
 - We're testing sandbox boundaries, not application behavior
 - A `Read` to `{project}/src/index.ts` just needs that file to exist
 - A `Bash` running `npm test` doesn't need real tests — it will succeed or fail based on sandbox permissions, not test correctness
@@ -416,7 +425,7 @@ If Approach A proves insufficient (e.g., Bash commands that assume specific dire
 ```json
 {
   "session-001": {
-    "project_type": "node",       // inferred from tool calls (package.json present?)
+    "project_type": "node", // inferred from tool calls (package.json present?)
     "estimated_file_count": 42,
     "tools_used": ["Read", "Bash", "Edit"],
     "has_network_calls": true
@@ -512,25 +521,25 @@ We defer this until Approach A hits a wall.
 
 ## Dependencies
 
-| Dependency | Status | Notes |
-|-----------|--------|-------|
-| `@agentclientprotocol/sdk` | Exists | Same ACP primitives used by echo agent |
-| `agent-safehouse` | Exists | CLI must be installed on developer machine |
-| `WorktreeManager` | Exists | Reused from session manager |
-| `PolicyTemplateRegistry` | Exists | Reused from M3 |
-| `policyToSandboxConfig()` | Exists | Reused from M3 |
-| `data/tool-use-dataset.jsonl` | Exists | 11,491 records, 296 sessions |
-| Node.js `fs`, `child_process` | Stdlib | For tool execution in replay agent |
+| Dependency                    | Status | Notes                                      |
+| ----------------------------- | ------ | ------------------------------------------ |
+| `@agentclientprotocol/sdk`    | Exists | Same ACP primitives used by echo agent     |
+| `agent-safehouse`             | Exists | CLI must be installed on developer machine |
+| `WorktreeManager`             | Exists | Reused from session manager                |
+| `PolicyTemplateRegistry`      | Exists | Reused from M3                             |
+| `policyToSandboxConfig()`     | Exists | Reused from M3                             |
+| `data/tool-use-dataset.jsonl` | Exists | 11,491 records, 296 sessions               |
+| Node.js `fs`, `child_process` | Stdlib | For tool execution in replay agent         |
 
 No new external dependencies required.
 
 ## File Inventory
 
-| File | Type | Description |
-|------|------|-------------|
-| `src/agents/replay-agent.ts` | New | ACP replay agent |
-| `src/main/replay-scaffold.ts` | New | Worktree file scaffolding for replay sessions |
-| `scripts/replay-test.ts` | New | CLI test harness for batch validation |
-| `src/main/types.ts` | Modified | Add `"replay"` to `AgentType`, add replay-related types |
-| `src/main/session-manager.ts` | Modified | Add `resolveReplayAgentCommand()`, handle replay agent type |
-| `src/renderer/src/components/NewSessionDialog.tsx` | Modified | Add replay agent option + session ID input |
+| File                                               | Type     | Description                                                 |
+| -------------------------------------------------- | -------- | ----------------------------------------------------------- |
+| `src/agents/replay-agent.ts`                       | New      | ACP replay agent                                            |
+| `src/main/replay-scaffold.ts`                      | New      | Worktree file scaffolding for replay sessions               |
+| `scripts/replay-test.ts`                           | New      | CLI test harness for batch validation                       |
+| `src/main/types.ts`                                | Modified | Add `"replay"` to `AgentType`, add replay-related types     |
+| `src/main/session-manager.ts`                      | Modified | Add `resolveReplayAgentCommand()`, handle replay agent type |
+| `src/renderer/src/components/NewSessionDialog.tsx` | Modified | Add replay agent option + session ID input                  |

--- a/docs/history/deterministic-test-agent/findings.md
+++ b/docs/history/deterministic-test-agent/findings.md
@@ -6,18 +6,18 @@
 
 ## Summary
 
-| Metric | Value |
-|--------|-------|
-| Sessions attempted | 296 |
-| Sessions completed | 285 (96.3%) |
-| Sessions failed | 11 (3.7%) |
-| Tool calls replayed | 10,044 |
-| Allowed | 5,989 (59.6%) |
-| Blocked | 0 (0.0%) |
-| Skipped | 3,423 (34.1%) |
-| Error | 632 (6.3%) |
-| Allowed rate | 100.0% |
-| False-block rate | 0.0% |
+| Metric              | Value         |
+| ------------------- | ------------- |
+| Sessions attempted  | 296           |
+| Sessions completed  | 285 (96.3%)   |
+| Sessions failed     | 11 (3.7%)     |
+| Tool calls replayed | 10,044        |
+| Allowed             | 5,989 (59.6%) |
+| Blocked             | 0 (0.0%)      |
+| Skipped             | 3,423 (34.1%) |
+| Error               | 632 (6.3%)    |
+| Allowed rate        | 100.0%        |
+| False-block rate    | 0.0%          |
 
 **Key finding**: With no sandbox enforcement, 100% of actionable tool calls are allowed (blocked = 0). This is the expected baseline — zero blocks confirms the replay agent is unconstrained by policy, even though some calls still encounter execution errors.
 
@@ -25,35 +25,36 @@
 
 All three policies produce identical results in unsandboxed mode (expected):
 
-| Policy | Allowed | Blocked | Skipped | Error | Allowed Rate |
-|--------|---------|---------|---------|-------|-------------|
-| standard-pr | 5,989 | 0 | 3,423 | 632 | 100.0% |
-| research-only | 5,989 | 0 | 3,423 | 632 | 100.0% |
-| permissive | 5,989 | 0 | 3,423 | 632 | 100.0% |
+| Policy        | Allowed | Blocked | Skipped | Error | Allowed Rate |
+| ------------- | ------- | ------- | ------- | ----- | ------------ |
+| standard-pr   | 5,989   | 0       | 3,423   | 632   | 100.0%       |
+| research-only | 5,989   | 0       | 3,423   | 632   | 100.0%       |
+| permissive    | 5,989   | 0       | 3,423   | 632   | 100.0%       |
 
 Policy differentiation will only appear when safehouse sandboxing is enabled (M5-6).
 
 ## Per-Tool Breakdown
 
-| Tool | Total | Allowed | Blocked | Skipped | Error |
-|------|-------|---------|---------|---------|-------|
-| Bash | 3,329 | 1,818 (54.6%) | 0 | 898 (27.0%) | 613 (18.4%) |
-| Read | 3,269 | 2,176 (66.6%) | 0 | 1,067 (32.6%) | 26 (0.8%) |
-| Edit | 841 | 570 (67.8%) | 0 | 265 (31.5%) | 6 (0.7%) |
-| Glob | 502 | 491 (97.8%) | 0 | 11 (2.2%) | 0 |
-| Grep | 467 | 332 (71.1%) | 0 | 127 (27.2%) | 8 (1.7%) |
-| WebFetch | 426 | 414 (97.2%) | 0 | 12 (2.8%) | 0 |
-| WebSearch | 367 | 0 | 0 | 367 (100%) | 0 |
-| TodoWrite | 334 | 0 | 0 | 334 (100%) | 0 |
-| Write | 190 | 166 (87.4%) | 0 | 23 (12.1%) | 1 (0.5%) |
-| MCP tools | 136 | 0 | 0 | 136 (100%) | 0 |
-| Other (Agent, Task, etc.) | 183 | 0 | 0 | 183 (100%) | 0 |
+| Tool                      | Total | Allowed       | Blocked | Skipped       | Error       |
+| ------------------------- | ----- | ------------- | ------- | ------------- | ----------- |
+| Bash                      | 3,329 | 1,818 (54.6%) | 0       | 898 (27.0%)   | 613 (18.4%) |
+| Read                      | 3,269 | 2,176 (66.6%) | 0       | 1,067 (32.6%) | 26 (0.8%)   |
+| Edit                      | 841   | 570 (67.8%)   | 0       | 265 (31.5%)   | 6 (0.7%)    |
+| Glob                      | 502   | 491 (97.8%)   | 0       | 11 (2.2%)     | 0           |
+| Grep                      | 467   | 332 (71.1%)   | 0       | 127 (27.2%)   | 8 (1.7%)    |
+| WebFetch                  | 426   | 414 (97.2%)   | 0       | 12 (2.8%)     | 0           |
+| WebSearch                 | 367   | 0             | 0       | 367 (100%)    | 0           |
+| TodoWrite                 | 334   | 0             | 0       | 334 (100%)    | 0           |
+| Write                     | 190   | 166 (87.4%)   | 0       | 23 (12.1%)    | 1 (0.5%)    |
+| MCP tools                 | 136   | 0             | 0       | 136 (100%)    | 0           |
+| Other (Agent, Task, etc.) | 183   | 0             | 0       | 183 (100%)    | 0           |
 
 ## Error Analysis
 
 ### Bash errors (613 / 3,329 = 18.4%)
 
 The highest error rate. Root causes:
+
 - **Command not found**: Commands like `pnpm`, `cargo`, `gh`, `npx` that aren't installed in the replay environment
 - **Git operations**: `git push`, `git pull` and other network-dependent git commands that fail without remote access
 - **Missing dependencies**: Build commands (`npm run build`, `cargo test`) that fail because project dependencies aren't installed
@@ -64,23 +65,25 @@ These are **not sandbox blocks** — they're environmental errors from replaying
 ### Read/Edit/Grep errors (40 combined)
 
 Very low error rate (<1%). Causes:
+
 - Missing files not covered by scaffolding (files referenced only in later tool calls after being created by Write/Bash)
 - Permission errors on files within `.git/` internals
 
 ### Session failures (11 / 296 = 3.7%)
 
 Root causes:
+
 - **EEXIST on scaffold**: 9 sessions failed because `mkdir` in `applyScaffold` collided with existing git-tracked files (e.g., `.gitignore`, `.git`, `examples/src`). The scaffold tries to create a directory where a file already exists. Fix: improve `looksLikeFile()` heuristic or add ENOTDIR handling in scaffold.
 - **Git worktree contention**: 1 session failed due to concurrent git ref updates (`unable to append to .git/logs/refs/heads/...`). This is a concurrency issue with git worktrees sharing the same `.git` directory.
 - **ENOTDIR in scaffold**: 1 session failed because a path component in node_modules was a symlink/file, not a directory.
 
 ## Skipped Calls Analysis (3,423 / 10,044 = 34.1%)
 
-| Skip reason | Count | Percentage |
-|-------------|-------|-----------|
-| Non-replayable tools (WebSearch, TodoWrite, Agent, etc.) | 1,369 | 40.0% |
-| Un-resolvable paths ({project-name}, .claude/) | ~1,156 | 33.8% |
-| {host} placeholder in commands/URLs | ~898 | 26.2% |
+| Skip reason                                              | Count  | Percentage |
+| -------------------------------------------------------- | ------ | ---------- |
+| Non-replayable tools (WebSearch, TodoWrite, Agent, etc.) | 1,369  | 40.0%      |
+| Un-resolvable paths ({project-name}, .claude/)           | ~1,156 | 33.8%      |
+| {host} placeholder in commands/URLs                      | ~898   | 26.2%      |
 
 The skip rate is expected — these represent tool calls that either have no filesystem/process side effects or contain anonymized values that can't be resolved.
 

--- a/docs/history/deterministic-test-agent/plan.md
+++ b/docs/history/deterministic-test-agent/plan.md
@@ -69,7 +69,7 @@ Define the data types and get the bare ACP agent running. No tool execution yet 
 Extend `AgentType` and add the replay-specific types:
 
 ```typescript
-export type AgentType = "echo" | "claude-code" | "replay";
+export type AgentType = 'echo' | 'claude-code' | 'replay';
 
 // --- Replay Types ---
 
@@ -83,7 +83,7 @@ export interface ReplayToolCall {
 export interface ReplayResult {
   id: number;
   tool: string;
-  replay_outcome: "allowed" | "blocked" | "skipped" | "error";
+  replay_outcome: 'allowed' | 'blocked' | 'skipped' | 'error';
   error_message?: string;
   original_outcome: string;
 }
@@ -92,6 +92,7 @@ export interface ReplayResult {
 ### 1.2 Create `src/agents/replay-agent.ts` skeleton
 
 Model after `echo-agent.ts`. The skeleton:
+
 - Sets up `AgentSideConnection` with stdio streams
 - Implements `initialize`, `newSession`, `prompt`, `cancel`
 - In `prompt`: parses the prompt text as `JSON.parse(text)` to get `ReplayToolCall[]`
@@ -136,31 +137,31 @@ function resolveReplayAgentCommand(
   worktreePath: string,
 ): SpawnConfig {
   const isDev = !app.isPackaged;
-  const require = createRequire(app.getAppPath() + "/");
+  const require = createRequire(app.getAppPath() + '/');
 
   let cmd: string;
   let args: string[];
 
   if (isDev) {
-    const tsxBin = require.resolve("tsx/cli");
-    const agentScript = join(app.getAppPath(), "src", "agents", "replay-agent.ts");
+    const tsxBin = require.resolve('tsx/cli');
+    const agentScript = join(app.getAppPath(), 'src', 'agents', 'replay-agent.ts');
     cmd = process.execPath;
     args = [tsxBin, agentScript];
   } else {
-    const agentScript = join(__dirname, "..", "agents", "replay-agent.js");
+    const agentScript = join(__dirname, '..', 'agents', 'replay-agent.js');
     cmd = process.execPath;
     args = [agentScript];
   }
 
   const env: Record<string, string> = {
-    ELECTRON_RUN_AS_NODE: "1",
+    ELECTRON_RUN_AS_NODE: '1',
     REPLAY_WORKTREE_PATH: worktreePath,
   };
 
   // Wrap in safehouse if sandbox config present
   if (sandboxConfig) {
     const safehouseArgs = buildSafehouseArgs(sandboxConfig, [cmd, ...args]);
-    return { cmd: "safehouse", args: safehouseArgs, cwd, env };
+    return { cmd: 'safehouse', args: safehouseArgs, cwd, env };
   }
 
   return { cmd, args, env, cwd };
@@ -180,10 +181,10 @@ function resolveAgentCommand(
   sandboxConfig: SandboxConfig | null,
   worktreePath?: string,
 ): SpawnConfig {
-  if (agentType === "echo") {
+  if (agentType === 'echo') {
     return resolveEchoAgentCommand();
   }
-  if (agentType === "replay") {
+  if (agentType === 'replay') {
     return resolveReplayAgentCommand(cwd, sandboxConfig, worktreePath ?? cwd);
   }
   return resolveClaudeCodeCommand(cwd, sandboxConfig);
@@ -193,6 +194,7 @@ function resolveAgentCommand(
 ### 2.3 Update `createSession()` for replay-specific behavior
 
 The replay agent needs:
+
 - A worktree (same as claude-code) — for sandbox-scoped file operations
 - A policy template (same as claude-code) — for sandbox config generation
 - **No** `ANTHROPIC_API_KEY` in env passthrough
@@ -201,12 +203,13 @@ Update the conditional in `createSession()`:
 
 ```typescript
 // Resolve policy template — replay agents also get sandboxed
-const resolvedPolicyId = (agentType === "claude-code" || agentType === "replay")
-  ? (policyId ?? this.policyRegistry.defaultId)
-  : null;
+const resolvedPolicyId =
+  agentType === 'claude-code' || agentType === 'replay'
+    ? (policyId ?? this.policyRegistry.defaultId)
+    : null;
 
 // Create worktree for Claude Code and replay sessions
-if (agentType === "claude-code" || agentType === "replay") {
+if (agentType === 'claude-code' || agentType === 'replay') {
   const isGitRepo = await this.worktreeManager.validateGitRepo(projectDir);
   if (!isGitRepo) {
     throw new Error(`Not a git repository: ${projectDir}`);
@@ -231,23 +234,27 @@ const { cmd, args, env, cwd } = resolveAgentCommand(
 The current `sessions:create` handler only accepts `"echo"` and `"claude-code"`. Add `"replay"`:
 
 ```typescript
-ipcMain.handle('sessions:create', (_e, projectDir: unknown, agentType: unknown, policyId: unknown) => {
-  if (typeof projectDir !== 'string') {
-    throw new Error('Invalid argument: projectDir must be a string')
-  }
-  const validTypes = ['echo', 'claude-code', 'replay'] as const
-  type ValidType = typeof validTypes[number]
-  const validAgentType: ValidType = validTypes.includes(agentType as ValidType)
-    ? (agentType as ValidType)
-    : 'claude-code'
-  const validPolicyId = typeof policyId === 'string' ? policyId : undefined
-  return sessionManager.createSession(projectDir, validAgentType, validPolicyId)
-})
+ipcMain.handle(
+  'sessions:create',
+  (_e, projectDir: unknown, agentType: unknown, policyId: unknown) => {
+    if (typeof projectDir !== 'string') {
+      throw new Error('Invalid argument: projectDir must be a string');
+    }
+    const validTypes = ['echo', 'claude-code', 'replay'] as const;
+    type ValidType = (typeof validTypes)[number];
+    const validAgentType: ValidType = validTypes.includes(agentType as ValidType)
+      ? (agentType as ValidType)
+      : 'claude-code';
+    const validPolicyId = typeof policyId === 'string' ? policyId : undefined;
+    return sessionManager.createSession(projectDir, validAgentType, validPolicyId);
+  },
+);
 ```
 
 ### 2.5 Write `scripts/test-replay-agent.ts`
 
 Test script that:
+
 1. Spawns the replay agent directly (no Electron, no sandbox)
 2. Performs ACP handshake (initialize → newSession)
 3. Sends a prompt with a hand-crafted JSON tool-call array
@@ -281,19 +288,19 @@ In `replay-agent.ts`, implement an `executeToolCall()` function with handlers fo
 **Error classification logic** (shared across all executors):
 
 ```typescript
-function classifyError(err: unknown): "blocked" | "error" {
+function classifyError(err: unknown): 'blocked' | 'error' {
   if (err instanceof Error) {
     const msg = err.message.toLowerCase();
     if (
-      msg.includes("eperm") ||
-      msg.includes("eacces") ||
-      msg.includes("operation not permitted") ||
-      msg.includes("permission denied")
+      msg.includes('eperm') ||
+      msg.includes('eacces') ||
+      msg.includes('operation not permitted') ||
+      msg.includes('permission denied')
     ) {
-      return "blocked";
+      return 'blocked';
     }
   }
-  return "error";
+  return 'error';
 }
 ```
 
@@ -302,29 +309,29 @@ function classifyError(err: unknown): "blocked" | "error" {
 ```typescript
 async function executeBash(command: string, cwd: string): Promise<ReplayResult> {
   // Skip network-dependent commands
-  if (command.includes("{host}")) return { ...base, replay_outcome: "skipped" };
+  if (command.includes('{host}')) return { ...base, replay_outcome: 'skipped' };
 
   try {
     execSync(deanonymizeCommand(command), {
       cwd,
       timeout: 5000,
-      stdio: ["pipe", "pipe", "pipe"],
+      stdio: ['pipe', 'pipe', 'pipe'],
       env: process.env,
     });
-    return { ...base, replay_outcome: "allowed" };
+    return { ...base, replay_outcome: 'allowed' };
   } catch (err) {
     // Check if it's a sandbox block vs. a regular command failure
-    const stderr = (err as any)?.stderr?.toString() ?? "";
-    const msg = (err as Error).message ?? "";
+    const stderr = (err as any)?.stderr?.toString() ?? '';
+    const msg = (err as Error).message ?? '';
     const combined = stderr + msg;
     if (
-      combined.includes("Operation not permitted") ||
-      combined.includes("EPERM") ||
-      combined.includes("Permission denied")
+      combined.includes('Operation not permitted') ||
+      combined.includes('EPERM') ||
+      combined.includes('Permission denied')
     ) {
-      return { ...base, replay_outcome: "blocked", error_message: combined.slice(0, 200) };
+      return { ...base, replay_outcome: 'blocked', error_message: combined.slice(0, 200) };
     }
-    return { ...base, replay_outcome: "error", error_message: combined.slice(0, 200) };
+    return { ...base, replay_outcome: 'error', error_message: combined.slice(0, 200) };
   }
 }
 ```
@@ -341,15 +348,25 @@ Build a skip set:
 
 ```typescript
 const SKIP_TOOLS = new Set([
-  "WebSearch", "Task", "Agent", "TodoWrite",
-  "EnterPlanMode", "ExitPlanMode", "ToolSearch",
-  "Skill", "AskUserQuestion", "TaskOutput", "TaskStop",
-  "EnterWorktree", "ExitWorktree", "NotebookEdit",
+  'WebSearch',
+  'Task',
+  'Agent',
+  'TodoWrite',
+  'EnterPlanMode',
+  'ExitPlanMode',
+  'ToolSearch',
+  'Skill',
+  'AskUserQuestion',
+  'TaskOutput',
+  'TaskStop',
+  'EnterWorktree',
+  'ExitWorktree',
+  'NotebookEdit',
 ]);
 
 function shouldSkip(tool: string): boolean {
   if (SKIP_TOOLS.has(tool)) return true;
-  if (tool.startsWith("mcp__")) return true;  // MCP tools
+  if (tool.startsWith('mcp__')) return true; // MCP tools
   return false;
 }
 ```
@@ -360,11 +377,31 @@ Update `scripts/test-replay-agent.ts` to send a mixed sequence:
 
 ```json
 [
-  {"id": 1, "tool": "Read", "input": {"file_path": "{project}/test.txt"}, "original_outcome": "approved"},
-  {"id": 2, "tool": "Write", "input": {"file_path": "{project}/new.txt", "content": "hello"}, "original_outcome": "approved"},
-  {"id": 3, "tool": "Bash", "input": {"command": "ls {project}"}, "original_outcome": "approved"},
-  {"id": 4, "tool": "TodoWrite", "input": {"todos": []}, "original_outcome": "approved"},
-  {"id": 5, "tool": "Read", "input": {"file_path": "/etc/passwd"}, "original_outcome": "approved"}
+  {
+    "id": 1,
+    "tool": "Read",
+    "input": { "file_path": "{project}/test.txt" },
+    "original_outcome": "approved"
+  },
+  {
+    "id": 2,
+    "tool": "Write",
+    "input": { "file_path": "{project}/new.txt", "content": "hello" },
+    "original_outcome": "approved"
+  },
+  {
+    "id": 3,
+    "tool": "Bash",
+    "input": { "command": "ls {project}" },
+    "original_outcome": "approved"
+  },
+  { "id": 4, "tool": "TodoWrite", "input": { "todos": [] }, "original_outcome": "approved" },
+  {
+    "id": 5,
+    "tool": "Read",
+    "input": { "file_path": "/etc/passwd" },
+    "original_outcome": "approved"
+  }
 ]
 ```
 
@@ -423,14 +460,15 @@ function deanonymizeCommand(command: string, ctx: ReplayContext): string {
 ### 4.3 Add skip detection for un-resolvable paths
 
 Some paths in the dataset can't be meaningfully de-anonymized:
+
 - `{project-name}` — appears in `.claude/projects/-Users-{user}-Code-{project-name}/...` (Claude Code's internal state files, not project files)
 - Paths containing `.claude/` — agent reading its own session transcripts, not replayable
 
 ```typescript
 function hasUnresolvablePath(input: Record<string, unknown>): boolean {
   const json = JSON.stringify(input);
-  if (json.includes("{project-name}")) return true;
-  if (json.includes(".claude/")) return true;
+  if (json.includes('{project-name}')) return true;
+  if (json.includes('.claude/')) return true;
   return false;
 }
 ```
@@ -440,15 +478,23 @@ These tool calls get `replay_outcome: "skipped"`.
 ### 4.4 Verify
 
 Take record `id: 1` from the dataset:
+
 ```json
-{"id":1,"tool":"Read","input":{"file_path":"{project}/.claude/projects/-Users-{user}-Code-{project-name}/fd033680-dc2e-44b6-a5c4-8079d916b2bf.jsonl"}}
+{
+  "id": 1,
+  "tool": "Read",
+  "input": {
+    "file_path": "{project}/.claude/projects/-Users-{user}-Code-{project-name}/fd033680-dc2e-44b6-a5c4-8079d916b2bf.jsonl"
+  }
+}
 ```
 
 This should be detected as un-resolvable (contains `{project-name}` and `.claude/`) → `skipped`.
 
 Take a normal record like:
+
 ```json
-{"tool":"Read","input":{"file_path":"{project}/src/index.ts"}}
+{ "tool": "Read", "input": { "file_path": "{project}/src/index.ts" } }
 ```
 
 This should de-anonymize to `<worktreePath>/src/index.ts` → valid path.
@@ -464,7 +510,7 @@ Before replaying, populate the worktree with stub files so that `Read` and `Edit
 ### 5.1 Create `src/main/replay-scaffold.ts`
 
 ```typescript
-import type { ReplayToolCall } from "./types.js";
+import type { ReplayToolCall } from './types.js';
 
 export interface ScaffoldPlan {
   /** Relative path → file content */
@@ -486,16 +532,17 @@ export function buildScaffoldPlan(
 
 **Path extraction logic per tool**:
 
-| Tool | Input field(s) | Scaffold action |
-|------|---------------|-----------------|
-| `Read` | `input.file_path` | Create file with `// stub\n` |
-| `Write` | `input.file_path` | Create parent directory only (write creates the file) |
-| `Edit` | `input.file_path` | Create file with `input.old_string` as content (if present) |
-| `Grep` | `input.path` | Create file or directory depending on whether path looks like a file or dir |
-| `Glob` | `input.path` | Create directory |
-| `Bash` | `input.command` | Best-effort: extract paths that start with `{project}/` from the command string |
+| Tool    | Input field(s)    | Scaffold action                                                                 |
+| ------- | ----------------- | ------------------------------------------------------------------------------- |
+| `Read`  | `input.file_path` | Create file with `// stub\n`                                                    |
+| `Write` | `input.file_path` | Create parent directory only (write creates the file)                           |
+| `Edit`  | `input.file_path` | Create file with `input.old_string` as content (if present)                     |
+| `Grep`  | `input.path`      | Create file or directory depending on whether path looks like a file or dir     |
+| `Glob`  | `input.path`      | Create directory                                                                |
+| `Bash`  | `input.command`   | Best-effort: extract paths that start with `{project}/` from the command string |
 
 **Path filtering**:
+
 - Only scaffold paths that start with `{project}/` (or de-anonymize to within the worktree)
 - Skip paths containing `{project-name}`, `.claude/`, or `{home}`
 - Skip paths that are system paths (`/etc`, `/usr`, `/tmp`, `/var`)
@@ -503,13 +550,10 @@ export function buildScaffoldPlan(
 ### 5.2 Implement `applyScaffold()`
 
 ```typescript
-import { mkdir, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 
-export async function applyScaffold(
-  worktreePath: string,
-  plan: ScaffoldPlan,
-): Promise<number> {
+export async function applyScaffold(worktreePath: string, plan: ScaffoldPlan): Promise<number> {
   // Create directories first
   for (const dir of plan.directories) {
     await mkdir(join(worktreePath, dir), { recursive: true });
@@ -518,7 +562,7 @@ export async function applyScaffold(
   for (const [relPath, content] of plan.files) {
     const absPath = join(worktreePath, relPath);
     await mkdir(dirname(absPath), { recursive: true });
-    await writeFile(absPath, content, "utf-8");
+    await writeFile(absPath, content, 'utf-8');
   }
   return plan.files.size;
 }
@@ -529,12 +573,12 @@ export async function applyScaffold(
 For `Edit` tool calls, the dataset includes `input.old_string` — the text the edit expects to find. Seed the stub file with this content so the edit can match:
 
 ```typescript
-if (tool === "Edit" && typeof input.old_string === "string") {
+if (tool === 'Edit' && typeof input.old_string === 'string') {
   files.set(relPath, input.old_string);
 } else {
   // Don't overwrite if already seeded with Edit content
   if (!files.has(relPath)) {
-    files.set(relPath, "// stub\n");
+    files.set(relPath, '// stub\n');
   }
 }
 ```
@@ -544,6 +588,7 @@ If multiple edits target the same file with different `old_string` values, conca
 ### 5.4 Write `scripts/test-scaffold.ts`
 
 Test script that:
+
 1. Loads a real dataset session (e.g., `session-001`)
 2. Creates a temp directory (not a real worktree — just for scaffold testing)
 3. Calls `buildScaffoldPlan()` and `applyScaffold()`
@@ -561,9 +606,9 @@ Provide a clean API for loading and querying the dataset. This is used by both t
 ### 6.1 Create `src/main/dataset-loader.ts`
 
 ```typescript
-import { createReadStream } from "node:fs";
-import { createInterface } from "node:readline";
-import type { ReplayToolCall } from "./types.js";
+import { createReadStream } from 'node:fs';
+import { createInterface } from 'node:readline';
+import type { ReplayToolCall } from './types.js';
 
 interface DatasetRecord {
   id: number;
@@ -582,16 +627,16 @@ interface DatasetRecord {
  * Load the dataset and group records by session.
  * Returns a Map from session ID to sorted tool-call array.
  */
-export async function loadDataset(
-  datasetPath: string,
-): Promise<Map<string, ReplayToolCall[]>>;
+export async function loadDataset(datasetPath: string): Promise<Map<string, ReplayToolCall[]>>;
 
 /**
  * Get summary statistics for the loaded dataset.
  */
-export function datasetSummary(
-  sessions: Map<string, ReplayToolCall[]>,
-): { sessionCount: number; recordCount: number; toolDistribution: Record<string, number> };
+export function datasetSummary(sessions: Map<string, ReplayToolCall[]>): {
+  sessionCount: number;
+  recordCount: number;
+  toolDistribution: Record<string, number>;
+};
 ```
 
 **Record → ReplayToolCall mapping**:
@@ -737,15 +782,15 @@ function buildReport(
   sessionResults: SessionReplayResult[],
   datasetPath: string,
 ): ReplayReport {
-  const allResults = sessionResults.flatMap(s => s.results);
-  const allowed = allResults.filter(r => r.replay_outcome === "allowed").length;
-  const blocked = allResults.filter(r => r.replay_outcome === "blocked").length;
-  const skipped = allResults.filter(r => r.replay_outcome === "skipped").length;
-  const error = allResults.filter(r => r.replay_outcome === "error").length;
+  const allResults = sessionResults.flatMap((s) => s.results);
+  const allowed = allResults.filter((r) => r.replay_outcome === 'allowed').length;
+  const blocked = allResults.filter((r) => r.replay_outcome === 'blocked').length;
+  const skipped = allResults.filter((r) => r.replay_outcome === 'skipped').length;
+  const error = allResults.filter((r) => r.replay_outcome === 'error').length;
 
   // False blocks: sandbox blocked something that was approved in the original session
   const falseBlocks = allResults.filter(
-    r => r.replay_outcome === "blocked" && r.original_outcome === "approved"
+    (r) => r.replay_outcome === 'blocked' && r.original_outcome === 'approved',
   ).length;
   const actionable = allowed + blocked; // excluding skipped and error
 
@@ -755,8 +800,8 @@ function buildReport(
       dataset: datasetPath,
       policyId,
       sessionsTotal: sessionResults.length,
-      sessionsCompleted: sessionResults.filter(s => s.results.length > 0).length,
-      sessionsFailed: sessionResults.filter(s => s.results.length === 0).length,
+      sessionsCompleted: sessionResults.filter((s) => s.results.length > 0).length,
+      sessionsFailed: sessionResults.filter((s) => s.results.length === 0).length,
     },
     summary: {
       totalToolCalls: allResults.length,
@@ -765,9 +810,7 @@ function buildReport(
       skipped,
       error,
       allowedRate: actionable > 0 ? allowed / actionable : 1,
-      falseBlockRate: (allowed + falseBlocks) > 0
-        ? falseBlocks / (allowed + falseBlocks)
-        : 0,
+      falseBlockRate: allowed + falseBlocks > 0 ? falseBlocks / (allowed + falseBlocks) : 0,
     },
     byTool: computeByToolBreakdown(allResults),
     sessions: sessionResults,
@@ -787,6 +830,7 @@ npx tsx scripts/replay-test.ts \
 ```
 
 Verify the report:
+
 - Every tool call has a `replay_outcome`
 - `skipped` for TodoWrite, WebSearch, MCP tools
 - `allowed` or `error` for Read, Edit, Bash (no sandbox blocks expected for in-worktree operations)
@@ -825,7 +869,7 @@ async function replayBatch(
         process.stderr.write(`  FAILED: ${(err as Error).message}\n`);
         results.push({
           sessionId,
-          project: toolCalls[0]?.project ?? "unknown",
+          project: toolCalls[0]?.project ?? 'unknown',
           toolCallCount: toolCalls.length,
           results: [],
           scaffoldedFiles: 0,
@@ -887,6 +931,7 @@ npx tsx scripts/replay-test.ts \
 ```
 
 This is the first real validation run. Review the report for:
+
 - Are the numbers plausible?
 - Which tools have the most blocks?
 - Are blocks real (sandbox enforcement) or noise (missing files, command failures)?
@@ -914,6 +959,7 @@ npx tsx scripts/replay-test.ts \
 ### 9.2 Analyze results
 
 For each policy, examine:
+
 - **Allowed rate**: What fraction of real-world operations does the policy permit?
 - **False-block rate**: Among operations that were approved in the original session, what fraction does the policy block?
 - **Per-tool breakdown**: Which tools are most affected?
@@ -923,18 +969,19 @@ For each policy, examine:
 
 For blocked operations, categorize:
 
-| Category | Description | Example |
-|----------|-------------|---------|
-| **Sandbox enforcement** | Real sandbox block (EPERM on restricted path) | Read `/etc/passwd`, write to `{home}/...` |
-| **Missing-file noise** | File doesn't exist in scaffold (ENOENT counted as error, not block) | Bash `cat` on unscaffolded file |
-| **Network gap** | Operation needs network but network isn't enforced yet | `git push`, `npm install`, `curl` |
-| **Temp-dir gap** | Operation writes to temp which safehouse allows broadly | Write to `/tmp/...` |
+| Category                | Description                                                         | Example                                   |
+| ----------------------- | ------------------------------------------------------------------- | ----------------------------------------- |
+| **Sandbox enforcement** | Real sandbox block (EPERM on restricted path)                       | Read `/etc/passwd`, write to `{home}/...` |
+| **Missing-file noise**  | File doesn't exist in scaffold (ENOENT counted as error, not block) | Bash `cat` on unscaffolded file           |
+| **Network gap**         | Operation needs network but network isn't enforced yet              | `git push`, `npm install`, `curl`         |
+| **Temp-dir gap**        | Operation writes to temp which safehouse allows broadly             | Write to `/tmp/...`                       |
 
 This categorization directly informs M5 and M6 priorities.
 
 ### 9.4 Document findings
 
 Create `docs/milestones/deterministic-test-agent/findings.md` with:
+
 - Summary table: policy × metric (allowed rate, false-block rate)
 - Per-tool heatmap (text table)
 - Block categorization breakdown
@@ -954,7 +1001,7 @@ Add the replay agent as a selectable option in the Glitter Ball UI.
 Add an agent type selector above the policy selector. Three options: Claude Code (default), Echo (dev), Replay.
 
 ```tsx
-const [agentType, setAgentType] = useState<'claude-code' | 'echo' | 'replay'>('claude-code')
+const [agentType, setAgentType] = useState<'claude-code' | 'echo' | 'replay'>('claude-code');
 ```
 
 Add a section to the dialog:
@@ -975,18 +1022,20 @@ Add a section to the dialog:
 When `agentType === "replay"`, show a text input for the dataset session ID to replay:
 
 ```tsx
-{agentType === 'replay' && (
-  <div style={sectionStyle}>
-    <label style={labelStyle}>Dataset Session ID</label>
-    <input
-      type="text"
-      placeholder="e.g., session-042"
-      value={replaySessionId}
-      onChange={(e) => setReplaySessionId(e.target.value)}
-      style={textInputStyle}
-    />
-  </div>
-)}
+{
+  agentType === 'replay' && (
+    <div style={sectionStyle}>
+      <label style={labelStyle}>Dataset Session ID</label>
+      <input
+        type="text"
+        placeholder="e.g., session-042"
+        value={replaySessionId}
+        onChange={(e) => setReplaySessionId(e.target.value)}
+        style={textInputStyle}
+      />
+    </div>
+  );
+}
 ```
 
 The policy selector should still be shown for replay (the user picks which policy to test).
@@ -1025,6 +1074,7 @@ async function handleCreate() {
 Add a new IPC call for loading replay data:
 
 **`src/preload/index.ts`**:
+
 ```typescript
 sessions: {
   // ... existing ...
@@ -1034,6 +1084,7 @@ sessions: {
 ```
 
 **`src/main/index.ts`**:
+
 ```typescript
 ipcMain.handle('sessions:loadReplayData', async (_e, datasetSessionId: unknown) => {
   if (typeof datasetSessionId !== 'string') {

--- a/docs/history/electron-acp-hello-world/design.md
+++ b/docs/history/electron-acp-hello-world/design.md
@@ -93,26 +93,28 @@ Validate the Electron + ACP plumbing end-to-end: a user types a message in the U
 A standalone Node.js script that speaks ACP on the agent side. This is our test double for Claude Code in later milestones.
 
 **Responsibilities:**
+
 - Create an `AgentSideConnection` from `@agentclientprotocol/sdk`
 - Handle `InitializeRequest`: return capabilities (name, version, supported features)
 - Handle `NewSessionRequest`: create a session, return session ID
 - Handle `PromptRequest`: extract the user's message text, stream it back as a `SessionNotification` containing `TextContent`, then send `PromptResponse` with `StopReason.EndTurn`
 
 **Behavior:**
+
 - Echoes the user's message prefixed with `Echo: `
 - Streams the response in small chunks (simulating token-by-token streaming) with short delays between chunks, so we can validate the streaming UI
 - Logs lifecycle events to stderr
 
 ```typescript
 // Pseudocode for the echo agent
-import { AgentSideConnection, StopReason } from "@agentclientprotocol/sdk";
+import { AgentSideConnection, StopReason } from '@agentclientprotocol/sdk';
 
 const connection = new AgentSideConnection(process.stdin, process.stdout);
 
 connection.onInitialize(async (params) => {
   return {
-    name: "glitterball-echo-agent",
-    version: "0.1.0",
+    name: 'glitterball-echo-agent',
+    version: '0.1.0',
     // ... capabilities
   };
 });
@@ -127,7 +129,7 @@ connection.onPrompt(async (params, { sendUpdate, signal }) => {
 
   // Stream in chunks to exercise the streaming path
   for (const chunk of chunkString(reply, 10)) {
-    sendUpdate({ type: "text", text: chunk });
+    sendUpdate({ type: 'text', text: chunk });
     await delay(50);
   }
 
@@ -144,22 +146,25 @@ connection.listen();
 Runs in the Electron main process. Manages session lifecycle and ACP connections.
 
 **State per session:**
+
 ```typescript
 interface SessionState {
   id: string;
   agentProcess: ChildProcess;
   connection: ClientSideConnection;
-  messages: Message[];       // in-memory history for the UI
-  status: "initializing" | "ready" | "error" | "closed";
+  messages: Message[]; // in-memory history for the UI
+  status: 'initializing' | 'ready' | 'error' | 'closed';
 }
 ```
 
 **Lifecycle:**
+
 1. **Create session**: Spawn echo agent as child process → create `ClientSideConnection` over its stdio → send `InitializeRequest` → send `NewSessionRequest` → mark session `ready`
 2. **Send message**: Send `PromptRequest` with user text → listen for `SessionNotification` updates → accumulate into message history → forward to renderer via IPC
 3. **Close session**: Send cancel if a turn is in progress → kill child process → clean up state
 
 **Error handling:**
+
 - If the agent process exits unexpectedly, mark the session as `error` and surface it in the UI
 - If `InitializeRequest` fails or times out (~5s), mark session as `error`
 
@@ -180,13 +185,13 @@ interface GlitterballAPI {
 
 interface SessionSummary {
   id: string;
-  status: "initializing" | "ready" | "error" | "closed";
+  status: 'initializing' | 'ready' | 'error' | 'closed';
   messageCount: number;
 }
 
 interface SessionUpdate {
   sessionId: string;
-  type: "message" | "status-change" | "stream-chunk";
+  type: 'message' | 'status-change' | 'stream-chunk';
   // ... payload varies by type
 }
 ```
@@ -215,12 +220,12 @@ Minimal two-panel layout. No routing library, no state management library — ju
 
 ### Dependencies
 
-| Package | Purpose |
-|---------|---------|
-| `electron` | App shell |
-| `@agentclientprotocol/sdk` | ACP client + agent connections |
-| `react`, `react-dom` | UI |
-| `typescript` | Type safety throughout |
+| Package                             | Purpose                                                |
+| ----------------------------------- | ------------------------------------------------------ |
+| `electron`                          | App shell                                              |
+| `@agentclientprotocol/sdk`          | ACP client + agent connections                         |
+| `react`, `react-dom`                | UI                                                     |
+| `typescript`                        | Type safety throughout                                 |
 | `electron-forge` or `electron-vite` | Build tooling (bundling, dev server, HMR for renderer) |
 
 **Build tooling choice:** `electron-vite` is the lighter option — it uses Vite for the renderer (fast HMR) and esbuild/Vite for main/preload. `electron-forge` is more opinionated and heavier. Recommend **`electron-vite`** for this spike given the preference for fast iteration.
@@ -257,6 +262,7 @@ bouncer/
 ### TypeScript Configuration
 
 Three tsconfig files (standard electron-vite pattern):
+
 - `tsconfig.json` — base config with shared compiler options
 - `tsconfig.main.json` — extends base, targets Node (main + preload + agents)
 - `tsconfig.renderer.json` — extends base, targets DOM (React)

--- a/docs/history/electron-acp-hello-world/plan.md
+++ b/docs/history/electron-acp-hello-world/plan.md
@@ -116,14 +116,11 @@ Build the echo agent as a standalone Node script before touching any Electron co
 This script will be run as a child process — it reads JSON-RPC from stdin and writes to stdout.
 
 ```typescript
-import * as acp from "@agentclientprotocol/sdk";
-import { Writable, Readable } from "node:stream";
+import * as acp from '@agentclientprotocol/sdk';
+import { Writable, Readable } from 'node:stream';
 
 // Create the ndJson stream over stdio
-const stream = acp.ndJsonStream(
-  Writable.toWeb(process.stdout),
-  Readable.toWeb(process.stdin)
-);
+const stream = acp.ndJsonStream(Writable.toWeb(process.stdout), Readable.toWeb(process.stdin));
 
 // Create the agent-side connection
 new acp.AgentSideConnection(
@@ -131,7 +128,7 @@ new acp.AgentSideConnection(
     async initialize(params) {
       return {
         protocolVersion: acp.PROTOCOL_VERSION,
-        agentInfo: { name: "glitterball-echo-agent", version: "0.1.0" },
+        agentInfo: { name: 'glitterball-echo-agent', version: '0.1.0' },
         agentCapabilities: { streaming: true },
       };
     },
@@ -145,9 +142,9 @@ new acp.AgentSideConnection(
     async prompt(params) {
       // Extract text from the prompt content blocks
       const userText = params.prompt
-        .filter((block): block is acp.TextContent => block.type === "text")
+        .filter((block): block is acp.TextContent => block.type === 'text')
         .map((block) => block.text)
-        .join("");
+        .join('');
 
       const reply = `Echo: ${userText}`;
 
@@ -157,17 +154,17 @@ new acp.AgentSideConnection(
         const chunk = reply.slice(i, i + chunkSize);
         await connection.sessionUpdate({
           sessionId: params.sessionId,
-          update: { type: "agent_message_chunk", text: chunk },
+          update: { type: 'agent_message_chunk', text: chunk },
         });
         await new Promise((r) => setTimeout(r, 50));
       }
 
-      return { stopReason: "end_turn" };
+      return { stopReason: 'end_turn' };
     },
 
     // Stubs for required interface methods
     async loadSession(params) {
-      throw new Error("Not implemented");
+      throw new Error('Not implemented');
     },
     async authenticate(params) {
       return {};
@@ -179,10 +176,10 @@ new acp.AgentSideConnection(
       return {};
     },
   }),
-  stream
+  stream,
 );
 
-process.stderr.write("Echo agent started\n");
+process.stderr.write('Echo agent started\n');
 ```
 
 > **Important:** The exact API may differ from the above. The `Agent` interface returned from the `AgentSideConnection` callback may have additional required methods, or the types may be slightly different. Adapt based on what TypeScript reports. The critical discovery questions are:
@@ -200,12 +197,14 @@ process.stderr.write("Echo agent started\n");
 Options:
 
 **Option A (recommended for dev): Run directly with tsx**
+
 ```bash
 npx tsx electron/agents/echo-agent.ts
 ```
 
 **Option B: Build with esbuild**
 Add to `package.json`:
+
 ```json
 {
   "scripts": {
@@ -233,61 +232,75 @@ If the agent doesn't handle single-shot stdin well (it likely expects a long-liv
 
 ```typescript
 // scripts/test-echo-agent.ts
-import { spawn } from "node:child_process";
-import * as acp from "@agentclientprotocol/sdk";
-import { Writable, Readable } from "node:stream";
+import { spawn } from 'node:child_process';
+import * as acp from '@agentclientprotocol/sdk';
+import { Writable, Readable } from 'node:stream';
 
-const agent = spawn("npx", ["tsx", "electron/agents/echo-agent.ts"], {
-  stdio: ["pipe", "pipe", "inherit"],
+const agent = spawn('npx', ['tsx', 'electron/agents/echo-agent.ts'], {
+  stdio: ['pipe', 'pipe', 'inherit'],
 });
 
-const stream = acp.ndJsonStream(
-  Writable.toWeb(agent.stdin),
-  Readable.toWeb(agent.stdout)
-);
+const stream = acp.ndJsonStream(Writable.toWeb(agent.stdin), Readable.toWeb(agent.stdout));
 
 const connection = new acp.ClientSideConnection(
   (agentInterface) => ({
     async sessionUpdate(params) {
-      console.log("Stream update:", JSON.stringify(params.update));
+      console.log('Stream update:', JSON.stringify(params.update));
     },
     // Stub other Client methods...
-    async readTextFile(params) { throw new Error("Not implemented"); },
-    async writeTextFile(params) { throw new Error("Not implemented"); },
-    async requestPermission(params) { throw new Error("Not implemented"); },
-    async createTerminal(params) { throw new Error("Not implemented"); },
-    async terminalOutput(params) { throw new Error("Not implemented"); },
-    async killTerminal(params) { throw new Error("Not implemented"); },
-    async waitForTerminalExit(params) { throw new Error("Not implemented"); },
-    async releaseTerminal(params) { throw new Error("Not implemented"); },
+    async readTextFile(params) {
+      throw new Error('Not implemented');
+    },
+    async writeTextFile(params) {
+      throw new Error('Not implemented');
+    },
+    async requestPermission(params) {
+      throw new Error('Not implemented');
+    },
+    async createTerminal(params) {
+      throw new Error('Not implemented');
+    },
+    async terminalOutput(params) {
+      throw new Error('Not implemented');
+    },
+    async killTerminal(params) {
+      throw new Error('Not implemented');
+    },
+    async waitForTerminalExit(params) {
+      throw new Error('Not implemented');
+    },
+    async releaseTerminal(params) {
+      throw new Error('Not implemented');
+    },
   }),
-  stream
+  stream,
 );
 
 // Drive the protocol
 const initResp = await connection.initialize({
   protocolVersion: acp.PROTOCOL_VERSION,
-  clientInfo: { name: "test-harness", version: "0.1.0" },
+  clientInfo: { name: 'test-harness', version: '0.1.0' },
   clientCapabilities: {},
 });
-console.log("Initialized:", initResp);
+console.log('Initialized:', initResp);
 
 const sessionResp = await connection.newSession({
   cwd: process.cwd(),
   mcpServers: [],
 });
-console.log("Session:", sessionResp.sessionId);
+console.log('Session:', sessionResp.sessionId);
 
 const promptResp = await connection.prompt({
   sessionId: sessionResp.sessionId,
-  prompt: [{ type: "text", text: "Hello world" }],
+  prompt: [{ type: 'text', text: 'Hello world' }],
 });
-console.log("Prompt done:", promptResp);
+console.log('Prompt done:', promptResp);
 
 agent.kill();
 ```
 
 Run with:
+
 ```bash
 npx tsx scripts/test-echo-agent.ts
 ```
@@ -314,7 +327,7 @@ npx tsx scripts/test-echo-agent.ts
 ```typescript
 export interface Message {
   id: string;
-  role: "user" | "agent";
+  role: 'user' | 'agent';
   text: string;
   timestamp: number;
   streaming?: boolean; // true while agent is still sending chunks
@@ -322,15 +335,15 @@ export interface Message {
 
 export interface SessionSummary {
   id: string;
-  status: "initializing" | "ready" | "error" | "closed";
+  status: 'initializing' | 'ready' | 'error' | 'closed';
   messageCount: number;
 }
 
 export type SessionUpdate =
-  | { sessionId: string; type: "status-change"; status: SessionSummary["status"] }
-  | { sessionId: string; type: "message"; message: Message }
-  | { sessionId: string; type: "stream-chunk"; messageId: string; text: string }
-  | { sessionId: string; type: "stream-end"; messageId: string };
+  | { sessionId: string; type: 'status-change'; status: SessionSummary['status'] }
+  | { sessionId: string; type: 'message'; message: Message }
+  | { sessionId: string; type: 'stream-chunk'; messageId: string; text: string }
+  | { sessionId: string; type: 'stream-end'; messageId: string };
 ```
 
 ### 3.2 Implement `SessionManager.createSession()`
@@ -343,21 +356,22 @@ export type SessionUpdate =
 - [x] Listen for `exit`/`error` on child process → mark session `error`
 
 ```typescript
-import { spawn, ChildProcess } from "node:child_process";
-import { Writable, Readable } from "node:stream";
-import * as acp from "@agentclientprotocol/sdk";
+import { spawn, ChildProcess } from 'node:child_process';
+import { Writable, Readable } from 'node:stream';
+import * as acp from '@agentclientprotocol/sdk';
 
 interface SessionState {
   id: string;
-  acpSessionId: string;  // the session ID returned by the agent
+  acpSessionId: string; // the session ID returned by the agent
   agentProcess: ChildProcess;
   connection: acp.ClientSideConnection;
   messages: Message[];
-  status: "initializing" | "ready" | "error" | "closed";
+  status: 'initializing' | 'ready' | 'error' | 'closed';
 }
 ```
 
 **`createSession()` flow:**
+
 1. Generate a local session ID (`crypto.randomUUID()`)
 2. Spawn the echo agent: `spawn("npx", ["tsx", "electron/agents/echo-agent.ts"], { stdio: ["pipe", "pipe", "inherit"] })`
    - In production builds, spawn `node dist-electron/agents/echo-agent.js` instead
@@ -378,6 +392,7 @@ interface SessionState {
 - [x] On prompt completion, finalize agent message and emit `stream-end`
 
 **`sendMessage()` flow:**
+
 1. Look up session, verify status is `ready`
 2. Create a user `Message`, push to `messages[]`, emit IPC event
 3. Create an agent `Message` (empty, `streaming: true`), push to `messages[]`, emit IPC event
@@ -414,20 +429,19 @@ class SessionManager {
 - [x] Update `src/preload/index.ts` with `contextBridge.exposeInMainWorld`
 
 ```typescript
-import { contextBridge, ipcRenderer } from "electron";
+import { contextBridge, ipcRenderer } from 'electron';
 
-contextBridge.exposeInMainWorld("glitterball", {
+contextBridge.exposeInMainWorld('glitterball', {
   sessions: {
-    list: () => ipcRenderer.invoke("sessions:list"),
-    create: () => ipcRenderer.invoke("sessions:create"),
+    list: () => ipcRenderer.invoke('sessions:list'),
+    create: () => ipcRenderer.invoke('sessions:create'),
     sendMessage: (sessionId: string, text: string) =>
-      ipcRenderer.invoke("sessions:sendMessage", sessionId, text),
-    closeSession: (sessionId: string) =>
-      ipcRenderer.invoke("sessions:close", sessionId),
+      ipcRenderer.invoke('sessions:sendMessage', sessionId, text),
+    closeSession: (sessionId: string) => ipcRenderer.invoke('sessions:close', sessionId),
     onUpdate: (callback: (update: any) => void) => {
       const handler = (_event: any, update: any) => callback(update);
-      ipcRenderer.on("session-update", handler);
-      return () => ipcRenderer.removeListener("session-update", handler);
+      ipcRenderer.on('session-update', handler);
+      return () => ipcRenderer.removeListener('session-update', handler);
     },
   },
 });
@@ -440,11 +454,13 @@ contextBridge.exposeInMainWorld("glitterball", {
 ```typescript
 interface GlitterballAPI {
   sessions: {
-    list(): Promise<import("../electron/main/types").SessionSummary[]>;
-    create(): Promise<import("../electron/main/types").SessionSummary>;
+    list(): Promise<import('../electron/main/types').SessionSummary[]>;
+    create(): Promise<import('../electron/main/types').SessionSummary>;
     sendMessage(sessionId: string, text: string): Promise<void>;
     closeSession(sessionId: string): Promise<void>;
-    onUpdate(callback: (update: import("../electron/main/types").SessionUpdate) => void): () => void;
+    onUpdate(
+      callback: (update: import('../electron/main/types').SessionUpdate) => void,
+    ): () => void;
   };
 }
 
@@ -458,20 +474,18 @@ interface Window {
 - [x] Register `ipcMain.handle` handlers that delegate to `SessionManager`
 
 ```typescript
-import { ipcMain } from "electron";
+import { ipcMain } from 'electron';
 
 const sessionManager = new SessionManager((channel, data) => {
   mainWindow.webContents.send(channel, data);
 });
 
-ipcMain.handle("sessions:list", () => sessionManager.listSessions());
-ipcMain.handle("sessions:create", () => sessionManager.createSession());
-ipcMain.handle("sessions:sendMessage", (_e, sessionId, text) =>
-  sessionManager.sendMessage(sessionId, text)
+ipcMain.handle('sessions:list', () => sessionManager.listSessions());
+ipcMain.handle('sessions:create', () => sessionManager.createSession());
+ipcMain.handle('sessions:sendMessage', (_e, sessionId, text) =>
+  sessionManager.sendMessage(sessionId, text),
 );
-ipcMain.handle("sessions:close", (_e, sessionId) =>
-  sessionManager.closeSession(sessionId)
-);
+ipcMain.handle('sessions:close', (_e, sessionId) => sessionManager.closeSession(sessionId));
 ```
 
 ### 4.4 Verify from renderer
@@ -559,17 +573,17 @@ interface Props {
 ```typescript
 function handleUpdate(update: SessionUpdate) {
   switch (update.type) {
-    case "status-change":
+    case 'status-change':
       // Update session status in sessions[]
       break;
-    case "message":
+    case 'message':
       // Append to messagesBySession
       break;
-    case "stream-chunk":
+    case 'stream-chunk':
       // Append text to streamingText[messageId]
       // This triggers re-render of the streaming message
       break;
-    case "stream-end":
+    case 'stream-end':
       // Finalize the message text, remove from streamingText
       // Mark the Message as streaming: false
       break;
@@ -642,13 +656,13 @@ Run through this manually before considering M0 complete:
 
 ## Sequencing Summary
 
-| Phase | Description | Depends On | Key Risk |
-|------|-------------|------------|----------|
-| 1 | Project scaffolding | — | electron-vite conflicts with existing files |
-| 2 | Echo agent | Phase 1 (for deps) | ACP SDK API surface unknowns |
-| 3 | Session manager | Phase 2 | Stdio transport in Electron main process |
-| 4 | IPC bridge | Phase 3 | contextBridge typing ceremony |
-| 5 | React UI | Phase 4 | Streaming state management |
-| 6 | Edge cases | Phase 5 | Agent lifecycle edge cases |
+| Phase | Description         | Depends On         | Key Risk                                    |
+| ----- | ------------------- | ------------------ | ------------------------------------------- |
+| 1     | Project scaffolding | —                  | electron-vite conflicts with existing files |
+| 2     | Echo agent          | Phase 1 (for deps) | ACP SDK API surface unknowns                |
+| 3     | Session manager     | Phase 2            | Stdio transport in Electron main process    |
+| 4     | IPC bridge          | Phase 3            | contextBridge typing ceremony               |
+| 5     | React UI            | Phase 4            | Streaming state management                  |
+| 6     | Edge cases          | Phase 5            | Agent lifecycle edge cases                  |
 
 The **highest-risk phase is 2** (echo agent) because it's our first real contact with the ACP SDK. Everything after that builds incrementally on known foundations. If Phase 2 reveals that the SDK works differently than documented, update the design doc before proceeding.

--- a/docs/history/initial-research/goals.md
+++ b/docs/history/initial-research/goals.md
@@ -2,11 +2,11 @@
 
 ## Project Vision
 
-Our goal for the "Bouncer" project is to experiment with *some amount* of automation for permission requests in coding agents: in other words, a **policy bot** for enabling safe but convenient workflows with coding agents.
+Our goal for the "Bouncer" project is to experiment with _some amount_ of automation for permission requests in coding agents: in other words, a **policy bot** for enabling safe but convenient workflows with coding agents.
 
-The *ideal* would be to identify classes of common coding use cases where the policy bot can automate away 100% of the need for human permission requests with 0% false negatives (i.e., cases where the policy bot allows the coding agent to do an operation that turns out to have been unsafe). But this may not be an achievable goal.
+The _ideal_ would be to identify classes of common coding use cases where the policy bot can automate away 100% of the need for human permission requests with 0% false negatives (i.e., cases where the policy bot allows the coding agent to do an operation that turns out to have been unsafe). But this may not be an achievable goal.
 
-A *good result* would be one where we can implement a policy automation that automates away *some* permission requests with 0% false nmegatives.
+A _good result_ would be one where we can implement a policy automation that automates away _some_ permission requests with 0% false nmegatives.
 
 In other words, our **top priority** is safety; our **secondary priority** is automating unnecessary permission requests.
 
@@ -16,7 +16,7 @@ The following principles should guide our experiments:
 
 **Sandboxing is useless without policy**: There are many sandboxing technologies that can be used to provide strong guarantees about what an agent does and doesn't have access to, both low-level (containers, hypervisors, network proxies, etc) as well as a new crop of agent sandboxing technologies that have been in the news. But to some degree "sandboxing" as a solution for agent automation simply begs the question. The hardest part of the problem is defining the model of safety: what constitutes unsafe/unacceptable agent behavior? In other words, we need to identify useful policies.
 
-**There is low-hanging fruit everywhere**: There may be some brilliant "theory of everything" that gets us to the ideal outcome, and maybe we won't be the ones to find it. But that doesn't mean we can't make things better. The perfect is the enemy of progress. If we can identify *some* safe patterns and automate them, we can build a tool that make semi-autonomous (human-in-the-loop) agent experiences much more efficient, even if we can't get them to fully autonomous. And the default experience of most coding agents is that agents are extremely conservative and repetitive about asking the user's permission. There is a lot we can do to make this better without losing safety.
+**There is low-hanging fruit everywhere**: There may be some brilliant "theory of everything" that gets us to the ideal outcome, and maybe we won't be the ones to find it. But that doesn't mean we can't make things better. The perfect is the enemy of progress. If we can identify _some_ safe patterns and automate them, we can build a tool that make semi-autonomous (human-in-the-loop) agent experiences much more efficient, even if we can't get them to fully autonomous. And the default experience of most coding agents is that agents are extremely conservative and repetitive about asking the user's permission. There is a lot we can do to make this better without losing safety.
 
 **Both deterministic and non-deterministic solutions are on the table**: Using an LLM as a judge for safety policies sounds a little scary, but if it can be constrained enough to be predictable, an LLM may be more adaptable to minor but benign syntactic variations in tool use requests than deterministic policy specifications, which may end up being too rigid and brittle to handle the natural variations in real-world tool use. We should be willing to explore both deterministic and non-deterministic heuristics, and hybrid solutions as well.
 

--- a/docs/history/initial-research/pr-0-dataset-extraction.md
+++ b/docs/history/initial-research/pr-0-dataset-extraction.md
@@ -15,18 +15,18 @@ Produce a clean, anonymized, minimal dataset of tool use requests and their outc
 
 For each tool use in the session history, we need one record:
 
-| Field | Source | Description |
-|-------|--------|-------------|
-| `id` | Synthetic | Sequential integer, stable ordering |
-| `tool` | `tool_use.name` | Tool name (Read, Bash, Edit, etc.) |
-| `input` | `tool_use.input` | Tool input parameters (scrubbed) |
-| `outcome` | Derived | `approved`, `rejected`, or `error` |
-| `error_type` | Derived | For errors: `user_rejected` or `system_error` |
-| `project` | Derived | Anonymized project identifier (e.g., `project-01`) |
-| `session` | Derived | Anonymized session identifier (e.g., `session-042`) |
-| `is_subagent` | `isSidechain` / filename | Whether this occurred in a subagent |
-| `permission_mode` | `permissionMode` | The active permission mode at time of request |
-| `timestamp_relative` | Derived | Seconds since start of session (not wall-clock time) |
+| Field                | Source                   | Description                                          |
+| -------------------- | ------------------------ | ---------------------------------------------------- |
+| `id`                 | Synthetic                | Sequential integer, stable ordering                  |
+| `tool`               | `tool_use.name`          | Tool name (Read, Bash, Edit, etc.)                   |
+| `input`              | `tool_use.input`         | Tool input parameters (scrubbed)                     |
+| `outcome`            | Derived                  | `approved`, `rejected`, or `error`                   |
+| `error_type`         | Derived                  | For errors: `user_rejected` or `system_error`        |
+| `project`            | Derived                  | Anonymized project identifier (e.g., `project-01`)   |
+| `session`            | Derived                  | Anonymized session identifier (e.g., `session-042`)  |
+| `is_subagent`        | `isSidechain` / filename | Whether this occurred in a subagent                  |
+| `permission_mode`    | `permissionMode`         | The active permission mode at time of request        |
+| `timestamp_relative` | Derived                  | Seconds since start of session (not wall-clock time) |
 
 ### Fields Intentionally Excluded
 
@@ -43,16 +43,17 @@ For each tool use in the session history, we need one record:
 
 All file paths are transformed:
 
-| Raw Path | Anonymized |
-|----------|------------|
-| `/Users/dherman/Code/thinkwell/src/index.ts` | `{project}/src/index.ts` |
-| `/Users/dherman/Code/cadmus/packages/server/src/db.ts` | `{project}/packages/server/src/db.ts` |
-| `/Users/dherman/.claude/settings.json` | `{home}/.claude/settings.json` |
-| `/Users/dherman/.zshrc` | `{home}/.zshrc` |
-| `/etc/hosts` | `/etc/hosts` (system paths left as-is) |
-| `/tmp/foo` | `/tmp/foo` (temp paths left as-is) |
+| Raw Path                                               | Anonymized                             |
+| ------------------------------------------------------ | -------------------------------------- |
+| `/Users/dherman/Code/thinkwell/src/index.ts`           | `{project}/src/index.ts`               |
+| `/Users/dherman/Code/cadmus/packages/server/src/db.ts` | `{project}/packages/server/src/db.ts`  |
+| `/Users/dherman/.claude/settings.json`                 | `{home}/.claude/settings.json`         |
+| `/Users/dherman/.zshrc`                                | `{home}/.zshrc`                        |
+| `/etc/hosts`                                           | `/etc/hosts` (system paths left as-is) |
+| `/tmp/foo`                                             | `/tmp/foo` (temp paths left as-is)     |
 
 Rules:
+
 1. Replace the user's home directory prefix with `{home}`
 2. Replace the project directory prefix with `{project}` (the project directory is derived from the session's project path)
 3. Leave system paths (`/etc`, `/usr`, `/tmp`, `/var`) unchanged
@@ -62,12 +63,12 @@ Rules:
 
 Each unique project directory maps to a stable anonymous name:
 
-| Raw Project | Anonymous ID |
-|-------------|-------------|
+| Raw Project                     | Anonymous ID |
+| ------------------------------- | ------------ |
 | `/Users/dherman/Code/thinkwell` | `project-01` |
-| `/Users/dherman/Code/cadmus` | `project-02` |
-| `/Users/dherman/Code/bouncer` | `project-03` |
-| ... | `project-NN` |
+| `/Users/dherman/Code/cadmus`    | `project-02` |
+| `/Users/dherman/Code/bouncer`   | `project-03` |
+| ...                             | `project-NN` |
 
 Assignment order: sorted alphabetically by original path, then numbered sequentially. This ensures stable IDs across re-extractions.
 
@@ -75,11 +76,11 @@ Assignment order: sorted alphabetically by original path, then numbered sequenti
 
 Each unique session UUID maps to a sequential ID:
 
-| Raw Session | Anonymous ID |
-|-------------|-------------|
+| Raw Session                            | Anonymous ID  |
+| -------------------------------------- | ------------- |
 | `0805e6a3-f2d9-4df8-a0eb-2970477c3c34` | `session-001` |
 | `6133ee45-5d2c-4803-aff2-5e4ff1890450` | `session-002` |
-| ... | `session-NNN` |
+| ...                                    | `session-NNN` |
 
 Assignment order: sorted by first-seen timestamp.
 
@@ -96,6 +97,7 @@ Bash commands need special handling because they contain arbitrary text:
 ### Other String Scrubbing
 
 For non-Bash tool inputs:
+
 - **Edit `old_string` / `new_string`**: Keep the code content (it's the thing we're classifying), but apply path scrubbing within it
 - **Write `content`**: Replace entirely with `{file_content}` (we don't need file contents for policy research)
 - **Grep `pattern`**: Keep as-is (search patterns are not PII)
@@ -164,12 +166,14 @@ Metadata about the extraction:
 ### Task 1: Build the Extraction Script
 
 Write `scripts/extract-dataset.py` that:
+
 1. Walks `~/.claude/projects/` to find all `.jsonl` session files
 2. Parses each file, correlating tool_use with tool_result messages
 3. Applies anonymization rules
 4. Outputs `data/tool-use-dataset.jsonl` and `data/dataset-summary.json`
 
 The script should:
+
 - Be idempotent (safe to re-run)
 - Accept `--source-dir` argument (default: `~/.claude/projects`)
 - Accept `--output-dir` argument (default: `./data`)
@@ -195,6 +199,7 @@ The script should:
 ### Task 3: Validate Dataset Completeness
 
 Compare extraction stats against the raw data analysis we already did:
+
 - Total tool uses should be ~7,188
 - Bash count should be ~2,460
 - Rejection count should be ~13
@@ -205,6 +210,7 @@ Any significant discrepancies indicate a parsing bug.
 ### Task 4: Update PR 1 and PR 2 Plans
 
 Once the dataset exists, update both PR plans to:
+
 - Reference `data/tool-use-dataset.jsonl` instead of raw session data
 - Remove inline extraction scripts (they're now redundant)
 - Add filtering commands for their specific needs, e.g.:

--- a/docs/history/initial-research/pr-1-read-only-auto-approval.md
+++ b/docs/history/initial-research/pr-1-read-only-auto-approval.md
@@ -8,13 +8,13 @@ Auto-approve Read, Grep, Glob, and TodoWrite tool uses with 0% false positives, 
 
 From analysis of 7,188 tool uses across 615 sessions:
 
-| Tool | Count | % of Total | Rejections |
-|------|------:|----------:|-----------:|
-| Read | 2,129 | 29.6% | 2 (collateral, not safety-motivated) |
-| Grep | 374 | 5.2% | 1 (collateral) |
-| Glob | 260 | 3.6% | 1 (collateral) |
-| TodoWrite | 353 | 4.9% | 0 |
-| **Total** | **3,116** | **43.3%** | **~0 legitimate** |
+| Tool      |     Count | % of Total |                           Rejections |
+| --------- | --------: | ---------: | -----------------------------------: |
+| Read      |     2,129 |      29.6% | 2 (collateral, not safety-motivated) |
+| Grep      |       374 |       5.2% |                       1 (collateral) |
+| Glob      |       260 |       3.6% |                       1 (collateral) |
+| TodoWrite |       353 |       4.9% |                                    0 |
+| **Total** | **3,116** |  **43.3%** |                    **~0 legitimate** |
 
 The handful of rejections were collateral — the user was rejecting the agent's overall approach (e.g., shutting down a subagent), not objecting to the read operation itself.
 
@@ -29,6 +29,7 @@ These tools are inherently safe because they don't mutate state. The only risk v
 **Question**: What % of Read operations target files outside the project directory?
 
 **Method**:
+
 1. Extract all Read tool inputs from session history (the `file_path` field)
 2. Compare each path against the project directory (from the session's `cwd` or project path)
 3. Categorize: in-project, in-home-dir, system-level, other
@@ -36,6 +37,7 @@ These tools are inherently safe because they don't mutate state. The only risk v
 **Expected output**: A table showing the distribution. If >95% are in-project, path-scoping is a strong policy lever.
 
 **Command to run**:
+
 ```bash
 python3 -c "
 import json, os
@@ -88,6 +90,7 @@ print(f'System-level: {system_level} ({100*system_level/total:.1f}%)')
 **Question**: Are there files within the project tree that should still be gated?
 
 **Method**:
+
 1. From the Read paths collected in Task 1, check for patterns like `.env`, `credentials`, `secrets`, `*.pem`, `*.key`, etc.
 2. Also check: do any Grep/Glob operations target sensitive patterns?
 
@@ -98,6 +101,7 @@ print(f'System-level: {system_level} ({100*system_level/total:.1f}%)')
 **Question**: Do Grep/Glob operations ever have safety-relevant characteristics?
 
 **Method**:
+
 1. Extract all Grep inputs — check the `path` and `pattern` fields
 2. Extract all Glob inputs — check the `pattern` and `path` fields
 3. Look for any that target sensitive locations or patterns
@@ -117,17 +121,17 @@ policy:
     - tool: Read
       decision: approve
       conditions:
-        - path_within: "${project_dir}"
+        - path_within: '${project_dir}'
         - path_not_matches:
-            - "**/.env"
-            - "**/.env.*"
-            - "**/credentials*"
-            - "**/*.pem"
-            - "**/*.key"
+            - '**/.env'
+            - '**/.env.*'
+            - '**/credentials*'
+            - '**/*.pem'
+            - '**/*.key'
     - tool: Read
       decision: ask
       conditions:
-        - path_not_within: "${project_dir}"
+        - path_not_within: '${project_dir}'
     - tool: Grep
       decision: approve
     - tool: Glob
@@ -143,7 +147,7 @@ Extract all read-only tool uses from session history into a labeled dataset:
 ```json
 {
   "tool": "Read",
-  "input": {"file_path": "/Users/dherman/Code/thinkwell/src/index.ts"},
+  "input": { "file_path": "/Users/dherman/Code/thinkwell/src/index.ts" },
   "context": {
     "project": "/Users/dherman/Code/thinkwell",
     "session": "abc123"

--- a/docs/history/initial-research/pr-2-bash-classification.md
+++ b/docs/history/initial-research/pr-2-bash-classification.md
@@ -14,17 +14,17 @@ From analysis of 7,188 tool uses across 615 sessions:
 
 ### Bash Command Distribution (1,934 sampled)
 
-| Command | Count | % of Bash | Notes |
-|---------|------:|----------:|-------|
-| git | 630 | 33% | Mix of read-only and write |
-| gh | 244 | 13% | GitHub CLI, mix of read/write |
-| pnpm/npm/npx | 242 | 13% | Build/test/install |
-| ls/cd/pwd | 282 | 15% | Navigation, always safe |
-| grep/cat/find/head/tail | 196 | 10% | Read-only |
-| cargo | 37 | 2% | Build/test |
-| docker | 23 | 1% | Varies widely |
-| rm | 14 | <1% | Destructive |
-| Other | ~266 | 14% | Long tail |
+| Command                 | Count | % of Bash | Notes                         |
+| ----------------------- | ----: | --------: | ----------------------------- |
+| git                     |   630 |       33% | Mix of read-only and write    |
+| gh                      |   244 |       13% | GitHub CLI, mix of read/write |
+| pnpm/npm/npx            |   242 |       13% | Build/test/install            |
+| ls/cd/pwd               |   282 |       15% | Navigation, always safe       |
+| grep/cat/find/head/tail |   196 |       10% | Read-only                     |
+| cargo                   |    37 |        2% | Build/test                    |
+| docker                  |    23 |        1% | Varies widely                 |
+| rm                      |    14 |       <1% | Destructive                   |
+| Other                   |  ~266 |       14% | Long tail                     |
 
 ### What Was Actually Rejected
 
@@ -32,13 +32,13 @@ Only 2 Bash rejections in the dataset, both `pnpm install` in worktree directori
 
 ## Safety Level Taxonomy
 
-| Level | Label | Description | Policy | Examples |
-|-------|-------|-------------|--------|----------|
-| L0 | Pure read | No state change possible | Auto-approve | `ls`, `cat`, `git status`, `git log`, `git diff`, `which`, `pwd`, `head`, `tail`, `wc`, `find` (without `-exec`/`-delete`), `grep`, `echo` (no redirection) |
-| L1 | Build/test | Creates local artifacts, repeatable, no lasting side effects | Auto-approve (with constraints) | `pnpm build`, `pnpm test`, `cargo build`, `cargo test`, `npm run lint`, `pnpm typecheck` |
-| L2 | Local mutation | Changes local files/state, generally reversible | Conditional | `git add`, `git commit`, `mkdir`, `pnpm install`, `git checkout`, `git branch` |
-| L3 | External effects | Visible to others or hard to reverse | Require approval | `git push`, `gh pr create`, `gh issue comment`, `curl -X POST`, `docker push`, `aws *` |
-| L4 | Destructive | Data loss risk | Require approval + warning | `rm -rf`, `git reset --hard`, `git push --force`, `git clean -f`, `docker rm` |
+| Level | Label            | Description                                                  | Policy                          | Examples                                                                                                                                                    |
+| ----- | ---------------- | ------------------------------------------------------------ | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| L0    | Pure read        | No state change possible                                     | Auto-approve                    | `ls`, `cat`, `git status`, `git log`, `git diff`, `which`, `pwd`, `head`, `tail`, `wc`, `find` (without `-exec`/`-delete`), `grep`, `echo` (no redirection) |
+| L1    | Build/test       | Creates local artifacts, repeatable, no lasting side effects | Auto-approve (with constraints) | `pnpm build`, `pnpm test`, `cargo build`, `cargo test`, `npm run lint`, `pnpm typecheck`                                                                    |
+| L2    | Local mutation   | Changes local files/state, generally reversible              | Conditional                     | `git add`, `git commit`, `mkdir`, `pnpm install`, `git checkout`, `git branch`                                                                              |
+| L3    | External effects | Visible to others or hard to reverse                         | Require approval                | `git push`, `gh pr create`, `gh issue comment`, `curl -X POST`, `docker push`, `aws *`                                                                      |
+| L4    | Destructive      | Data loss risk                                               | Require approval + warning      | `rm -rf`, `git reset --hard`, `git push --force`, `git clean -f`, `docker rm`                                                                               |
 
 ## Research Tasks
 
@@ -49,6 +49,7 @@ Only 2 Bash rejections in the dataset, both `pnpm install` in worktree directori
 Extract every Bash tool_use input from session history into a structured dataset.
 
 **Command**:
+
 ```bash
 python3 -c "
 import json, os
@@ -96,6 +97,7 @@ print(f'Extracted {len(entries)} Bash commands')
 #### Task A2: Normalize and Deduplicate
 
 Group commands by pattern to identify unique command shapes:
+
 - `git status --short` and `git status -s` → same pattern
 - `cat /path/to/foo.ts` and `cat /path/to/bar.ts` → same pattern (cat + file)
 - `pnpm build` across different projects → same pattern
@@ -105,6 +107,7 @@ Group commands by pattern to identify unique command shapes:
 #### Task A3: Label Each Pattern
 
 For each unique command pattern, assign:
+
 - `safety_level`: L0-L4
 - `decision`: approve / ask / deny
 - `rationale`: Why this classification
@@ -135,6 +138,7 @@ for cmd, n in counts.most_common(30):
 ```
 
 **Expected breakdown**:
+
 - L0 (read-only): `git status`, `git log`, `git diff`, `git branch` (list), `git tag`, `git show`, `git remote -v`
 - L2 (local mutation): `git add`, `git commit`, `git checkout`, `git branch` (create/delete), `git stash`, `git merge`
 - L3 (external): `git push`, `git fetch` (safe but network), `git pull`
@@ -143,12 +147,14 @@ for cmd, n in counts.most_common(30):
 #### Task B2: GitHub CLI Deep Dive
 
 `gh` is 13% of Bash usage. Break down similarly:
+
 - L0: `gh pr list`, `gh pr view`, `gh run list`, `gh run view`, `gh issue list`
 - L3: `gh pr create`, `gh pr merge`, `gh issue create`, `gh issue comment`
 
 #### Task B3: Package Manager Deep Dive
 
 `pnpm`/`npm`/`npx` is 13%. Break down:
+
 - L1: `pnpm build`, `pnpm test`, `npm run lint`, `npx tsc --noEmit`
 - L2: `pnpm install`, `pnpm add <pkg>`, `npm install`
 - L3: `npm publish`, `pnpm deploy`
@@ -156,6 +162,7 @@ for cmd, n in counts.most_common(30):
 #### Task B4: Edge Cases and Compound Commands
 
 Identify commands that are hard to classify:
+
 - **Pipes**: `git log --oneline | head -5` (safe) vs `git log | xargs rm` (dangerous)
 - **Subshells**: `$(command)` embedded in other commands
 - **Redirects**: `echo foo > file.txt` (mutation via redirect)
@@ -169,6 +176,7 @@ Identify commands that are hard to classify:
 #### Task C1: Deterministic Classifier (L0 Fast Path)
 
 Build a simple parser that:
+
 1. Splits the command on pipes, `&&`, `||`, `;`
 2. For each subcommand, extracts the base command and subcommand/flags
 3. Matches against an allowlist of known-safe patterns
@@ -177,6 +185,7 @@ Build a simple parser that:
 **Test against**: The labeled dataset from Phase A.
 
 **Metrics to capture**:
+
 - Coverage: What % of commands does it classify (vs. falling through to "ask")?
 - Accuracy: What % of its classifications match the labels?
 - False positive rate: Does it EVER approve something labeled L3/L4?
@@ -209,6 +218,7 @@ Respond with ONLY the level (L0, L1, L2, L3, or L4) and a one-sentence rationale
 #### Task C3: Hybrid Classifier
 
 Combine C1 and C2:
+
 1. Deterministic fast path for L0 commands (covers ~60% of Bash usage)
 2. Deterministic deny path for known L4 patterns
 3. LLM fallback for everything in between
@@ -218,17 +228,18 @@ Combine C1 and C2:
 
 #### Task D1: Compare Approaches
 
-| Metric | Deterministic | LLM | Hybrid |
-|--------|--------------|-----|--------|
-| Coverage (% classified) | ? | ? | ? |
-| Accuracy | ? | ? | ? |
-| False positive rate | ? | ? | ? |
-| Latency (p50/p99) | ~0ms | ~?ms | ~?ms |
-| Cost per classification | $0 | ~$? | ~$? |
+| Metric                  | Deterministic | LLM  | Hybrid |
+| ----------------------- | ------------- | ---- | ------ |
+| Coverage (% classified) | ?             | ?    | ?      |
+| Accuracy                | ?             | ?    | ?      |
+| False positive rate     | ?             | ?    | ?      |
+| Latency (p50/p99)       | ~0ms          | ~?ms | ~?ms   |
+| Cost per classification | $0            | ~$?  | ~$?    |
 
 #### Task D2: Decide MVP Scope
 
 Based on D1 results, decide:
+
 - Which classifier approach to implement
 - Which safety levels to auto-approve in the MVP (likely L0 only, possibly L0+L1)
 - Whether to handle compound commands or punt on them
@@ -238,12 +249,14 @@ Based on D1 results, decide:
 Every Bash command is evaluated on two axes:
 
 ### Axis 1: Mutation Level
+
 - **None**: Command only reads state
 - **Local**: Command modifies files/state on this machine
 - **External**: Command sends data to external systems
 - **Destructive**: Command may cause irreversible data loss
 
 ### Axis 2: Scope
+
 - **Project-local**: Operates within the current project directory
 - **User-local**: Operates within the user's home directory
 - **System-wide**: Operates on system files/services

--- a/docs/history/initial-research/roadmap.md
+++ b/docs/history/initial-research/roadmap.md
@@ -5,8 +5,8 @@
 ## Progress
 
 - [x] **[PR 0: Dataset Extraction](./pr-0-dataset-extraction.md)** — Extract and anonymize tool use records from session history into `data/tool-use-dataset.jsonl`
-- [ ] ~~**[PR 1: Read-Only Auto-Approval](./pr-1-read-only-auto-approval.md)** — Validate path-scoping, identify sensitive file edge cases, draft deterministic policy spec~~ *(superseded)*
-- [ ] ~~**[PR 2: Bash Command Classification](./pr-2-bash-classification.md)** — Build labeled dataset, develop L0-L4 taxonomy, prototype classifiers~~ *(superseded)*
+- [ ] ~~**[PR 1: Read-Only Auto-Approval](./pr-1-read-only-auto-approval.md)** — Validate path-scoping, identify sensitive file edge cases, draft deterministic policy spec~~ _(superseded)_
+- [ ] ~~**[PR 2: Bash Command Classification](./pr-2-bash-classification.md)** — Build labeled dataset, develop L0-L4 taxonomy, prototype classifiers~~ _(superseded)_
 
 ## Context
 
@@ -16,30 +16,30 @@ This plan is based on analysis of real Claude Code session history data from thi
 
 ### Tool Use Distribution
 
-| Tool | Count | % | Rejection Rate |
-|------|------:|--:|----------------|
-| Bash | 2,460 | 34.2% | 0.33% (8/2460) |
-| Read | 2,129 | 29.6% | 0.09% (2/2129) |
-| Edit | 883 | 12.3% | 0.45% (4/883) |
-| Grep | 374 | 5.2% | ~0% (1 in subagent) |
-| TodoWrite | 353 | 4.9% | 0% |
-| Glob | 260 | 3.6% | ~0% (1 in subagent) |
-| Write | 197 | 2.7% | 0.5% (1/197) |
-| Other | 532 | 7.4% | varies |
+| Tool      | Count |     % | Rejection Rate      |
+| --------- | ----: | ----: | ------------------- |
+| Bash      | 2,460 | 34.2% | 0.33% (8/2460)      |
+| Read      | 2,129 | 29.6% | 0.09% (2/2129)      |
+| Edit      |   883 | 12.3% | 0.45% (4/883)       |
+| Grep      |   374 |  5.2% | ~0% (1 in subagent) |
+| TodoWrite |   353 |  4.9% | 0%                  |
+| Glob      |   260 |  3.6% | ~0% (1 in subagent) |
+| Write     |   197 |  2.7% | 0.5% (1/197)        |
+| Other     |   532 |  7.4% | varies              |
 
 ### Bash Command Breakdown (1,934 commands sampled)
 
-| Command | Count | % of Bash | Safety Profile |
-|---------|------:|----------:|----------------|
-| git | 630 | 33% | Mostly read-only (status, diff, log); some write (add, commit, push) |
-| gh | 244 | 13% | Read (pr list, run view) vs write (pr create, issue comment) |
-| pnpm/npm/npx | 242 | 13% | Build/test safe; install/add modify state |
-| ls/cd/pwd | 282 | 15% | Always safe |
-| grep/cat/find/head/tail | 196 | 10% | Always safe (read-only) |
-| cargo | 37 | 2% | Build/test safe |
-| docker | 23 | 1% | Varies widely |
-| rm | 14 | <1% | Destructive |
-| Everything else | ~266 | 14% | Case-by-case |
+| Command                 | Count | % of Bash | Safety Profile                                                       |
+| ----------------------- | ----: | --------: | -------------------------------------------------------------------- |
+| git                     |   630 |       33% | Mostly read-only (status, diff, log); some write (add, commit, push) |
+| gh                      |   244 |       13% | Read (pr list, run view) vs write (pr create, issue comment)         |
+| pnpm/npm/npx            |   242 |       13% | Build/test safe; install/add modify state                            |
+| ls/cd/pwd               |   282 |       15% | Always safe                                                          |
+| grep/cat/find/head/tail |   196 |       10% | Always safe (read-only)                                              |
+| cargo                   |    37 |        2% | Build/test safe                                                      |
+| docker                  |    23 |        1% | Varies widely                                                        |
+| rm                      |    14 |       <1% | Destructive                                                          |
+| Everything else         |  ~266 |       14% | Case-by-case                                                         |
 
 ### Rejection Analysis (All 13 Rejections)
 
@@ -50,7 +50,7 @@ Every rejection fell into one of these categories:
 3. **Unwanted agent spawning** (3): Task/Agent subagent creation the user considered unnecessary.
 4. **Accidental read rejection** (2): Read/Grep in subagent context — likely collateral from rejecting the subagent's entire approach.
 
-**Key insight**: Rejections were almost never about safety concerns — they were about *relevance* (the agent doing something the user didn't ask for). This is an important distinction for policy design.
+**Key insight**: Rejections were almost never about safety concerns — they were about _relevance_ (the agent doing something the user didn't ask for). This is an important distinction for policy design.
 
 ---
 
@@ -65,10 +65,12 @@ We'll pursue two tracks in parallel: a **quick win** (read-only auto-approval) a
 **Hypothesis**: These tools are inherently safe because they don't mutate state. The data confirms this — across 3,116 uses, there are essentially 0 legitimate rejections (the 2-3 that occurred were collateral, not safety-motivated).
 
 **Safety model**: A tool use is safe to auto-approve if:
+
 - It is purely read-only (no side effects on the filesystem, network, or external systems), AND
 - It operates within the project directory or explicitly allowed paths
 
 **Scope constraints**:
+
 - Read: Auto-approve for files within the project tree. Flag reads outside the project (e.g., `~/.env`, `/etc/passwd`) for review.
 - Grep/Glob: Auto-approve. These are always scoped to a path.
 - TodoWrite: Auto-approve. Internal state only.
@@ -76,6 +78,7 @@ We'll pursue two tracks in parallel: a **quick win** (read-only auto-approval) a
 **Implementation approach**: Deterministic. Simple allowlist + path validation. No LLM needed.
 
 **Research tasks**:
+
 - [ ] Validate the path-scoping assumption: extract all Read tool inputs from history and check what % read files outside the project directory
 - [ ] Identify edge cases: are there Read targets that are within the project tree but still sensitive (e.g., `.env`, credentials files)?
 - [ ] Draft a policy specification
@@ -90,19 +93,20 @@ We'll pursue two tracks in parallel: a **quick win** (read-only auto-approval) a
 
 Develop a taxonomy of Bash command safety levels:
 
-| Level | Description | Examples | Auto-approve? |
-|-------|-------------|----------|---------------|
-| **L0: Pure read** | No state change possible | `ls`, `cat`, `git status`, `git log`, `git diff`, `which`, `pwd`, `head`, `tail`, `wc`, `find` (without `-exec`/`-delete`) | Yes |
-| **L1: Build/test** | Local artifacts only, repeatable | `pnpm build`, `pnpm test`, `cargo build`, `cargo test`, `npm run lint` | Yes (with constraints) |
-| **L2: Local mutation** | Changes local files/state, reversible | `git add`, `git commit`, `mkdir`, `pnpm install`, `git checkout <branch>` | Conditional |
-| **L3: External effects** | Visible to others or hard to reverse | `git push`, `gh pr create`, `gh issue comment`, `curl -X POST`, `docker push`, `aws` | No (require approval) |
-| **L4: Destructive** | Data loss risk | `rm -rf`, `git reset --hard`, `git push --force`, `docker rm`, `DROP TABLE` | No (require approval + warning) |
+| Level                    | Description                           | Examples                                                                                                                   | Auto-approve?                   |
+| ------------------------ | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| **L0: Pure read**        | No state change possible              | `ls`, `cat`, `git status`, `git log`, `git diff`, `which`, `pwd`, `head`, `tail`, `wc`, `find` (without `-exec`/`-delete`) | Yes                             |
+| **L1: Build/test**       | Local artifacts only, repeatable      | `pnpm build`, `pnpm test`, `cargo build`, `cargo test`, `npm run lint`                                                     | Yes (with constraints)          |
+| **L2: Local mutation**   | Changes local files/state, reversible | `git add`, `git commit`, `mkdir`, `pnpm install`, `git checkout <branch>`                                                  | Conditional                     |
+| **L3: External effects** | Visible to others or hard to reverse  | `git push`, `gh pr create`, `gh issue comment`, `curl -X POST`, `docker push`, `aws`                                       | No (require approval)           |
+| **L4: Destructive**      | Data loss risk                        | `rm -rf`, `git reset --hard`, `git push --force`, `docker rm`, `DROP TABLE`                                                | No (require approval + warning) |
 
 #### Phase 2b: Classification Strategy
 
 Three approaches to evaluate:
 
 **Option A — Deterministic (regex/pattern matching)**:
+
 - Parse the command string, extract the base command and flags
 - Match against a curated allowlist/denylist
 - Pros: Predictable, fast, auditable
@@ -110,12 +114,14 @@ Three approaches to evaluate:
 - Challenge: `git log` is safe but `git log | xargs rm` is not
 
 **Option B — LLM-as-judge**:
+
 - Send the command to a small/fast LLM with a safety classification prompt
 - Pros: Handles syntactic variation, can reason about intent
 - Cons: Non-deterministic, latency cost, potential for false negatives
 - Mitigation: Constrain to binary safe/unsafe output, use structured output
 
 **Option C — Hybrid (recommended for investigation)**:
+
 - Deterministic fast-path for clearly safe patterns (L0 commands)
 - LLM fallback for ambiguous commands
 - Deterministic deny for clearly dangerous patterns (L4 commands)
@@ -133,6 +139,7 @@ Build a labeled dataset from real session history for testing:
 5. **Split**: Training set (for tuning prompts or rules) and test set (for evaluation)
 
 **Format**: Each entry should include:
+
 ```json
 {
   "command": "git status --short",
@@ -156,10 +163,12 @@ Build a labeled dataset from real session history for testing:
 Drawing from Claude Code's existing permission model (default/acceptEdits/plan/bypassPermissions) but designing from first principles:
 
 ### What Claude Code's Model Gets Right
+
 - **Mode-based simplicity**: Users pick a posture (cautious vs. permissive) rather than configuring per-tool rules
 - **Tool-level granularity in settings.json**: `allow` rules like `Bash(npm run lint)` show the direction of pattern-based auto-approval
 
 ### Where It Falls Short (Gaps We Can Address)
+
 - **All-or-nothing for Bash**: You either approve every Bash command or get prompted for each one. There's no middle ground for "approve read-only Bash commands."
 - **No semantic understanding**: `Bash(git status)` and `Bash(git push --force)` are treated identically unless you write exact-match rules for each
 - **Static rules**: The allowlist in settings.json doesn't adapt to context (what project, what branch, what the agent is currently doing)

--- a/docs/history/live-agent-integration/design.md
+++ b/docs/history/live-agent-integration/design.md
@@ -73,14 +73,14 @@ Milestone 0 established the `SessionManager → ChildProcess → ACP` pipeline w
 
 ### What Changes from Milestone 0
 
-| Component | M0 | M1 |
-|-----------|----|----|
-| Agent process | Echo agent (`src/agents/echo-agent.ts`) | Claude Code via `@zed-industries/claude-agent-acp` (echo agent kept as fallback) |
-| Agent working directory | `process.cwd()` | Per-session git worktree |
-| ACP Client methods | `sessionUpdate` only; `requestPermission` returns `cancelled` | `sessionUpdate`, `requestPermission`, `readTextFile`, `writeTextFile`, `createTerminal`, `terminalOutput`, `killTerminal`, `waitForTerminalExit`, `releaseTerminal` |
-| Session updates | Text chunks only | Text chunks, tool call events, plan events |
-| UI rendering | Plain text messages | Text + tool call indicators + plan display |
-| Session creation | Instant | User selects a project directory; worktree created from current branch |
+| Component               | M0                                                            | M1                                                                                                                                                                  |
+| ----------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Agent process           | Echo agent (`src/agents/echo-agent.ts`)                       | Claude Code via `@zed-industries/claude-agent-acp` (echo agent kept as fallback)                                                                                    |
+| Agent working directory | `process.cwd()`                                               | Per-session git worktree                                                                                                                                            |
+| ACP Client methods      | `sessionUpdate` only; `requestPermission` returns `cancelled` | `sessionUpdate`, `requestPermission`, `readTextFile`, `writeTextFile`, `createTerminal`, `terminalOutput`, `killTerminal`, `waitForTerminalExit`, `releaseTerminal` |
+| Session updates         | Text chunks only                                              | Text chunks, tool call events, plan events                                                                                                                          |
+| UI rendering            | Plain text messages                                           | Text + tool call indicators + plan display                                                                                                                          |
+| Session creation        | Instant                                                       | User selects a project directory; worktree created from current branch                                                                                              |
 
 ---
 
@@ -91,6 +91,7 @@ Milestone 0 established the `SessionManager → ChildProcess → ACP` pipeline w
 The `@zed-industries/claude-agent-acp` package is an npm package that wraps Claude Code as an ACP-compliant agent. It is spawned as a subprocess, just like the echo agent.
 
 **Spawn command:**
+
 ```bash
 npx @zed-industries/claude-agent-acp
 ```
@@ -184,13 +185,13 @@ async requestPermission(params: RequestPermissionParams): Promise<RequestPermiss
 
 Claude Code sends richer `SessionNotification` updates than the echo agent. Beyond `agent_message_chunk` (text), we need to handle:
 
-| `sessionUpdate` variant | Content | How we handle it |
-|------------------------|---------|-----------------|
-| `agent_message_chunk` | `TextContent` | Append to streaming message (same as M0) |
-| `agent_message_chunk` | `ToolCallContent` | Track tool call status; emit UI update |
-| `plan_update` | Plan entries with status | Display plan progress in UI |
-| `agent_message_start` | New message boundary | Create new agent message in history |
-| `agent_message_end` | Message complete | Finalize message, mark streaming=false |
+| `sessionUpdate` variant | Content                  | How we handle it                         |
+| ----------------------- | ------------------------ | ---------------------------------------- |
+| `agent_message_chunk`   | `TextContent`            | Append to streaming message (same as M0) |
+| `agent_message_chunk`   | `ToolCallContent`        | Track tool call status; emit UI update   |
+| `plan_update`           | Plan entries with status | Display plan progress in UI              |
+| `agent_message_start`   | New message boundary     | Create new agent message in history      |
+| `agent_message_end`     | Message complete         | Finalize message, mark streaming=false   |
 
 The session manager's `sessionUpdate` handler in the `Client` implementation needs to dispatch on both the `sessionUpdate` discriminator and the `content.type` within it.
 
@@ -221,9 +222,9 @@ New module responsible for git worktree lifecycle. Extracted from the session ma
 
 ```typescript
 export interface WorktreeInfo {
-  path: string;           // Absolute path to the worktree
-  branch: string;         // Branch name (bouncer/<session-id>)
-  projectDir: string;     // Original project directory
+  path: string; // Absolute path to the worktree
+  branch: string; // Branch name (bouncer/<session-id>)
+  projectDir: string; // Original project directory
 }
 
 export class WorktreeManager {
@@ -251,12 +252,13 @@ export class WorktreeManager {
 The existing session manager gains:
 
 **New fields on `SessionState`:**
+
 ```typescript
 interface SessionState {
   // ... existing fields from M0 ...
-  agentType: "echo" | "claude-code";
+  agentType: 'echo' | 'claude-code';
   projectDir: string;
-  worktree: WorktreeInfo | null;    // null for echo agent sessions
+  worktree: WorktreeInfo | null; // null for echo agent sessions
   terminals: Map<string, ChildProcess>;
 }
 ```
@@ -272,12 +274,12 @@ interface SessionState {
 ```typescript
 function resolveClaudeCodeCommand(worktreePath: string): SpawnConfig {
   // Resolve the claude-agent-acp binary from node_modules
-  const require = createRequire(app.getAppPath() + "/");
-  const binPath = require.resolve("@zed-industries/claude-agent-acp/bin");
+  const require = createRequire(app.getAppPath() + '/');
+  const binPath = require.resolve('@zed-industries/claude-agent-acp/bin');
   return {
     cmd: process.execPath,
     args: [binPath],
-    env: { ELECTRON_RUN_AS_NODE: "1" },
+    env: { ELECTRON_RUN_AS_NODE: '1' },
     cwd: worktreePath,
   };
 }
@@ -293,7 +295,7 @@ Rather than a separate module, terminal management is implemented as part of the
 interface TerminalState {
   id: string;
   process: ChildProcess;
-  output: string;           // Accumulated stdout+stderr
+  output: string; // Accumulated stdout+stderr
   exitCode: number | null;
 }
 ```
@@ -305,28 +307,28 @@ The terminal's `cwd` is set to the session's worktree path. stdout and stderr ar
 Extended to support richer session updates:
 
 ```typescript
-export type AgentType = "echo" | "claude-code";
+export type AgentType = 'echo' | 'claude-code';
 
 export interface SessionSummary {
   id: string;
-  status: "initializing" | "ready" | "error" | "closed";
+  status: 'initializing' | 'ready' | 'error' | 'closed';
   messageCount: number;
   agentType: AgentType;
   projectDir: string;
 }
 
 export type SessionUpdate =
-  | { sessionId: string; type: "status-change"; status: SessionSummary["status"] }
-  | { sessionId: string; type: "message"; message: Message }
-  | { sessionId: string; type: "stream-chunk"; messageId: string; text: string }
-  | { sessionId: string; type: "stream-end"; messageId: string }
-  | { sessionId: string; type: "tool-call"; messageId: string; toolCall: ToolCallInfo }
-  | { sessionId: string; type: "plan-update"; plan: PlanInfo };
+  | { sessionId: string; type: 'status-change'; status: SessionSummary['status'] }
+  | { sessionId: string; type: 'message'; message: Message }
+  | { sessionId: string; type: 'stream-chunk'; messageId: string; text: string }
+  | { sessionId: string; type: 'stream-end'; messageId: string }
+  | { sessionId: string; type: 'tool-call'; messageId: string; toolCall: ToolCallInfo }
+  | { sessionId: string; type: 'plan-update'; plan: PlanInfo };
 
 export interface ToolCallInfo {
   id: string;
   name: string;
-  status: "pending" | "in_progress" | "completed" | "failed";
+  status: 'pending' | 'in_progress' | 'completed' | 'failed';
   input?: Record<string, unknown>;
   output?: string;
 }
@@ -337,7 +339,7 @@ export interface PlanInfo {
 
 export interface PlanEntry {
   title: string;
-  status: "pending" | "in_progress" | "completed" | "failed";
+  status: 'pending' | 'in_progress' | 'completed' | 'failed';
 }
 ```
 
@@ -346,23 +348,22 @@ export interface PlanEntry {
 Extended with project selection:
 
 ```typescript
-contextBridge.exposeInMainWorld("glitterball", {
+contextBridge.exposeInMainWorld('glitterball', {
   sessions: {
-    list: () => ipcRenderer.invoke("sessions:list"),
+    list: () => ipcRenderer.invoke('sessions:list'),
     create: (projectDir: string, agentType?: string) =>
-      ipcRenderer.invoke("sessions:create", projectDir, agentType),
+      ipcRenderer.invoke('sessions:create', projectDir, agentType),
     sendMessage: (sessionId: string, text: string) =>
-      ipcRenderer.invoke("sessions:sendMessage", sessionId, text),
-    closeSession: (sessionId: string) =>
-      ipcRenderer.invoke("sessions:close", sessionId),
+      ipcRenderer.invoke('sessions:sendMessage', sessionId, text),
+    closeSession: (sessionId: string) => ipcRenderer.invoke('sessions:close', sessionId),
     onUpdate: (callback: (update: any) => void) => {
       const handler = (_event: any, update: any) => callback(update);
-      ipcRenderer.on("session-update", handler);
-      return () => ipcRenderer.removeListener("session-update", handler);
+      ipcRenderer.on('session-update', handler);
+      return () => ipcRenderer.removeListener('session-update', handler);
     },
   },
   dialog: {
-    selectDirectory: () => ipcRenderer.invoke("dialog:selectDirectory"),
+    selectDirectory: () => ipcRenderer.invoke('dialog:selectDirectory'),
   },
 });
 ```
@@ -370,10 +371,10 @@ contextBridge.exposeInMainWorld("glitterball", {
 The main process handler for `dialog:selectDirectory` uses Electron's dialog API:
 
 ```typescript
-ipcMain.handle("dialog:selectDirectory", async () => {
+ipcMain.handle('dialog:selectDirectory', async () => {
   const result = await dialog.showOpenDialog(mainWindow, {
-    properties: ["openDirectory"],
-    title: "Select project directory",
+    properties: ['openDirectory'],
+    title: 'Select project directory',
   });
   if (result.canceled || result.filePaths.length === 0) return null;
   return result.filePaths[0];
@@ -385,17 +386,20 @@ ipcMain.handle("dialog:selectDirectory", async () => {
 UI changes are minimal — the primary goal is getting the agent working, not UI polish:
 
 **Session creation flow:**
+
 1. User clicks "New Session"
 2. Directory picker dialog opens
 3. On selection, session is created with `claude-code` agent type
 4. Session appears in list with "initializing" status (worktree creation + ACP handshake may take a few seconds)
 
 **Chat rendering additions:**
+
 - **Tool call indicators**: When a `tool-call` update arrives, show a collapsed block: `🔧 Bash: git status [completed]`. Expand on click to show input/output. (Stretch goal — a simple one-line indicator is the minimum.)
 - **Plan display**: If `plan-update` arrives, show a checklist of plan entries with status indicators above the chat. (Stretch goal.)
 - **Text streaming**: Unchanged from M0.
 
 **Session list enhancement:**
+
 - Show project directory name (e.g., "bouncer") as the session label instead of a UUID
 - Show agent type indicator (echo vs. Claude Code)
 
@@ -405,17 +409,17 @@ UI changes are minimal — the primary goal is getting the agent working, not UI
 
 ### New npm packages
 
-| Package | Purpose |
-|---------|---------|
+| Package                            | Purpose                                                   |
+| ---------------------------------- | --------------------------------------------------------- |
 | `@zed-industries/claude-agent-acp` | Claude Code ACP adapter — spawned as the agent subprocess |
 
 ### Existing packages (no changes)
 
-| Package | Purpose |
-|---------|---------|
+| Package                    | Purpose                               |
+| -------------------------- | ------------------------------------- |
 | `@agentclientprotocol/sdk` | ACP client connection, protocol types |
-| `electron` | App shell |
-| `react`, `react-dom` | UI |
+| `electron`                 | App shell                             |
+| `react`, `react-dom`       | UI                                    |
 
 ### System requirements
 

--- a/docs/history/live-agent-integration/plan.md
+++ b/docs/history/live-agent-integration/plan.md
@@ -18,7 +18,7 @@ This plan breaks the [design](design.md) into concrete, sequentially-executable 
   - [x] 2.4 Write `scripts/test-claude-agent.ts` standalone test
   - [x] 2.5 Smoke test: ACP handshake + simple prompt with Claude Code
   - [x] 2.6 Document deviations in `sdk-deviations.md`
-- [x] **Phase 3+4+5: Session Manager Integration + IPC + UI** *(collapsed — Phase 2 revealed Claude Code handles tools internally, making Phase 3 terminal management unnecessary)*
+- [x] **Phase 3+4+5: Session Manager Integration + IPC + UI** _(collapsed — Phase 2 revealed Claude Code handles tools internally, making Phase 3 terminal management unnecessary)_
   - [x] Extend `SessionState` with agentType, projectDir, worktree
   - [x] Update `createSession()` — agent type selection + worktree creation
   - [x] Implement `resolveClaudeCodeCommand()`
@@ -53,17 +53,17 @@ Build and test the worktree manager in isolation before touching the session man
 - [ ] Create the file with the class skeleton and types
 
 ```typescript
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 const execFileAsync = promisify(execFile);
 
 export interface WorktreeInfo {
-  path: string;         // Absolute path to the worktree directory
-  branch: string;       // Branch name: bouncer/<session-id>
-  projectDir: string;   // Original project directory
+  path: string; // Absolute path to the worktree directory
+  branch: string; // Branch name: bouncer/<session-id>
+  projectDir: string; // Original project directory
 }
 
 export class WorktreeManager {
@@ -71,12 +71,18 @@ export class WorktreeManager {
 
   constructor(basePath?: string) {
     // Default: system temp dir / glitterball-worktrees
-    this.basePath = basePath ?? join(tmpdir(), "glitterball-worktrees");
+    this.basePath = basePath ?? join(tmpdir(), 'glitterball-worktrees');
   }
 
-  async validateGitRepo(dir: string): Promise<boolean> { /* ... */ }
-  async create(sessionId: string, projectDir: string): Promise<WorktreeInfo> { /* ... */ }
-  async remove(info: WorktreeInfo): Promise<void> { /* ... */ }
+  async validateGitRepo(dir: string): Promise<boolean> {
+    /* ... */
+  }
+  async create(sessionId: string, projectDir: string): Promise<WorktreeInfo> {
+    /* ... */
+  }
+  async remove(info: WorktreeInfo): Promise<void> {
+    /* ... */
+  }
 }
 ```
 
@@ -164,10 +170,10 @@ async remove(info: WorktreeInfo): Promise<void> {
 
 ```typescript
 // scripts/test-worktree.ts
-import { WorktreeManager } from "../src/main/worktree-manager.js";
-import { randomUUID } from "node:crypto";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
+import { WorktreeManager } from '../src/main/worktree-manager.js';
+import { randomUUID } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 const manager = new WorktreeManager();
@@ -176,13 +182,13 @@ const manager = new WorktreeManager();
 const projectDir = process.cwd();
 const sessionId = randomUUID();
 
-console.log("=== Worktree Manager Test ===\n");
+console.log('=== Worktree Manager Test ===\n');
 
 // Validate git repo
 const isGitRepo = await manager.validateGitRepo(projectDir);
 console.log(`1. Is git repo: ${isGitRepo}`);
 if (!isGitRepo) {
-  console.error("Not a git repo — run this from the bouncer project root");
+  console.error('Not a git repo — run this from the bouncer project root');
   process.exit(1);
 }
 
@@ -193,15 +199,15 @@ console.log(`   Path: ${info.path}`);
 console.log(`   Branch: ${info.branch}`);
 
 // Verify it exists
-const { stdout: worktreeList } = await execFileAsync(
-  "git", ["worktree", "list"], { cwd: projectDir }
-);
+const { stdout: worktreeList } = await execFileAsync('git', ['worktree', 'list'], {
+  cwd: projectDir,
+});
 console.log(`\n3. git worktree list:\n${worktreeList}`);
 
 // Verify branch exists
-const { stdout: branchList } = await execFileAsync(
-  "git", ["branch", "--list", info.branch], { cwd: projectDir }
-);
+const { stdout: branchList } = await execFileAsync('git', ['branch', '--list', info.branch], {
+  cwd: projectDir,
+});
 console.log(`4. Branch exists: ${branchList.trim().length > 0}`);
 
 // Remove worktree
@@ -209,20 +215,21 @@ console.log(`\n5. Removing worktree...`);
 await manager.remove(info);
 
 // Verify cleanup
-const { stdout: worktreeListAfter } = await execFileAsync(
-  "git", ["worktree", "list"], { cwd: projectDir }
-);
+const { stdout: worktreeListAfter } = await execFileAsync('git', ['worktree', 'list'], {
+  cwd: projectDir,
+});
 console.log(`6. git worktree list after cleanup:\n${worktreeListAfter}`);
 
-const { stdout: branchListAfter } = await execFileAsync(
-  "git", ["branch", "--list", info.branch], { cwd: projectDir }
-);
+const { stdout: branchListAfter } = await execFileAsync('git', ['branch', '--list', info.branch], {
+  cwd: projectDir,
+});
 console.log(`7. Branch gone: ${branchListAfter.trim().length === 0}`);
 
-console.log("\n=== Done ===");
+console.log('\n=== Done ===');
 ```
 
 Add to `package.json` scripts:
+
 ```json
 "test:worktree": "tsx scripts/test-worktree.ts"
 ```
@@ -270,16 +277,16 @@ ls -la node_modules/.bin/claude-agent-acp*
 The spawning pattern should mirror how we resolve `tsx` for the echo agent. In `session-manager.ts` the existing code uses `createRequire` to resolve binary paths:
 
 ```typescript
-const require = createRequire(app.getAppPath() + "/");
-const tsxBin = require.resolve("tsx/cli");
+const require = createRequire(app.getAppPath() + '/');
+const tsxBin = require.resolve('tsx/cli');
 ```
 
 We need the equivalent for `claude-agent-acp`. The exact `require.resolve()` target depends on what the package exports:
 
 ```typescript
 // Likely one of:
-require.resolve("@zed-industries/claude-agent-acp/bin");
-require.resolve("@zed-industries/claude-agent-acp/cli");
+require.resolve('@zed-industries/claude-agent-acp/bin');
+require.resolve('@zed-industries/claude-agent-acp/cli');
 // or the path from the package.json bin field
 ```
 
@@ -291,17 +298,17 @@ require.resolve("@zed-industries/claude-agent-acp/cli");
 
 The ACP SDK defines these optional Client methods (from `sdk-deviations.md`, only `requestPermission` and `sessionUpdate` are required):
 
-| Method | Required? | Expected by Claude Code? |
-|--------|-----------|--------------------------|
-| `sessionUpdate` | Yes | Yes — streaming responses |
-| `requestPermission` | Yes | Yes — permission prompts |
-| `readTextFile` | No | Likely — Read tool |
-| `writeTextFile` | No | Likely — Write/Edit tools |
-| `createTerminal` | No | Likely — Bash tool |
-| `terminalOutput` | No | Likely — get command output |
-| `killTerminal` | No | Likely — kill running commands |
-| `waitForTerminalExit` | No | Likely — await command completion |
-| `releaseTerminal` | No | Likely — cleanup after command |
+| Method                | Required? | Expected by Claude Code?          |
+| --------------------- | --------- | --------------------------------- |
+| `sessionUpdate`       | Yes       | Yes — streaming responses         |
+| `requestPermission`   | Yes       | Yes — permission prompts          |
+| `readTextFile`        | No        | Likely — Read tool                |
+| `writeTextFile`       | No        | Likely — Write/Edit tools         |
+| `createTerminal`      | No        | Likely — Bash tool                |
+| `terminalOutput`      | No        | Likely — get command output       |
+| `killTerminal`        | No        | Likely — kill running commands    |
+| `waitForTerminalExit` | No        | Likely — await command completion |
+| `releaseTerminal`     | No        | Likely — cleanup after command    |
 
 We need to discover which of these Claude Code actually calls. The test script in 2.4 will reveal this — any unimplemented method that Claude Code calls will throw an error.
 
@@ -323,25 +330,25 @@ We need to discover which of these Claude Code actually calls. The test script i
 //   - @zed-industries/claude-agent-acp installed
 //   - ANTHROPIC_API_KEY set or Claude Code OAuth active
 
-import { spawn } from "node:child_process";
-import { createRequire } from "node:module";
-import { Writable, Readable } from "node:stream";
-import * as acp from "@agentclientprotocol/sdk";
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { Writable, Readable } from 'node:stream';
+import * as acp from '@agentclientprotocol/sdk';
 
 const require = createRequire(import.meta.url);
 
 // --- Resolve the claude-agent-acp binary ---
 // TODO: Update this path after discovery in step 2.2
-const agentBin = require.resolve("@zed-industries/claude-agent-acp/bin");
+const agentBin = require.resolve('@zed-industries/claude-agent-acp/bin');
 
 const agent = spawn(process.execPath, [agentBin], {
-  stdio: ["pipe", "pipe", "inherit"], // stderr → console for debugging
+  stdio: ['pipe', 'pipe', 'inherit'], // stderr → console for debugging
   cwd: process.cwd(),
-  env: { ...process.env, ELECTRON_RUN_AS_NODE: "1" },
+  env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
 });
 
-agent.on("error", (err) => console.error("Agent spawn error:", err));
-agent.on("exit", (code) => console.log(`Agent exited with code ${code}`));
+agent.on('error', (err) => console.error('Agent spawn error:', err));
+agent.on('exit', (code) => console.log(`Agent exited with code ${code}`));
 
 const output = Writable.toWeb(agent.stdin!) as WritableStream<Uint8Array>;
 const input = Readable.toWeb(agent.stdout!) as ReadableStream<Uint8Array>;
@@ -354,87 +361,84 @@ const connection = new acp.ClientSideConnection(
   (_agentInterface) => ({
     async sessionUpdate(params) {
       const update = params.update;
-      if (
-        update.sessionUpdate === "agent_message_chunk" &&
-        update.content.type === "text"
-      ) {
+      if (update.sessionUpdate === 'agent_message_chunk' && update.content.type === 'text') {
         process.stdout.write(update.content.text);
       } else {
-        console.log("\n[sessionUpdate]", JSON.stringify(update, null, 2));
+        console.log('\n[sessionUpdate]', JSON.stringify(update, null, 2));
       }
     },
 
     async requestPermission(params) {
-      console.log("\n[requestPermission]", JSON.stringify(params, null, 2));
+      console.log('\n[requestPermission]', JSON.stringify(params, null, 2));
       // Auto-approve for testing
-      return { outcome: { outcome: "approved" as const } };
+      return { outcome: { outcome: 'approved' as const } };
     },
 
     // --- Discovery stubs: log and implement minimally ---
 
     async readTextFile(params) {
-      console.log("\n[readTextFile]", JSON.stringify(params));
+      console.log('\n[readTextFile]', JSON.stringify(params));
       // Passthrough to filesystem
-      const { readFile } = await import("node:fs/promises");
-      const content = await readFile(params.uri, "utf-8");
+      const { readFile } = await import('node:fs/promises');
+      const content = await readFile(params.uri, 'utf-8');
       return { content };
     },
 
     async writeTextFile(params) {
-      console.log("\n[writeTextFile]", JSON.stringify(params));
-      const { writeFile } = await import("node:fs/promises");
-      await writeFile(params.uri, params.content, "utf-8");
+      console.log('\n[writeTextFile]', JSON.stringify(params));
+      const { writeFile } = await import('node:fs/promises');
+      await writeFile(params.uri, params.content, 'utf-8');
     },
 
     async createTerminal(params) {
-      console.log("\n[createTerminal]", JSON.stringify(params));
+      console.log('\n[createTerminal]', JSON.stringify(params));
       // Minimal terminal: spawn shell, return ID
-      const { spawn: spawnShell } = await import("node:child_process");
-      const shell = spawnShell(process.env.SHELL || "/bin/zsh", [], {
+      const { spawn: spawnShell } = await import('node:child_process');
+      const shell = spawnShell(process.env.SHELL || '/bin/zsh', [], {
         cwd: process.cwd(),
         env: { ...process.env },
-        stdio: ["pipe", "pipe", "pipe"],
+        stdio: ['pipe', 'pipe', 'pipe'],
       });
       const terminalId = `term-${Date.now()}`;
       // Store for later use (simplified — real impl uses a Map on session state)
       (globalThis as any).__terminals = (globalThis as any).__terminals || {};
       (globalThis as any).__terminals[terminalId] = {
         process: shell,
-        output: "",
+        output: '',
       };
-      shell.stdout?.on("data", (data: Buffer) => {
+      shell.stdout?.on('data', (data: Buffer) => {
         (globalThis as any).__terminals[terminalId].output += data.toString();
       });
-      shell.stderr?.on("data", (data: Buffer) => {
+      shell.stderr?.on('data', (data: Buffer) => {
         (globalThis as any).__terminals[terminalId].output += data.toString();
       });
       return { terminalId };
     },
 
     async terminalOutput(params) {
-      console.log("\n[terminalOutput]", JSON.stringify(params));
+      console.log('\n[terminalOutput]', JSON.stringify(params));
       const term = (globalThis as any).__terminals?.[params.terminalId];
       if (!term) throw new Error(`Unknown terminal: ${params.terminalId}`);
       const output = term.output;
-      term.output = ""; // Consume
+      term.output = ''; // Consume
       return { output };
     },
 
     async killTerminal(params) {
-      console.log("\n[killTerminal]", JSON.stringify(params));
+      console.log('\n[killTerminal]', JSON.stringify(params));
       const term = (globalThis as any).__terminals?.[params.terminalId];
-      if (term) term.process.kill("SIGTERM");
+      if (term) term.process.kill('SIGTERM');
     },
 
     async waitForTerminalExit(params) {
-      console.log("\n[waitForTerminalExit]", JSON.stringify(params));
+      console.log('\n[waitForTerminalExit]', JSON.stringify(params));
       const term = (globalThis as any).__terminals?.[params.terminalId];
       if (!term) return { exitCode: 1 };
       return new Promise((resolve) => {
         if (term.process.exitCode !== null) {
           resolve({ exitCode: term.process.exitCode });
         } else {
-          term.process.on("exit", (code: number | null) => {
+          term.process.on('exit', (code: number | null) => {
             resolve({ exitCode: code ?? 1 });
           });
         }
@@ -442,7 +446,7 @@ const connection = new acp.ClientSideConnection(
     },
 
     async releaseTerminal(params) {
-      console.log("\n[releaseTerminal]", JSON.stringify(params));
+      console.log('\n[releaseTerminal]', JSON.stringify(params));
       const term = (globalThis as any).__terminals?.[params.terminalId];
       if (term) {
         term.process.kill();
@@ -450,40 +454,40 @@ const connection = new acp.ClientSideConnection(
       }
     },
   }),
-  stream
+  stream,
 );
 
 // --- Drive the protocol ---
 
 try {
-  console.log("Initializing...");
+  console.log('Initializing...');
   const initResp = await connection.initialize({
     protocolVersion: acp.PROTOCOL_VERSION,
     clientCapabilities: {},
   });
-  console.log("Initialized:", JSON.stringify(initResp, null, 2));
+  console.log('Initialized:', JSON.stringify(initResp, null, 2));
 
-  console.log("\nCreating session...");
+  console.log('\nCreating session...');
   const sessionResp = await connection.newSession({
     cwd: process.cwd(),
     mcpServers: [],
   });
-  console.log("Session:", sessionResp.sessionId);
+  console.log('Session:', sessionResp.sessionId);
 
   // Simple prompt that exercises file reading and terminal use
-  const prompt = "What files are in the current directory? List them briefly.";
+  const prompt = 'What files are in the current directory? List them briefly.';
   console.log(`\nSending prompt: "${prompt}"\n`);
-  console.log("--- Response ---");
+  console.log('--- Response ---');
 
   const promptResp = await connection.prompt({
     sessionId: sessionResp.sessionId,
-    prompt: [{ type: "text", text: prompt }],
+    prompt: [{ type: 'text', text: prompt }],
   });
 
-  console.log("\n--- End Response ---");
+  console.log('\n--- End Response ---');
   console.log(`\nStop reason: ${promptResp.stopReason}`);
 } catch (err) {
-  console.error("\nError:", err);
+  console.error('\nError:', err);
   process.exitCode = 1;
 } finally {
   agent.kill();
@@ -493,6 +497,7 @@ try {
 **Important:** The `readTextFile`, `writeTextFile`, `createTerminal`, etc. signatures above are guesses based on the ACP reference doc. The actual parameter and return types may differ. The SDK's TypeScript compiler will flag mismatches — fix them during implementation.
 
 Add to `package.json` scripts:
+
 ```json
 "test:claude-agent": "tsx scripts/test-claude-agent.ts"
 ```
@@ -508,6 +513,7 @@ Add to `package.json` scripts:
 **Expected observations:**
 
 For a prompt like "What files are in the current directory?", Claude Code should:
+
 1. Call `createTerminal` to spawn a shell
 2. Write `ls` (or similar) to the terminal
 3. Call `waitForTerminalExit` / `terminalOutput` to get the result
@@ -544,12 +550,12 @@ With the discovery from Phase 2 in hand, implement proper terminal management. T
 - [ ] Add to `src/main/types.ts`
 
 ```typescript
-import type { ChildProcess } from "node:child_process";
+import type { ChildProcess } from 'node:child_process';
 
 export interface TerminalState {
   id: string;
   process: ChildProcess;
-  output: string;        // Accumulated stdout + stderr since last read
+  output: string; // Accumulated stdout + stderr since last read
   exitCode: number | null;
   exited: boolean;
   exitPromise: Promise<number>; // Resolves when process exits
@@ -689,12 +695,12 @@ interface SessionState {
   agentProcess: ChildProcess;
   connection: acp.ClientSideConnection;
   messages: Message[];
-  status: "initializing" | "ready" | "error" | "closed";
+  status: 'initializing' | 'ready' | 'error' | 'closed';
 
   // New fields for M1
   agentType: AgentType;
   projectDir: string;
-  worktree: WorktreeInfo | null;   // null for echo agent sessions
+  worktree: WorktreeInfo | null; // null for echo agent sessions
   terminals: Map<string, TerminalState>;
 }
 ```
@@ -758,22 +764,22 @@ async createSession(
 ```typescript
 function resolveAgentCommand(
   agentType: AgentType,
-  worktreePath: string | null
+  worktreePath: string | null,
 ): { cmd: string; args: string[]; env?: Record<string, string>; cwd?: string } {
-  if (agentType === "echo") {
+  if (agentType === 'echo') {
     return resolveEchoAgentCommand();
   }
   return resolveClaudeCodeCommand(worktreePath!);
 }
 
 function resolveClaudeCodeCommand(worktreePath: string) {
-  const require = createRequire(app.getAppPath() + "/");
+  const require = createRequire(app.getAppPath() + '/');
   // TODO: Update path based on Phase 2 discovery
-  const binPath = require.resolve("@zed-industries/claude-agent-acp/bin");
+  const binPath = require.resolve('@zed-industries/claude-agent-acp/bin');
   return {
     cmd: process.execPath,
     args: [binPath],
-    env: { ELECTRON_RUN_AS_NODE: "1" },
+    env: { ELECTRON_RUN_AS_NODE: '1' },
     cwd: worktreePath,
   };
 }
@@ -801,11 +807,11 @@ Where `resolveFilePath` normalizes the URI/path:
 ```typescript
 function resolveFilePath(uri: string, cwd: string): string {
   // Handle file:// URIs
-  if (uri.startsWith("file://")) {
+  if (uri.startsWith('file://')) {
     return new URL(uri).pathname;
   }
   // Handle relative paths
-  if (!uri.startsWith("/")) {
+  if (!uri.startsWith('/')) {
     return join(cwd, uri);
   }
   // Absolute path — use as-is
@@ -934,12 +940,12 @@ Wire the new session manager capabilities into the renderer through the IPC brid
 - [ ] Add handler in `src/main/index.ts`
 
 ```typescript
-import { dialog } from "electron";
+import { dialog } from 'electron';
 
-ipcMain.handle("dialog:selectDirectory", async () => {
+ipcMain.handle('dialog:selectDirectory', async () => {
   const result = await dialog.showOpenDialog(mainWindow!, {
-    properties: ["openDirectory"],
-    title: "Select project directory",
+    properties: ['openDirectory'],
+    title: 'Select project directory',
   });
   if (result.canceled || result.filePaths.length === 0) return null;
   return result.filePaths[0];
@@ -951,17 +957,13 @@ ipcMain.handle("dialog:selectDirectory", async () => {
 - [ ] Modify the IPC handler to pass through `projectDir` and `agentType`
 
 ```typescript
-ipcMain.handle(
-  "sessions:create",
-  (_e, projectDir: unknown, agentType: unknown) => {
-    if (typeof projectDir !== "string") {
-      throw new Error("Invalid argument: projectDir must be a string");
-    }
-    const validAgentType =
-      agentType === "echo" ? "echo" : "claude-code";
-    return sessionManager.createSession(projectDir, validAgentType);
+ipcMain.handle('sessions:create', (_e, projectDir: unknown, agentType: unknown) => {
+  if (typeof projectDir !== 'string') {
+    throw new Error('Invalid argument: projectDir must be a string');
   }
-);
+  const validAgentType = agentType === 'echo' ? 'echo' : 'claude-code';
+  return sessionManager.createSession(projectDir, validAgentType);
+});
 ```
 
 ### 5.3 Update preload bridge
@@ -969,24 +971,23 @@ ipcMain.handle(
 - [ ] Add `dialog.selectDirectory` and update `sessions.create` signature
 
 ```typescript
-contextBridge.exposeInMainWorld("glitterball", {
+contextBridge.exposeInMainWorld('glitterball', {
   sessions: {
-    list: () => ipcRenderer.invoke("sessions:list"),
+    list: () => ipcRenderer.invoke('sessions:list'),
     create: (projectDir: string, agentType?: string) =>
-      ipcRenderer.invoke("sessions:create", projectDir, agentType),
+      ipcRenderer.invoke('sessions:create', projectDir, agentType),
     sendMessage: (sessionId: string, text: string) =>
-      ipcRenderer.invoke("sessions:sendMessage", sessionId, text),
-    closeSession: (sessionId: string) =>
-      ipcRenderer.invoke("sessions:close", sessionId),
+      ipcRenderer.invoke('sessions:sendMessage', sessionId, text),
+    closeSession: (sessionId: string) => ipcRenderer.invoke('sessions:close', sessionId),
     onUpdate: (callback: (update: unknown) => void) => {
       const handler = (_event: Electron.IpcRendererEvent, update: unknown): void =>
         callback(update);
-      ipcRenderer.on("session-update", handler);
-      return () => ipcRenderer.removeListener("session-update", handler);
+      ipcRenderer.on('session-update', handler);
+      return () => ipcRenderer.removeListener('session-update', handler);
     },
   },
   dialog: {
-    selectDirectory: () => ipcRenderer.invoke("dialog:selectDirectory"),
+    selectDirectory: () => ipcRenderer.invoke('dialog:selectDirectory'),
   },
 });
 ```
@@ -998,7 +999,7 @@ contextBridge.exposeInMainWorld("glitterball", {
 ```typescript
 /// <reference types="vite/client" />
 
-import type { AgentType, SessionSummary, SessionUpdate } from "../../main/types";
+import type { AgentType, SessionSummary, SessionUpdate } from '../../main/types';
 
 interface GlitterballAPI {
   sessions: {
@@ -1028,10 +1029,8 @@ declare global {
 
 ```typescript
 // In SessionList, per session entry:
-const label = session.projectDir
-  ? session.projectDir.split("/").pop()
-  : `Session`;
-const agentLabel = session.agentType === "echo" ? " (echo)" : "";
+const label = session.projectDir ? session.projectDir.split('/').pop() : `Session`;
+const agentLabel = session.agentType === 'echo' ? ' (echo)' : '';
 // Render: <span>{label}{agentLabel}</span>
 ```
 
@@ -1049,7 +1048,7 @@ async function handleCreateSession() {
     setSessions((prev) => [...prev, session]);
     setActiveSessionId(session.id);
   } catch (err) {
-    console.error("Failed to create session:", err);
+    console.error('Failed to create session:', err);
     // TODO: show error in UI (e.g., "Not a git repository")
   }
 }
@@ -1131,11 +1130,11 @@ case "plan-update":
 ```typescript
 export interface Message {
   id: string;
-  role: "user" | "agent";
+  role: 'user' | 'agent';
   text: string;
   timestamp: number;
   streaming?: boolean;
-  toolCalls?: ToolCallInfo[];  // New in M1
+  toolCalls?: ToolCallInfo[]; // New in M1
 }
 ```
 
@@ -1163,16 +1162,16 @@ export interface Message {
 - [ ] Parse stderr output from the agent process on early exit to surface the actual error message
 
 ```typescript
-agentProcess.on("exit", (code) => {
-  if (session.status === "initializing" && code !== 0) {
+agentProcess.on('exit', (code) => {
+  if (session.status === 'initializing' && code !== 0) {
     // Agent died during startup — likely auth or config issue
     const stderr = collectedStderr; // Captured from stderr stream
-    session.status = "error";
+    session.status = 'error';
     session.errorMessage = stderr || `Agent exited with code ${code}`;
-    this.emit("session-update", {
+    this.emit('session-update', {
       sessionId: id,
-      type: "status-change",
-      status: "error",
+      type: 'status-change',
+      status: 'error',
       error: session.errorMessage,
     });
   }
@@ -1267,14 +1266,14 @@ Run through this manually before considering M1 complete:
 
 ## Sequencing Summary
 
-| Phase | Description | Depends On | Key Risk |
-|-------|-------------|------------|----------|
-| 1 | Worktree manager | — | Git edge cases (submodules, dirty state) |
-| 2 | Claude Code agent discovery | Phase 1 (for worktree CWD) | **Highest risk** — first contact with `claude-agent-acp` |
-| 3 | Terminal management | Phase 2 (to know terminal semantics) | PTY requirement, command execution model |
-| 4 | Session manager integration | Phase 1, 2, 3 | Wiring complexity, type alignment |
-| 5 | IPC and UI updates | Phase 4 | Directory picker UX, tool call rendering |
-| 6 | Edge cases and polish | Phase 5 | Cleanup reliability, error surface area |
+| Phase | Description                 | Depends On                           | Key Risk                                                 |
+| ----- | --------------------------- | ------------------------------------ | -------------------------------------------------------- |
+| 1     | Worktree manager            | —                                    | Git edge cases (submodules, dirty state)                 |
+| 2     | Claude Code agent discovery | Phase 1 (for worktree CWD)           | **Highest risk** — first contact with `claude-agent-acp` |
+| 3     | Terminal management         | Phase 2 (to know terminal semantics) | PTY requirement, command execution model                 |
+| 4     | Session manager integration | Phase 1, 2, 3                        | Wiring complexity, type alignment                        |
+| 5     | IPC and UI updates          | Phase 4                              | Directory picker UX, tool call rendering                 |
+| 6     | Edge cases and polish       | Phase 5                              | Cleanup reliability, error surface area                  |
 
 **The highest-risk phase is 2** (Claude Code agent discovery). Everything in Phases 3-6 depends on what we learn there. If the `claude-agent-acp` package works differently than expected — different spawn mechanism, different Client method requirements, different terminal model — we'll need to adjust the design before proceeding. Phase 2's standalone test script is specifically designed to absorb this risk before we modify the session manager.
 

--- a/docs/history/live-agent-integration/sdk-deviations.md
+++ b/docs/history/live-agent-integration/sdk-deviations.md
@@ -10,7 +10,7 @@ Discovered during Phase 2 of Milestone 1 against `@zed-industries/claude-agent-a
 
 The `sessionUpdate` notifications with `sessionUpdate: "tool_call"` and `"tool_call_update"` report tool execution status and results, but the actual execution has already happened by the time the client sees the update.
 
-**Impact:** Phase 3 (terminal management) as designed is unnecessary for basic operation. The client-side terminal and file methods are optional capabilities that Claude Code *can* use but doesn't *need* to use — it has its own implementations.
+**Impact:** Phase 3 (terminal management) as designed is unnecessary for basic operation. The client-side terminal and file methods are optional capabilities that Claude Code _can_ use but doesn't _need_ to use — it has its own implementations.
 
 **For Milestone 2 (sandboxing):** This is actually good news. Since Claude Code spawns its own subprocesses, all child processes inherit the Seatbelt sandbox. We don't need to intercept tool execution at the ACP level — the OS sandbox handles it.
 
@@ -57,6 +57,7 @@ Also includes optional `line` (1-based start line) and `limit` (max lines to rea
 **Plan assumed:** `clientCapabilities: {}`
 
 **Actual:** Capabilities have explicit flags:
+
 ```typescript
 clientCapabilities: {
   terminal: true,                                    // enables terminal methods
@@ -72,13 +73,13 @@ Without these flags, the agent won't call the corresponding Client methods. In p
 
 **Actual:** Claude Code sends several update variants:
 
-| `sessionUpdate` | When | Content |
-|-----------------|------|---------|
-| `available_commands_update` | After session creation | List of available slash commands |
-| `tool_call` | Tool invocation starts | Tool name, status=pending |
-| `tool_call_update` | Tool progress/completion | Input, output, status transitions |
-| `agent_message_chunk` | Text streaming | Text content |
-| `usage_update` | After prompt completes | Token usage and cost |
+| `sessionUpdate`             | When                     | Content                           |
+| --------------------------- | ------------------------ | --------------------------------- |
+| `available_commands_update` | After session creation   | List of available slash commands  |
+| `tool_call`                 | Tool invocation starts   | Tool name, status=pending         |
+| `tool_call_update`          | Tool progress/completion | Input, output, status transitions |
+| `agent_message_chunk`       | Text streaming           | Text content                      |
+| `usage_update`              | After prompt completes   | Token usage and cost              |
 
 The `tool_call` and `tool_call_update` notifications include `_meta.claudeCode.toolName` with the actual tool name (e.g., "Bash") and `_meta.claudeCode.toolResponse` with the tool's output.
 
@@ -87,6 +88,7 @@ The `tool_call` and `tool_call_update` notifications include `_meta.claudeCode.t
 **Resolved path:** `@zed-industries/claude-agent-acp/dist/index.js`
 
 The package's `bin` field maps `claude-agent-acp` to `dist/index.js`. It's a `#!/usr/bin/env node` script. The entry point:
+
 1. Loads managed settings
 2. Redirects `console.log` → `console.error` (stdout reserved for ACP)
 3. Calls `runAcp()` which sets up the `AgentSideConnection`

--- a/docs/history/network-boundary/design.md
+++ b/docs/history/network-boundary/design.md
@@ -12,23 +12,23 @@ After M7, the agent cannot bypass policy by using `curl`, `fetch`, `wget`, or an
 
 M6 closed most bypass paths by containerizing the agent: the real `gh` binary doesn't exist, hooks are mounted read-only, and the system gitconfig is tamper-resistant. But three gaps remain:
 
-| Gap | How the agent can exploit it today |
-|---|---|
-| Raw HTTP to GitHub API | `curl https://api.github.com/repos/.../pulls -X PUT` to merge a PR |
-| `--no-verify` on git push | Skips the pre-push hook entirely; git still pushes via HTTPS |
-| Node.js `fetch` / other HTTP clients | Any code the agent writes or runs can call any API |
+| Gap                                  | How the agent can exploit it today                                 |
+| ------------------------------------ | ------------------------------------------------------------------ |
+| Raw HTTP to GitHub API               | `curl https://api.github.com/repos/.../pulls -X PUT` to merge a PR |
+| `--no-verify` on git push            | Skips the pre-push hook entirely; git still pushes via HTTPS       |
+| Node.js `fetch` / other HTTP clients | Any code the agent writes or runs can call any API                 |
 
 All three are HTTP-level operations. A proxy that sits between the container and the internet can inspect and enforce policy on every request, regardless of which tool initiated it.
 
 ### Role Evolution After M7
 
-| Mechanism | Role before M7 | Role after M7 |
-|---|---|---|
-| `gh` shim | Security (best-effort in container) | UX (fast-reject + better error messages) |
-| Git hooks | Security (best-effort, read-only mount) | UX (better error messages) |
-| Network proxy | N/A | **Authoritative security boundary** |
-| Container filesystem | Filesystem isolation | Filesystem isolation (unchanged) |
-| ACP | Observability | Observability (unchanged) |
+| Mechanism            | Role before M7                          | Role after M7                            |
+| -------------------- | --------------------------------------- | ---------------------------------------- |
+| `gh` shim            | Security (best-effort in container)     | UX (fast-reject + better error messages) |
+| Git hooks            | Security (best-effort, read-only mount) | UX (better error messages)               |
+| Network proxy        | N/A                                     | **Authoritative security boundary**      |
+| Container filesystem | Filesystem isolation                    | Filesystem isolation (unchanged)         |
+| ACP                  | Observability                           | Observability (unchanged)                |
 
 ## Architecture Overview
 
@@ -122,9 +122,9 @@ export async function startProxy(config: ProxyConfig): Promise<ProxyHandle>;
 
 ```typescript
 export interface BouncerCA {
-  cert: string;  // PEM-encoded CA certificate
-  key: string;   // PEM-encoded CA private key
-  certPath: string;  // Path to cert file on disk
+  cert: string; // PEM-encoded CA certificate
+  key: string; // PEM-encoded CA private key
+  certPath: string; // Path to cert file on disk
 }
 
 /** Generate or load the Bouncer CA. */
@@ -134,10 +134,7 @@ export async function ensureCA(): Promise<BouncerCA>;
  * Generate a TLS certificate for a specific hostname,
  * signed by the Bouncer CA. Cached per hostname.
  */
-export function generateHostCert(
-  hostname: string,
-  ca: BouncerCA,
-): { cert: string; key: string };
+export function generateHostCert(hostname: string, ca: BouncerCA): { cert: string; key: string };
 ```
 
 **Implementation:** Use Node.js `crypto.generateKeyPairSync` + `crypto.X509Certificate` (Node 15+) or the `node-forge` package for X.509 certificate generation. The CA certificate has a long validity period (10 years); host certificates are short-lived (24 hours) and cached in memory.
@@ -211,22 +208,23 @@ This is added to the generated gitconfig in `generateGitconfig()`.
 
 ```typescript
 export type NetworkPolicy =
-  | { access: "full" }
-  | { access: "none" }
-  | { access: "filtered"; allowedDomains: string[]; inspectedDomains: string[] };
+  | { access: 'full' }
+  | { access: 'none' }
+  | { access: 'filtered'; allowedDomains: string[]; inspectedDomains: string[] };
 ```
 
 The existing `NetworkPolicy` type gains an `inspectedDomains` field for the `"filtered"` variant. `allowedDomains` controls which domains the proxy tunnels at all; `inspectedDomains` (a subset) controls which get TLS MITM for content inspection.
 
 **Template defaults:**
 
-| Template | `allowedDomains` | `inspectedDomains` |
-|---|---|---|
-| `standard-pr` | `github.com`, `api.github.com`, `uploads.github.com`, `registry.npmjs.org`, `crates.io`, `static.crates.io`, `index.crates.io`, `pypi.org`, `files.pythonhosted.org` | `api.github.com`, `github.com` |
-| `research-only` | `*` (all domains) | `api.github.com`, `github.com` |
-| `permissive` | `*` (all domains) | none (no MITM) |
+| Template        | `allowedDomains`                                                                                                                                                     | `inspectedDomains`             |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| `standard-pr`   | `github.com`, `api.github.com`, `uploads.github.com`, `registry.npmjs.org`, `crates.io`, `static.crates.io`, `index.crates.io`, `pypi.org`, `files.pythonhosted.org` | `api.github.com`, `github.com` |
+| `research-only` | `*` (all domains)                                                                                                                                                    | `api.github.com`, `github.com` |
+| `permissive`    | `*` (all domains)                                                                                                                                                    | none (no MITM)                 |
 
 **Domain matching rules:**
+
 - Exact match: `api.github.com` matches only `api.github.com`
 - Wildcard: `*.github.com` matches `api.github.com`, `uploads.github.com`, etc.
 - `*` matches all domains (used for `research-only` and `permissive` templates)
@@ -261,16 +259,16 @@ export function evaluateGitHubRequest(
 
 **REST API allowlist (reuses existing `parseApiEndpoint` logic):**
 
-| Pattern | Method | Decision |
-|---|---|---|
-| `/repos/{owner}/{repo}/pulls` | `GET` | Allow |
-| `/repos/{owner}/{repo}/pulls` | `POST` | Allow if `canCreatePr` (capture PR) |
-| `/repos/{owner}/{repo}/pulls/{n}` | `GET` | Allow |
-| `/repos/{owner}/{repo}/pulls/{n}` | `PATCH` | Allow if `n == ownedPrNumber` |
-| `/repos/{owner}/{repo}/issues` | `GET` | Allow |
-| `/repos/{owner}/{repo}/issues/{n}` | `GET` | Allow |
-| `/repos/{owner}/{repo}` | `GET` | Allow (repo metadata) |
-| Everything else | any | **Deny** |
+| Pattern                            | Method  | Decision                            |
+| ---------------------------------- | ------- | ----------------------------------- |
+| `/repos/{owner}/{repo}/pulls`      | `GET`   | Allow                               |
+| `/repos/{owner}/{repo}/pulls`      | `POST`  | Allow if `canCreatePr` (capture PR) |
+| `/repos/{owner}/{repo}/pulls/{n}`  | `GET`   | Allow                               |
+| `/repos/{owner}/{repo}/pulls/{n}`  | `PATCH` | Allow if `n == ownedPrNumber`       |
+| `/repos/{owner}/{repo}/issues`     | `GET`   | Allow                               |
+| `/repos/{owner}/{repo}/issues/{n}` | `GET`   | Allow                               |
+| `/repos/{owner}/{repo}`            | `GET`   | Allow (repo metadata)               |
+| Everything else                    | any     | **Deny**                            |
 
 Note that dangerous operations like `PUT /pulls/{n}/merge`, `DELETE` on any path, `POST /issues` (create issue), and `POST /graphql` are all denied implicitly — they simply aren't in the allowlist.
 
@@ -338,36 +336,35 @@ The proxy recognizes this pattern and applies git-specific policy enforcement.
 
 ```typescript
 export type NetworkPolicy =
-  | { access: "full" }
-  | { access: "none" }
-  | { access: "filtered"; allowedDomains: string[]; inspectedDomains: string[] };
+  | { access: 'full' }
+  | { access: 'none' }
+  | { access: 'filtered'; allowedDomains: string[]; inspectedDomains: string[] };
 ```
 
 **`standard-pr` template update:**
 
 ```typescript
 export const standardPrTemplate: PolicyTemplate = {
-  id: "standard-pr",
-  name: "Standard PR",
-  description: "Read-write worktree, network filtered to GitHub + package registries",
-  filesystem: { /* unchanged */ },
+  id: 'standard-pr',
+  name: 'Standard PR',
+  description: 'Read-write worktree, network filtered to GitHub + package registries',
+  filesystem: {
+    /* unchanged */
+  },
   network: {
-    access: "filtered",
+    access: 'filtered',
     allowedDomains: [
-      "github.com",
-      "api.github.com",
-      "uploads.github.com",
-      "registry.npmjs.org",
-      "crates.io",
-      "static.crates.io",
-      "index.crates.io",
-      "pypi.org",
-      "files.pythonhosted.org",
+      'github.com',
+      'api.github.com',
+      'uploads.github.com',
+      'registry.npmjs.org',
+      'crates.io',
+      'static.crates.io',
+      'index.crates.io',
+      'pypi.org',
+      'files.pythonhosted.org',
     ],
-    inspectedDomains: [
-      "api.github.com",
-      "github.com",
-    ],
+    inspectedDomains: ['api.github.com', 'github.com'],
   },
   // ... rest unchanged
 };
@@ -385,7 +382,7 @@ export interface ContainerConfig {
   workdir: string;
   mounts: ContainerMount[];
   env: Record<string, string>;
-  networkMode: "none" | "bridge" | "proxy";
+  networkMode: 'none' | 'bridge' | 'proxy';
   /** Docker network name (required when networkMode is "proxy") */
   networkName?: string;
 }
@@ -460,7 +457,7 @@ exec "$@"
 ```typescript
 mounts.push({
   hostPath: ca.certPath,
-  containerPath: "/usr/local/share/ca-certificates/bouncer/bouncer-ca.crt",
+  containerPath: '/usr/local/share/ca-certificates/bouncer/bouncer-ca.crt',
   readOnly: true,
 });
 ```
@@ -469,13 +466,13 @@ mounts.push({
 
 The proxy is only effective if the container's traffic goes through it. Since we use a standard bridge network (not `--internal` — see Phase 3 note), network-level blocking is not available. Instead, enforcement relies on proxy env vars, read-only config mounts, and the fact that all standard tooling (curl, git, npm, cargo, pip, Node.js) respects `HTTP_PROXY`/`HTTPS_PROXY`.
 
-| Attack | Mitigation |
-|---|---|
-| Direct IP connection (bypass proxy env vars) | Most tools respect proxy env vars; a determined agent could bypass, but this requires explicit low-level socket code — unlikely in normal agent workflows. Future hardening: iptables rules or `--internal` network with sidecar proxy container. |
-| DNS resolution to external IP | Standard tools resolve via the proxy when `HTTPS_PROXY` is set (CONNECT tunnel); direct DNS is available but connections without the proxy are unmonitored, not blocked |
-| Agent unsets `HTTP_PROXY` env vars | Env vars set at container start; agent can unset in child processes. Mitigated by read-only gitconfig with proxy setting, and by the fact that Claude Code itself respects env vars. |
-| Agent modifies `/etc/gitconfig` proxy setting | System gitconfig is mounted read-only |
-| Agent uses a SOCKS proxy or tunnel | Outbound connectivity is available on the bridge network; this is a known gap accepted for M7 scope |
+| Attack                                        | Mitigation                                                                                                                                                                                                                                        |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Direct IP connection (bypass proxy env vars)  | Most tools respect proxy env vars; a determined agent could bypass, but this requires explicit low-level socket code — unlikely in normal agent workflows. Future hardening: iptables rules or `--internal` network with sidecar proxy container. |
+| DNS resolution to external IP                 | Standard tools resolve via the proxy when `HTTPS_PROXY` is set (CONNECT tunnel); direct DNS is available but connections without the proxy are unmonitored, not blocked                                                                           |
+| Agent unsets `HTTP_PROXY` env vars            | Env vars set at container start; agent can unset in child processes. Mitigated by read-only gitconfig with proxy setting, and by the fact that Claude Code itself respects env vars.                                                              |
+| Agent modifies `/etc/gitconfig` proxy setting | System gitconfig is mounted read-only                                                                                                                                                                                                             |
+| Agent uses a SOCKS proxy or tunnel            | Outbound connectivity is available on the bridge network; this is a known gap accepted for M7 scope                                                                                                                                               |
 
 **Why not `--internal`?** Docker's `--internal` flag blocks all egress including DNS resolution of `host.docker.internal`, making the host-based proxy unreachable. An alternative architecture (sidecar proxy container on the same internal network) would restore network-level isolation but adds operational complexity. For M7, proxy-based enforcement is sufficient — the threat model assumes a non-adversarial agent that may be careless but is not actively trying to exfiltrate data.
 
@@ -498,11 +495,13 @@ The proxy is only effective if the container's traffic goes through it. Since we
 The `PolicyEvent.tool` type is extended to include `"proxy"`.
 
 **Logging levels:**
+
 - **Deny events:** Always logged via ACP (surfaced in the UI event log)
 - **Allow events for inspected domains:** Logged at debug level (available in session details)
 - **Allow events for tunneled (non-inspected) domains:** Not logged individually (too noisy); the CONNECT hostname is logged at trace level
 
 **UI additions:**
+
 - Proxy status indicator in session details (running/stopped/error)
 - Network policy badge: "Filtered" / "Full" / "None"
 - Proxy deny events appear in the sandbox event log alongside `gh` shim and git hook events
@@ -510,18 +509,21 @@ The `PolicyEvent.tool` type is extended to include `"proxy"`.
 ## Implementation Phases
 
 ### Phase A: Proxy Foundation
+
 1. Implement `src/main/proxy-tls.ts` — CA generation and host certificate minting
 2. Implement `src/main/proxy.ts` — HTTP proxy server with CONNECT tunneling and domain allowlist
 3. Unit tests: domain matching, CA generation, certificate signing
 4. Manual test: proxy a curl request through it, verify domain filtering
 
 ### Phase B: TLS Interception
+
 5. Add selective MITM for inspected domains (TLS termination + re-encryption)
 6. Implement dynamic host certificate generation (signed by Bouncer CA)
 7. Test: MITM'd request to api.github.com returns correct response
 8. Test: non-inspected domain is tunneled without MITM
 
 ### Phase C: Container Networking
+
 9. Implement `src/main/proxy-network.ts` — Docker network creation/cleanup
 10. Update `docker/agent.Dockerfile` with entrypoint for CA cert installation
 11. Update `ContainerConfig` type with `"proxy"` network mode
@@ -529,24 +531,28 @@ The `PolicyEvent.tool` type is extended to include `"proxy"`.
 13. Integration test: container routes traffic through proxy, direct egress blocked
 
 ### Phase D: GitHub Policy Engine Extraction
+
 14. Extract `evaluatePolicy`/`parseApiEndpoint` from `gh-shim.ts` into `src/main/github-policy-engine.ts`
 15. Update `gh-shim.ts` to import from the shared module
 16. Wire proxy request handler to call the shared policy engine
 17. Test: proxy enforces same policy decisions as `gh` shim
 
 ### Phase E: GitHub API Enforcement
+
 18. Implement REST API policy matching in proxy (method + path → allow/deny via allowlist)
 19. Implement PR capture from proxy response body
 20. Test: `POST /pulls` allowed and PR captured; `PUT /pulls/{n}/merge` denied
 21. Test: `POST /graphql` denied (not in allowlist); unknown endpoints denied
 
 ### Phase F: Git Smart HTTP Enforcement
+
 22. Implement `git-receive-pack` pkt-line parser
 23. Implement ref-update extraction and branch policy enforcement
 24. Test: push to allowed branch goes through; push to `main` blocked at proxy
 25. Test: `--no-verify` does NOT bypass the proxy (the whole point)
 
 ### Phase G: Session Manager Integration
+
 26. Update `createSession` to start proxy + create network before spawning container
 27. Update `closeSession` to stop proxy + remove network
 28. Update orphan cleanup for networks
@@ -554,6 +560,7 @@ The `PolicyEvent.tool` type is extended to include `"proxy"`.
 30. End-to-end test: full PR workflow through proxy
 
 ### Phase H: Policy Templates and UI
+
 31. Update `NetworkPolicy` type with `inspectedDomains`
 32. Update `standard-pr` template with domain allowlist
 33. Update `PolicyEvent.tool` to include `"proxy"`
@@ -562,33 +569,33 @@ The `PolicyEvent.tool` type is extended to include `"proxy"`.
 
 ## Files Changed
 
-| File | Change |
-|---|---|
-| `src/main/proxy.ts` | **New** — HTTP/HTTPS proxy server with domain filtering and GitHub policy enforcement |
-| `src/main/proxy-tls.ts` | **New** — CA generation, host certificate minting, certificate caching |
-| `src/main/proxy-network.ts` | **New** — Docker network creation/cleanup for proxy routing |
-| `src/main/github-policy-engine.ts` | **New** — shared policy evaluation logic (extracted from gh-shim.ts) |
-| `docker/entrypoint.sh` | **New** — container entrypoint that installs CA cert before running agent |
-| `docker/agent.Dockerfile` | **Modified** — add entrypoint, CA cert directory |
-| `src/main/gh-shim.ts` | **Modified** — import policy logic from shared module |
-| `src/main/types.ts` | **Modified** — `NetworkPolicy` gains `inspectedDomains`; `PolicyEvent.tool` gains `"proxy"`; `ContainerConfig.networkMode` gains `"proxy"` |
-| `src/main/policy-templates.ts` | **Modified** — `standard-pr` gets domain allowlist and filtered network |
-| `src/main/container.ts` | **Modified** — support `"proxy"` network mode (attach to named network instead of `--network bridge`) |
-| `src/main/policy-container.ts` | **Modified** — inject proxy env vars, CA cert mount, git proxy config into container config |
-| `src/main/session-manager.ts` | **Modified** — proxy lifecycle, network lifecycle, policy state sync from proxy |
-| `src/main/container-monitor.ts` | **Modified** — minor: proxy-related container events |
+| File                               | Change                                                                                                                                     |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `src/main/proxy.ts`                | **New** — HTTP/HTTPS proxy server with domain filtering and GitHub policy enforcement                                                      |
+| `src/main/proxy-tls.ts`            | **New** — CA generation, host certificate minting, certificate caching                                                                     |
+| `src/main/proxy-network.ts`        | **New** — Docker network creation/cleanup for proxy routing                                                                                |
+| `src/main/github-policy-engine.ts` | **New** — shared policy evaluation logic (extracted from gh-shim.ts)                                                                       |
+| `docker/entrypoint.sh`             | **New** — container entrypoint that installs CA cert before running agent                                                                  |
+| `docker/agent.Dockerfile`          | **Modified** — add entrypoint, CA cert directory                                                                                           |
+| `src/main/gh-shim.ts`              | **Modified** — import policy logic from shared module                                                                                      |
+| `src/main/types.ts`                | **Modified** — `NetworkPolicy` gains `inspectedDomains`; `PolicyEvent.tool` gains `"proxy"`; `ContainerConfig.networkMode` gains `"proxy"` |
+| `src/main/policy-templates.ts`     | **Modified** — `standard-pr` gets domain allowlist and filtered network                                                                    |
+| `src/main/container.ts`            | **Modified** — support `"proxy"` network mode (attach to named network instead of `--network bridge`)                                      |
+| `src/main/policy-container.ts`     | **Modified** — inject proxy env vars, CA cert mount, git proxy config into container config                                                |
+| `src/main/session-manager.ts`      | **Modified** — proxy lifecycle, network lifecycle, policy state sync from proxy                                                            |
+| `src/main/container-monitor.ts`    | **Modified** — minor: proxy-related container events                                                                                       |
 
 ## Risks and Mitigations
 
-| Risk | Likelihood | Impact | Mitigation |
-|---|---|---|---|
-| TLS interception breaks pinned certificates | Medium | Tools that pin GitHub's cert will reject proxy's cert | `NODE_EXTRA_CA_CERTS` + system trust store covers most tools; document known incompatibilities |
-| Proxy adds latency to every HTTP request | Low-Medium | Noticeable for high-frequency API calls (npm install) | Non-inspected domains are tunneled directly (no TLS termination overhead); proxy runs on localhost |
-| Git pkt-line parsing is incorrect or incomplete | Medium | Push allowed/denied incorrectly | Extensive test coverage against known git push payloads; fall back to deny on parse error |
-| REST allowlist too narrow for future use cases | Low | Agent can't perform legitimate API operations beyond the PR workflow | Allowlist is easy to extend per-template; `research-only` and `permissive` templates can use broader allowlists or bypass inspection |
-| Some HTTP clients ignore `HTTP_PROXY` | Low | Traffic bypasses proxy and reaches the internet unmonitored | Standard tools (curl, git, npm, cargo, pip, Node.js) all respect proxy env vars; iptables fallback or sidecar proxy if gaps found empirically |
-| Agent deliberately bypasses proxy env vars | Low | Unmonitored egress via direct socket connections | Accepted for M7 — threat model assumes non-adversarial agent; future hardening via iptables or sidecar proxy on `--internal` network |
-| Container startup latency increases (CA install + network setup) | Low | `update-ca-certificates` adds ~100ms; network creation adds ~200ms | Acceptable; CA install is one-time per container start |
+| Risk                                                             | Likelihood | Impact                                                               | Mitigation                                                                                                                                    |
+| ---------------------------------------------------------------- | ---------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| TLS interception breaks pinned certificates                      | Medium     | Tools that pin GitHub's cert will reject proxy's cert                | `NODE_EXTRA_CA_CERTS` + system trust store covers most tools; document known incompatibilities                                                |
+| Proxy adds latency to every HTTP request                         | Low-Medium | Noticeable for high-frequency API calls (npm install)                | Non-inspected domains are tunneled directly (no TLS termination overhead); proxy runs on localhost                                            |
+| Git pkt-line parsing is incorrect or incomplete                  | Medium     | Push allowed/denied incorrectly                                      | Extensive test coverage against known git push payloads; fall back to deny on parse error                                                     |
+| REST allowlist too narrow for future use cases                   | Low        | Agent can't perform legitimate API operations beyond the PR workflow | Allowlist is easy to extend per-template; `research-only` and `permissive` templates can use broader allowlists or bypass inspection          |
+| Some HTTP clients ignore `HTTP_PROXY`                            | Low        | Traffic bypasses proxy and reaches the internet unmonitored          | Standard tools (curl, git, npm, cargo, pip, Node.js) all respect proxy env vars; iptables fallback or sidecar proxy if gaps found empirically |
+| Agent deliberately bypasses proxy env vars                       | Low        | Unmonitored egress via direct socket connections                     | Accepted for M7 — threat model assumes non-adversarial agent; future hardening via iptables or sidecar proxy on `--internal` network          |
+| Container startup latency increases (CA install + network setup) | Low        | `update-ca-certificates` adds ~100ms; network creation adds ~200ms   | Acceptable; CA install is one-time per container start                                                                                        |
 
 ## Open Questions
 

--- a/docs/history/network-boundary/plan.md
+++ b/docs/history/network-boundary/plan.md
@@ -24,7 +24,7 @@ This plan breaks M7 into phases, each delivering a testable increment. The core 
   - [x] 3.3 Create `docker/entrypoint.sh`
   - [x] 3.4 Add `"proxy"` to `ContainerConfig.networkMode` and `buildDockerRunArgs()`
   - [x] 3.5 Test: container on session network routes traffic through proxy, proxy blocks denied domains
-- [x] **[Phase 4: GitHub Policy Engine Extraction](#phase-4-github-policy-engine-extraction)** *(parallel with Phases 1-3)*
+- [x] **[Phase 4: GitHub Policy Engine Extraction](#phase-4-github-policy-engine-extraction)** _(parallel with Phases 1-3)_
   - [x] 4.1 Create `github-policy-engine.ts` with `evaluateGitHubRequest()`
   - [x] 4.2 Extract `parseApiEndpoint()` and REST allowlist logic from `gh-shim.ts`
   - [x] 4.3 Update `gh-shim.ts` to import from shared module
@@ -51,10 +51,10 @@ This plan breaks M7 into phases, each delivering a testable increment. The core 
 - [x] **[Phase 8: Policy Templates, UI, and Validation](#phase-8-policy-templates-ui-and-validation)**
   - [x] 8.1 Update `NetworkPolicy` type with `inspectedDomains`
   - [x] 8.2 Update `standard-pr` template with domain allowlist
-  - [x] 8.3 Update `PolicyEvent.tool` to include `"proxy"` *(done in Phase 2)*
+  - [x] 8.3 Update `PolicyEvent.tool` to include `"proxy"` _(done in Phase 2)_
   - [x] 8.4 Update `policy-event-parser.ts` to parse `[bouncer:proxy]` lines
   - [x] 8.5 Add proxy status and network policy badges to session UI
-  - [x] 8.6 Full validation checklist *(covered by automated tests across Phases 1-7)*
+  - [x] 8.6 Full validation checklist _(covered by automated tests across Phases 1-7)_
   - [x] 8.7 Update `docs/roadmap.md` — mark M7 complete
 
 ---
@@ -66,15 +66,17 @@ This plan breaks M7 into phases, each delivering a testable increment. The core 
 ### New file: `src/main/proxy-tls.ts`
 
 **`BouncerCA` interface:**
+
 ```typescript
 export interface BouncerCA {
-  cert: string;      // PEM-encoded CA certificate
-  key: string;       // PEM-encoded CA private key
-  certPath: string;  // Path to cert file on disk (for container bind-mount)
+  cert: string; // PEM-encoded CA certificate
+  key: string; // PEM-encoded CA private key
+  certPath: string; // Path to cert file on disk (for container bind-mount)
 }
 ```
 
 **`ensureCA(): Promise<BouncerCA>`**
+
 - Compute CA directory: `join(app.getPath("userData"), "bouncer-ca")`
 - If `bouncer-ca.crt` and `bouncer-ca.key` exist, load and return them
 - Otherwise generate a new CA:
@@ -90,6 +92,7 @@ export interface BouncerCA {
 **Why `node-forge`**: Node's built-in `crypto` module can generate keys but has limited X.509 certificate construction support (no `crypto.createCertificate`). `node-forge` is a mature, well-maintained library specifically for this purpose. It adds ~500KB to the bundle. Alternative: shell out to `openssl` — simpler but creates a runtime dependency on the OpenSSL CLI being installed.
 
 **`generateHostCert(hostname, ca): { cert: string; key: string }`**
+
 - Check in-memory cache (`Map<string, { cert, key, expiresAt }>`)
 - If cached and not expired, return it
 - Otherwise generate:
@@ -106,6 +109,7 @@ export interface BouncerCA {
 ### Changes to `package.json`
 
 Add `node-forge` as a dependency:
+
 ```
 npm install node-forge
 npm install -D @types/node-forge
@@ -114,6 +118,7 @@ npm install -D @types/node-forge
 ### Testing
 
 Unit tests for `proxy-tls.ts`:
+
 - `ensureCA()` generates a valid CA cert (parse with `crypto.X509Certificate`, verify `ca` flag is true)
 - `ensureCA()` is idempotent — second call loads from disk, returns same cert
 - `generateHostCert("api.github.com", ca)` returns a cert signed by the CA
@@ -121,6 +126,7 @@ Unit tests for `proxy-tls.ts`:
 - Cache behavior: second call for same hostname returns cached cert; different hostname generates a new one
 
 ### Exit criteria
+
 - CA persists across app restarts (loaded from disk)
 - Host certificates form a valid TLS chain with the CA
 - Certificate generation is fast (<50ms per hostname)
@@ -142,14 +148,16 @@ Creates an `http.Server` that handles two types of requests:
 **1. CONNECT requests (HTTPS tunneling)**
 
 ```typescript
-server.on("connect", (req, clientSocket, head) => {
-  const [host, port] = req.url.split(":");
+server.on('connect', (req, clientSocket, head) => {
+  const [host, port] = req.url.split(':');
 
   if (!domainAllowed(host, config.allowedDomains)) {
-    clientSocket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
+    clientSocket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
     clientSocket.write(formatDenyMessage(host, config));
     clientSocket.destroy();
-    config.onPolicyEvent({ /* deny event */ });
+    config.onPolicyEvent({
+      /* deny event */
+    });
     return;
   }
 
@@ -161,7 +169,7 @@ server.on("connect", (req, clientSocket, head) => {
 
   // Tunnel path — connect directly to upstream
   const upstream = net.connect(parseInt(port), host, () => {
-    clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+    clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
     upstream.write(head);
     upstream.pipe(clientSocket);
     clientSocket.pipe(upstream);
@@ -172,7 +180,7 @@ server.on("connect", (req, clientSocket, head) => {
 **2. Plain HTTP requests**
 
 ```typescript
-server.on("request", (req, res) => {
+server.on('request', (req, res) => {
   const url = new URL(req.url);
   if (!domainAllowed(url.hostname, config.allowedDomains)) {
     res.writeHead(403);
@@ -187,6 +195,7 @@ server.on("request", (req, res) => {
 **3. TLS MITM handler (`handleMitm`)**
 
 When a CONNECT request targets an inspected domain:
+
 1. Tell the client the tunnel is established (`200 Connection Established`)
 2. Create a TLS server socket using `generateHostCert(host, config.ca)`:
    ```typescript
@@ -203,15 +212,16 @@ When a CONNECT request targets an inspected domain:
 
 **Implementation note on parsing MITM'd HTTP:** The simplest approach is to use `httpProxy` or manually pipe the decrypted stream. However, for policy enforcement we need to inspect the request before forwarding. Options:
 
-| Approach | Pros | Cons |
-|---|---|---|
-| **A: Full HTTP parse** — use `http.createServer` on the decrypted socket | Clean request/response API; can modify or reject before forwarding | Requires wrapping the TLS socket in a new HTTP server |
-| **B: Manual stream parse** — read headers, buffer body if needed | Lower overhead; minimal dependencies | Must handle chunked encoding, keep-alive, etc. |
-| **C: Use `http-mitm-proxy` or similar library** | Handles the hard parts (HTTP parsing, keep-alive, connection pooling) | External dependency; may not be maintained |
+| Approach                                                                 | Pros                                                                  | Cons                                                  |
+| ------------------------------------------------------------------------ | --------------------------------------------------------------------- | ----------------------------------------------------- |
+| **A: Full HTTP parse** — use `http.createServer` on the decrypted socket | Clean request/response API; can modify or reject before forwarding    | Requires wrapping the TLS socket in a new HTTP server |
+| **B: Manual stream parse** — read headers, buffer body if needed         | Lower overhead; minimal dependencies                                  | Must handle chunked encoding, keep-alive, etc.        |
+| **C: Use `http-mitm-proxy` or similar library**                          | Handles the hard parts (HTTP parsing, keep-alive, connection pooling) | External dependency; may not be maintained            |
 
 **Recommended: Approach A** — create an `http.Server` bound to the decrypted TLS socket. This gives us a standard `(req, res)` callback where we can inspect the request, call the policy engine, and either forward to upstream or return 403. Node's `http` module handles chunked encoding, keep-alive, and other HTTP details.
 
 **`domainMatches(hostname, pattern): boolean`**
+
 - `*` matches everything
 - `*.example.com` matches `foo.example.com`, `bar.example.com`, but not `example.com`
 - `example.com` matches only `example.com`
@@ -225,6 +235,7 @@ When a CONNECT request targets an inspected domain:
 ### Testing
 
 Unit tests:
+
 - `domainMatches`: exact, wildcard, `*`, no-match cases
 - `startProxy` + `curl --proxy http://localhost:{port}`:
   - Allowed domain: `curl --proxy ... http://httpbin.org/get` → 200
@@ -233,11 +244,13 @@ Unit tests:
   - CONNECT to denied domain: 403
 
 Integration test (requires CA from Phase 1):
+
 - Start proxy with MITM for `api.github.com`
 - `curl --proxy ... --cacert bouncer-ca.crt https://api.github.com/` → response returned (MITM'd but forwarded)
 - Verify the certificate presented to the client is signed by the Bouncer CA
 
 ### Exit criteria
+
 - Proxy correctly tunnels allowed domains
 - Proxy blocks denied domains with 403 and a descriptive message
 - MITM'd connections present a valid certificate chain (Bouncer CA → host cert)
@@ -252,27 +265,33 @@ Integration test (requires CA from Phase 1):
 ### New file: `src/main/proxy-network.ts`
 
 **`createSessionNetwork(sessionId): Promise<SessionNetwork>`**
+
 ```typescript
 const networkName = `bouncer-net-${sessionId}`;
-await execFileAsync("docker", [
-  "network", "create", networkName,
-  "--driver", "bridge",
+await execFileAsync('docker', [
+  'network',
+  'create',
+  networkName,
+  '--driver',
+  'bridge',
   // Note: we intentionally do NOT use --internal because it blocks
   // host.docker.internal resolution, making the host proxy unreachable.
   // The proxy is the enforcement layer instead.
-  "--label", "glitterball.managed=true",
-  "--label", `glitterball.sessionId=${sessionId}`,
+  '--label',
+  'glitterball.managed=true',
+  '--label',
+  `glitterball.sessionId=${sessionId}`,
 ]);
 return {
   networkName,
   async cleanup() {
-    await execFileAsync("docker", ["network", "rm", networkName])
-      .catch(() => {}); // idempotent
+    await execFileAsync('docker', ['network', 'rm', networkName]).catch(() => {}); // idempotent
   },
 };
 ```
 
 **`cleanupOrphanNetworks(activeSessionIds): Promise<void>`**
+
 - `docker network ls --filter label=glitterball.managed=true --format '{{.Name}}'`
 - For each network, extract session ID from the name (`bouncer-net-{sessionId}`)
 - If not in `activeSessionIds`, `docker network rm {name}`
@@ -318,38 +337,43 @@ exec "$@"
 ### Changes to `src/main/container.ts`
 
 Update `ContainerConfig.networkMode` type:
+
 ```typescript
-networkMode: "none" | "bridge" | "proxy";
+networkMode: 'none' | 'bridge' | 'proxy';
 ```
 
 Add optional `networkName` field:
+
 ```typescript
 networkName?: string;
 ```
 
 Update `buildDockerRunArgs`:
+
 ```typescript
-if (config.networkMode === "proxy" && config.networkName) {
-  args.push("--network", config.networkName);
+if (config.networkMode === 'proxy' && config.networkName) {
+  args.push('--network', config.networkName);
 } else {
-  args.push("--network", config.networkMode);
+  args.push('--network', config.networkMode);
 }
 ```
 
 ### Changes to `src/main/types.ts`
 
 Update `ContainerPolicy`:
+
 ```typescript
 export interface ContainerPolicy {
   image?: string;
   additionalMounts?: Array<{ hostPath: string; containerPath: string; readOnly: boolean }>;
-  networkMode?: "none" | "bridge" | "proxy";
+  networkMode?: 'none' | 'bridge' | 'proxy';
 }
 ```
 
 ### Testing
 
 Integration test (requires Docker/OrbStack):
+
 1. Generate CA (Phase 1)
 2. Start proxy on auto-assigned port (Phase 2)
 3. Create Docker bridge network
@@ -361,6 +385,7 @@ Integration test (requires Docker/OrbStack):
 7. Clean up network and container
 
 ### Exit criteria
+
 - Container can reach the internet through the proxy (env vars respected)
 - Proxy blocks denied domains with 403
 - CA certificate is trusted by curl, git, and Node.js inside the container
@@ -372,16 +397,18 @@ Integration test (requires Docker/OrbStack):
 
 **Goal**: Extract the policy evaluation logic from `gh-shim.ts` into a shared module used by both the shim and the proxy.
 
-*This phase has no dependency on Phases 1-3 and can be developed in parallel.*
+_This phase has no dependency on Phases 1-3 and can be developed in parallel._
 
 ### New file: `src/main/github-policy-engine.ts`
 
 Extract from `gh-shim.ts`:
+
 - `parseApiEndpoint()` — parses `/repos/{owner}/{repo}/...` URL paths
 - `ApiEndpointMatch` type
 - `expandPlaceholder()` helper
 
 Add new function:
+
 ```typescript
 /**
  * Evaluate a raw HTTP request against GitHub policy.
@@ -398,21 +425,22 @@ export function evaluateGitHubRequest(
 
   // Cross-repo check
   if (match.ownerRepo !== null && match.ownerRepo !== policy.repo) {
-    return { action: "deny", reason: `cross-repo access denied` };
+    return { action: 'deny', reason: `cross-repo access denied` };
   }
 
   // Default-deny allowlist
-  if (match.resource === "pulls") return evaluateApiPulls(match, policy);
-  if (match.resource === "issues") return evaluateApiIssues(match);
-  if (match.resource === "" && method === "GET") return { action: "allow" }; // repo metadata
+  if (match.resource === 'pulls') return evaluateApiPulls(match, policy);
+  if (match.resource === 'issues') return evaluateApiIssues(match);
+  if (match.resource === '' && method === 'GET') return { action: 'allow' }; // repo metadata
 
-  return { action: "deny", reason: `endpoint not in allowlist` };
+  return { action: 'deny', reason: `endpoint not in allowlist` };
 }
 ```
 
 The existing functions `evaluateApiPulls` and `evaluateApiIssues` are also moved here. The key difference from the shim's `evaluateApiPolicy` is that this function is **default-deny**: if the endpoint doesn't match a known pattern, it returns deny. The shim's version was also default-deny for the `api` subcommand, but the proxy function is the canonical allowlist for all HTTP traffic.
 
 Also add git push evaluation:
+
 ```typescript
 /**
  * Parse git pkt-line format to extract ref updates.
@@ -435,13 +463,14 @@ export function evaluateGitPush(
 ### Changes to `src/main/gh-shim.ts`
 
 Replace the extracted functions with imports:
+
 ```typescript
 import {
   parseApiEndpoint,
   evaluateApiPulls,
   evaluateApiIssues,
   type ApiEndpointMatch,
-} from "./github-policy-engine.js";
+} from './github-policy-engine.js';
 ```
 
 The shim's `evaluateApiPolicy` function now delegates to the shared module. The shim retains its `evaluatePolicy` function (which handles `gh` subcommand routing), since that's CLI-specific logic the proxy doesn't need.
@@ -469,6 +498,7 @@ The shim's `evaluateApiPolicy` function now delegates to the shared module. The 
   - Push to `refs/heads/main` with `allowedPushRefs: ["feature-branch"]` → denied
 
 ### Exit criteria
+
 - Shared module is the single source of truth for REST API policy evaluation
 - `gh` shim works identically after refactor (no behavioral changes)
 - esbuild bundle for the shim includes the shared module
@@ -491,23 +521,23 @@ async function handleMitmRequest(
   hostname: string,
   config: ProxyConfig,
 ): Promise<void> {
-  if (hostname === "api.github.com" && config.githubPolicy) {
+  if (hostname === 'api.github.com' && config.githubPolicy) {
     const decision = evaluateGitHubRequest(
-      req.method ?? "GET",
-      req.url ?? "/",
+      req.method ?? 'GET',
+      req.url ?? '/',
       config.githubPolicy,
     );
 
     config.onPolicyEvent({
       timestamp: Date.now(),
-      tool: "proxy",
+      tool: 'proxy',
       operation: `${req.method} ${req.url}`,
-      decision: decision.action === "deny" ? "deny" : "allow",
-      reason: decision.action === "deny" ? decision.reason : undefined,
+      decision: decision.action === 'deny' ? 'deny' : 'allow',
+      reason: decision.action === 'deny' ? decision.reason : undefined,
     });
 
-    if (decision.action === "deny") {
-      res.writeHead(403, { "Content-Type": "text/plain" });
+    if (decision.action === 'deny') {
+      res.writeHead(403, { 'Content-Type': 'text/plain' });
       res.end(`[bouncer:proxy] DENY ${req.method} ${req.url} — ${decision.reason}\n`);
       return;
     }
@@ -515,7 +545,7 @@ async function handleMitmRequest(
     // Forward to upstream and optionally capture response
     const upstreamRes = await forwardToUpstream(req, hostname);
 
-    if (decision.action === "allow-and-capture-pr") {
+    if (decision.action === 'allow-and-capture-pr') {
       // Read response body to capture PR number
       const body = await readResponseBody(upstreamRes);
       capturePrFromResponse(body, config);
@@ -533,21 +563,19 @@ async function handleMitmRequest(
 ```
 
 **PR capture from response:**
+
 ```typescript
-function capturePrFromResponse(
-  body: string,
-  config: ProxyConfig,
-): void {
+function capturePrFromResponse(body: string, config: ProxyConfig): void {
   try {
     const data = JSON.parse(body);
-    if (typeof data.number === "number" && config.githubPolicy) {
+    if (typeof data.number === 'number' && config.githubPolicy) {
       config.githubPolicy.canCreatePr = false;
       config.githubPolicy.ownedPrNumber = data.number;
       config.onPolicyEvent({
         timestamp: Date.now(),
-        tool: "proxy",
+        tool: 'proxy',
         operation: `captured PR #${data.number}`,
-        decision: "allow",
+        decision: 'allow',
       });
     }
   } catch {
@@ -561,6 +589,7 @@ function capturePrFromResponse(
 ### Testing
 
 Integration tests (require proxy + CA from Phases 1-2, plus a GitHub token):
+
 - `curl --proxy ... --cacert bouncer-ca.crt https://api.github.com/repos/{owner}/{repo}/pulls` → 200 (allowed)
 - `curl --proxy ... --cacert bouncer-ca.crt -X PUT https://api.github.com/repos/{owner}/{repo}/pulls/1/merge` → 403 (denied)
 - `curl --proxy ... --cacert bouncer-ca.crt -X POST https://api.github.com/graphql -d '{}'` → 403 (not in allowlist)
@@ -568,11 +597,13 @@ Integration tests (require proxy + CA from Phases 1-2, plus a GitHub token):
 - PR capture: `POST /pulls` → response body parsed, PR number extracted, policy state updated
 
 Unit tests (mocked upstream):
+
 - Verify policy decision is checked before forwarding
 - Verify 403 response includes `[bouncer:proxy]` prefix for policy event parsing
 - Verify PR capture updates the policy object
 
 ### Exit criteria
+
 - All REST allowlist entries enforced correctly
 - Unrecognized endpoints denied (default-deny)
 - PR creation captured from response body
@@ -595,11 +626,9 @@ async function handleGitHubMitmRequest(
   config: ProxyConfig,
 ): Promise<void> {
   // Match: POST /{owner}/{repo}.git/git-receive-pack
-  const pushMatch = req.url?.match(
-    /^\/([^/]+\/[^/]+)\.git\/git-receive-pack$/
-  );
+  const pushMatch = req.url?.match(/^\/([^/]+\/[^/]+)\.git\/git-receive-pack$/);
 
-  if (req.method === "POST" && pushMatch && config.githubPolicy) {
+  if (req.method === 'POST' && pushMatch && config.githubPolicy) {
     const repo = pushMatch[1];
 
     // Cross-repo check
@@ -617,9 +646,9 @@ async function handleGitHubMitmRequest(
     if (!result.allowed) {
       config.onPolicyEvent({
         timestamp: Date.now(),
-        tool: "proxy",
+        tool: 'proxy',
         operation: `git push ${result.deniedRef}`,
-        decision: "deny",
+        decision: 'deny',
         reason: `ref not in allowed list`,
       });
       res.writeHead(403);
@@ -628,13 +657,13 @@ async function handleGitHubMitmRequest(
     }
 
     // Forward the buffered body to upstream
-    const upstreamRes = await forwardToUpstreamWithBody(req, "github.com", body);
+    const upstreamRes = await forwardToUpstreamWithBody(req, 'github.com', body);
     pipeResponse(upstreamRes, res);
     return;
   }
 
   // All other github.com requests (ref advertisement, web UI, etc.) — forward
-  const upstreamRes = await forwardToUpstream(req, "github.com");
+  const upstreamRes = await forwardToUpstream(req, 'github.com');
   pipeResponse(upstreamRes, res);
 }
 ```
@@ -642,6 +671,7 @@ async function handleGitHubMitmRequest(
 ### `parseGitReceivePack` implementation details
 
 The git pkt-line format:
+
 - Each line starts with a 4-character hex length prefix (including the prefix itself)
 - `0000` is the flush packet (end of section)
 - The first ref update line may have capabilities appended after a NUL byte
@@ -657,21 +687,21 @@ export function parseGitReceivePack(body: Buffer): Array<{
   let offset = 0;
 
   while (offset < body.length) {
-    const lenHex = body.subarray(offset, offset + 4).toString("ascii");
+    const lenHex = body.subarray(offset, offset + 4).toString('ascii');
     const len = parseInt(lenHex, 16);
 
     if (len === 0) break; // flush packet
-    if (len < 4) break;   // invalid
+    if (len < 4) break; // invalid
 
-    const line = body.subarray(offset + 4, offset + len).toString("utf-8");
+    const line = body.subarray(offset + 4, offset + len).toString('utf-8');
     offset += len;
 
     // Strip capabilities (after NUL byte)
-    const nulIdx = line.indexOf("\0");
+    const nulIdx = line.indexOf('\0');
     const payload = nulIdx !== -1 ? line.substring(0, nulIdx) : line;
 
     // Parse: "<old-sha> <new-sha> <ref-name>\n"
-    const parts = payload.trim().split(" ");
+    const parts = payload.trim().split(' ');
     if (parts.length >= 3) {
       refs.push({
         oldSha: parts[0],
@@ -694,7 +724,7 @@ export function evaluateGitPush(
 ): { allowed: boolean; deniedRef?: string } {
   for (const ref of refs) {
     // Extract branch name from "refs/heads/branch-name"
-    const branch = ref.refName.replace(/^refs\/heads\//, "");
+    const branch = ref.refName.replace(/^refs\/heads\//, '');
     if (!policy.allowedPushRefs.includes(branch)) {
       return { allowed: false, deniedRef: ref.refName };
     }
@@ -706,6 +736,7 @@ export function evaluateGitPush(
 ### Testing
 
 Unit tests for `parseGitReceivePack`:
+
 - Construct a valid pkt-line buffer with known ref updates, verify parsing
 - Single ref update with capabilities on first line
 - Multiple ref updates
@@ -713,6 +744,7 @@ Unit tests for `parseGitReceivePack`:
 - Malformed input — returns empty array (fail closed)
 
 Integration test (requires proxy + container):
+
 1. Set up a test git repo with a GitHub remote
 2. Configure proxy with `allowedPushRefs: ["test-branch"]`
 3. From inside the container:
@@ -722,6 +754,7 @@ Integration test (requires proxy + container):
 4. Verify policy events logged for both allow and deny
 
 ### Exit criteria
+
 - Git push ref enforcement works at the network level
 - `--no-verify` does not bypass the proxy
 - Pkt-line parser handles real git push payloads correctly
@@ -736,6 +769,7 @@ Integration test (requires proxy + container):
 ### Changes to `src/main/session-manager.ts`
 
 **New fields on `SessionState`:**
+
 ```typescript
 interface SessionState {
   // ... existing fields ...
@@ -751,7 +785,7 @@ interface SessionState {
 let proxyHandle: ProxyHandle | null = null;
 let sessionNetwork: SessionNetwork | null = null;
 
-if (dockerAvailable && template?.network?.access === "filtered") {
+if (dockerAvailable && template?.network?.access === 'filtered') {
   const ca = await ensureCA();
 
   proxyHandle = await startProxy({
@@ -762,13 +796,13 @@ if (dockerAvailable && template?.network?.access === "filtered") {
     githubPolicy: session.githubPolicy,
     ca: { cert: ca.cert, key: ca.key },
     onPolicyEvent: (event) => {
-      this.emit("session-update", {
+      this.emit('session-update', {
         sessionId: id,
-        type: "policy-event",
+        type: 'policy-event',
         event,
       });
       // Persist policy state if PR was captured
-      if (session.githubPolicy && event.operation.startsWith("captured PR")) {
+      if (session.githubPolicy && event.operation.startsWith('captured PR')) {
         writePolicyState(id, session.githubPolicy).catch(() => {});
       }
     },
@@ -785,13 +819,13 @@ Then, when building the `ContainerConfig`:
 ```typescript
 // If proxy is active, use proxy network mode
 if (proxyHandle && sessionNetwork) {
-  containerConfig.networkMode = "proxy";
+  containerConfig.networkMode = 'proxy';
   containerConfig.networkName = sessionNetwork.networkName;
 
   // Add proxy env vars
   containerEnv.HTTP_PROXY = `http://host.docker.internal:${proxyHandle.port}`;
   containerEnv.HTTPS_PROXY = `http://host.docker.internal:${proxyHandle.port}`;
-  containerEnv.NO_PROXY = "localhost,127.0.0.1";
+  containerEnv.NO_PROXY = 'localhost,127.0.0.1';
 }
 ```
 
@@ -800,6 +834,7 @@ if (proxyHandle && sessionNetwork) {
 **`policyToContainerConfig` additions:**
 
 Add CA cert mount when proxy is active:
+
 ```typescript
 // New field in ContainerSessionContext:
 export interface ContainerSessionContext {
@@ -812,11 +847,12 @@ export interface ContainerSessionContext {
 ```
 
 In `policyToContainerConfig`:
+
 ```typescript
 if (ctx.caCertPath) {
   mounts.push({
     hostPath: ctx.caCertPath,
-    containerPath: "/usr/local/share/ca-certificates/bouncer/bouncer-ca.crt",
+    containerPath: '/usr/local/share/ca-certificates/bouncer/bouncer-ca.crt',
     readOnly: true,
   });
 }
@@ -825,17 +861,18 @@ if (ctx.caCertPath) {
 **`generateGitconfig` additions:**
 
 Add `[http] proxy` when a proxy port is provided:
+
 ```typescript
 export function generateGitconfig(opts: {
   hooksPath: string;
   credentialHelperPath: string;
   userName?: string;
   userEmail?: string;
-  proxyUrl?: string;  // New
+  proxyUrl?: string; // New
 }): string {
   // ... existing lines ...
   if (opts.proxyUrl) {
-    lines.push("[http]");
+    lines.push('[http]');
     lines.push(`    proxy = ${opts.proxyUrl}`);
   }
   // ...
@@ -857,6 +894,7 @@ if (session.sessionNetwork) {
 ### Changes to orphan cleanup
 
 In `startup` / `cleanupOrphans`:
+
 ```typescript
 await cleanupOrphanNetworks(activeSessionIds);
 ```
@@ -864,6 +902,7 @@ await cleanupOrphanNetworks(activeSessionIds);
 ### Testing
 
 End-to-end test — full PR workflow through proxy:
+
 1. Create a Claude Code session with `standard-pr` policy
 2. Agent edits files, commits, pushes to session branch → succeeds (git push through proxy, ref allowed)
 3. Agent runs `gh pr create` → succeeds (shim catches first for UX, REST API allowed by proxy)
@@ -874,6 +913,7 @@ End-to-end test — full PR workflow through proxy:
 8. Close session → proxy stopped, network removed, container removed
 
 ### Exit criteria
+
 - Proxy starts and stops with the session lifecycle
 - Container routes all traffic through the proxy
 - Policy events from the proxy appear in the UI event log
@@ -889,20 +929,22 @@ End-to-end test — full PR workflow through proxy:
 ### Changes to `src/main/types.ts`
 
 Update `NetworkPolicy`:
+
 ```typescript
 export type NetworkPolicy =
-  | { access: "full" }
-  | { access: "none" }
-  | { access: "filtered"; allowedDomains: string[]; inspectedDomains: string[] };
+  | { access: 'full' }
+  | { access: 'none' }
+  | { access: 'filtered'; allowedDomains: string[]; inspectedDomains: string[] };
 ```
 
 Update `PolicyEvent.tool`:
+
 ```typescript
 export interface PolicyEvent {
   timestamp: number;
-  tool: "gh" | "git" | "proxy";
+  tool: 'gh' | 'git' | 'proxy';
   operation: string;
-  decision: "allow" | "deny";
+  decision: 'allow' | 'deny';
   reason?: string;
 }
 ```
@@ -910,6 +952,7 @@ export interface PolicyEvent {
 ### Changes to `src/main/policy-templates.ts`
 
 Update `standardPrTemplate`:
+
 ```typescript
 network: {
   access: "filtered",
@@ -936,18 +979,21 @@ network: {
 ### Changes to `src/main/policy-event-parser.ts`
 
 Update the regex to match `[bouncer:proxy]`:
+
 ```typescript
 const POLICY_LINE_RE = /^\[bouncer:(gh|git|proxy)\] (ALLOW|DENY) (.+)$/;
 ```
 
 Update the tool type:
+
 ```typescript
-const tool = match[1] as "gh" | "git" | "proxy";
+const tool = match[1] as 'gh' | 'git' | 'proxy';
 ```
 
 ### UI changes
 
 **`SessionList.tsx`**: Add network policy badge next to the sandbox backend badge:
+
 - `"filtered"` → "Filtered Network" badge (with tooltip showing allowed domains)
 - `"full"` → "Full Network" badge
 - `"none"` → "No Network" badge
@@ -955,12 +1001,14 @@ const tool = match[1] as "gh" | "git" | "proxy";
 **`SandboxLog.tsx`**: Already handles `PolicyEvent` objects generically — proxy events appear automatically. Optionally, add an icon or color for `tool: "proxy"` events to distinguish them from `gh` shim and git hook events.
 
 **`ChatPanel.tsx` or session details**: Add proxy status line:
+
 - "Network: Filtered via proxy (port {N})" when proxy is active
 - "Network: Bridge (no proxy)" when proxy is not active
 
 ### Validation checklist
 
 **Proxy enforcement — REST API:**
+
 - [ ] `GET /repos/{owner}/{repo}/pulls` → allowed
 - [ ] `POST /repos/{owner}/{repo}/pulls` (with `canCreatePr`) → allowed, PR captured
 - [ ] `PATCH /repos/{owner}/{repo}/pulls/{ownedPr}` → allowed
@@ -974,26 +1022,31 @@ const tool = match[1] as "gh" | "git" | "proxy";
 - [ ] Unknown endpoint → denied
 
 **Proxy enforcement — git push:**
+
 - [ ] `git push origin {session-branch}` → allowed
 - [ ] `git push origin main` → denied by proxy
 - [ ] `git push --no-verify origin main` → denied by proxy (hook bypass doesn't help)
 - [ ] Push to different repo → denied
 
 **Proxy enforcement — domain filtering:**
+
 - [ ] `curl https://registry.npmjs.org/` (from container) → tunneled, succeeds
 - [ ] `curl https://evil.example.com/` (from container) → blocked by proxy (403 CONNECT)
 
 **Config integrity:**
+
 - [ ] Agent can't modify `/etc/gitconfig` proxy setting (read-only mount)
 - [ ] Proxy env vars set at container start and respected by standard tooling
 
 **Session lifecycle:**
+
 - [ ] Proxy starts with session, stops on close
 - [ ] Docker network created with session, removed on close
 - [ ] Orphan proxies/networks cleaned up on app restart
 - [ ] Safehouse fallback still works (no proxy, bridge network)
 
 **UX:**
+
 - [ ] `gh` shim denies with friendly error before proxy (fast-reject)
 - [ ] Git hook denies with friendly error before proxy (fast-reject)
 - [ ] Proxy deny events visible in sandbox event log
@@ -1007,6 +1060,7 @@ const tool = match[1] as "gh" | "git" | "proxy";
 - Verify all three policy templates work correctly with the new network infrastructure
 
 ### Exit criteria
+
 - All validation checklist items pass
 - Roadmap updated
 - No regressions in M6 functionality
@@ -1045,13 +1099,13 @@ Phase 4 (policy engine extraction) can be developed in parallel with Phases 1-3.
 
 After each phase merges, verify:
 
-| After Phase | Check |
-|---|---|
-| Phase 1 | CA generates, persists across restarts, host certs form valid chain |
-| Phase 2 | Proxy tunnels, blocks, and MITM's correctly; no resource leaks under concurrent connections |
-| Phase 3 | Container on session network routes traffic through proxy; proxy blocks denied domains; CA trusted by all tools in container |
-| Phase 4 | All existing `gh-shim` tests pass; esbuild bundle includes shared module |
-| Phase 5 | REST allowlist enforced at proxy; PR captured from response; cross-repo denied |
-| Phase 6 | Git push ref enforcement works; `--no-verify` does not bypass proxy |
-| Phase 7 | Full session lifecycle works with proxy; no orphan resources on crash |
-| Phase 8 | All validation items pass; no regressions |
+| After Phase | Check                                                                                                                        |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Phase 1     | CA generates, persists across restarts, host certs form valid chain                                                          |
+| Phase 2     | Proxy tunnels, blocks, and MITM's correctly; no resource leaks under concurrent connections                                  |
+| Phase 3     | Container on session network routes traffic through proxy; proxy blocks denied domains; CA trusted by all tools in container |
+| Phase 4     | All existing `gh-shim` tests pass; esbuild bundle includes shared module                                                     |
+| Phase 5     | REST allowlist enforced at proxy; PR captured from response; cross-repo denied                                               |
+| Phase 6     | Git push ref enforcement works; `--no-verify` does not bypass proxy                                                          |
+| Phase 7     | Full session lifecycle works with proxy; no orphan resources on crash                                                        |
+| Phase 8     | All validation items pass; no regressions                                                                                    |

--- a/docs/history/policy-templates/design.md
+++ b/docs/history/policy-templates/design.md
@@ -34,7 +34,7 @@ Milestone 2 ([findings](../../history/seatbelt-sandbox/findings.md)) validated t
 
 2. **Safehouse's flag system is the right abstraction layer.** The combination of `--workdir`, `--add-dirs`, `--add-dirs-ro`, `--env-pass`, `--enable`, and `--append-profile` gives us enough knobs to express meaningfully different policies without maintaining raw SBPL profiles.
 
-3. **Application-layer gaps exist but are out of scope.** Operations like `git push`, `git checkout main`, and `npm publish` are allowed by any OS-level sandbox that permits network access and git operations. These are Milestone 5 concerns — policy templates define *OS-level* boundaries only.
+3. **Application-layer gaps exist but are out of scope.** Operations like `git push`, `git checkout main`, and `npm publish` are allowed by any OS-level sandbox that permits network access and git operations. These are Milestone 5 concerns — policy templates define _OS-level_ boundaries only.
 
 4. **Network is the biggest differentiator between policies.** Safehouse allows full network by default. The most meaningful distinction between "standard PR work" and "permissive" is whether network access is restricted. Until Milestone 6 adds proxy-based domain filtering, network is binary: allowed or blocked via `--append-profile`.
 
@@ -46,7 +46,7 @@ These follow from the roadmap's [principles](../../roadmap.md#principles):
 
 - **Templates are boundaries, not action classifiers.** Each template defines a capability envelope. The agent operates freely within it. We don't inspect individual actions.
 - **Start small, iterate with data.** Three templates covering the most common workflows. Milestone 4 will validate coverage against real session data.
-- **Backend-agnostic policy definitions.** Templates describe *what* the agent can access, not *how* it's enforced. The same template should be expressible as safehouse flags today and as Dockerfile + bind mount configs tomorrow.
+- **Backend-agnostic policy definitions.** Templates describe _what_ the agent can access, not _how_ it's enforced. The same template should be expressible as safehouse flags today and as Dockerfile + bind mount configs tomorrow.
 - **Policy is configuration, not code.** Adding a template should require adding a data object to a registry, not wiring up new spawning logic.
 
 ---
@@ -111,15 +111,15 @@ Milestone 2 established: `SessionManager → defaultSandboxConfig() → buildSaf
 
 ### What Changes from Milestone 2
 
-| Component | M2 | M3 |
-|-----------|----|----|
-| Sandbox config | `defaultSandboxConfig()` — one hardcoded config | `policyToSandboxConfig(template, session)` — template-driven |
-| Session creation | `createSession(projectDir, agentType)` | `createSession(projectDir, agentType, policyId)` |
-| Session state | `sandboxConfig: SandboxConfig \| null` | Adds `policyId: string` |
-| Session summary | `sandboxed: boolean` | Adds `policyId: string \| null`, `policyName: string \| null` |
-| New session UI | Directory picker only | Directory picker + policy selector |
-| Session list | Shield badge for sandboxed | Policy name badge per session |
-| IPC | No policy awareness | `policies:list` handler, `policyId` in create call |
+| Component        | M2                                              | M3                                                            |
+| ---------------- | ----------------------------------------------- | ------------------------------------------------------------- |
+| Sandbox config   | `defaultSandboxConfig()` — one hardcoded config | `policyToSandboxConfig(template, session)` — template-driven  |
+| Session creation | `createSession(projectDir, agentType)`          | `createSession(projectDir, agentType, policyId)`              |
+| Session state    | `sandboxConfig: SandboxConfig \| null`          | Adds `policyId: string`                                       |
+| Session summary  | `sandboxed: boolean`                            | Adds `policyId: string \| null`, `policyName: string \| null` |
+| New session UI   | Directory picker only                           | Directory picker + policy selector                            |
+| Session list     | Shield badge for sandboxed                      | Policy name badge per session                                 |
+| IPC              | No policy awareness                             | `policies:list` handler, `policyId` in create call            |
 
 ---
 
@@ -171,7 +171,7 @@ export interface FilesystemPolicy {
    * - "read-write": Agent can read and write files in the worktree.
    * - "read-only": Agent can read but not modify files.
    */
-  worktreeAccess: "read-write" | "read-only";
+  worktreeAccess: 'read-write' | 'read-only';
 
   /**
    * Additional writable directories beyond the worktree.
@@ -192,7 +192,7 @@ export interface NetworkPolicy {
    * - "none": All network access blocked via --append-profile overlay.
    * - "filtered": Domain allowlist via proxy (Milestone 6 — not yet implemented).
    */
-  access: "full" | "none" | "filtered";
+  access: 'full' | 'none' | 'filtered';
 
   /**
    * Allowed domains when access is "filtered".
@@ -255,18 +255,21 @@ The default policy for typical coding work: implement a feature, fix a bug, writ
 ```
 
 **What it allows:**
+
 - Read and write files in the worktree
 - Run build tools, linters, test suites (via safehouse toolchain profiles)
 - Git operations (add, commit, branch) within the worktree
 - Read system binaries, libraries, toolchain caches
 
 **What it blocks:**
+
 - All network access (no `git push`, `npm install` from registry, web requests)
 - Writing outside the worktree (no modifying `~/.gitconfig`, other repos, etc.)
 
 **Practical implication:** The agent must work with dependencies already installed in the worktree (or installed during worktree setup). This is the right constraint for most PR implementation work where you don't want the agent reaching out to external services.
 
 **Open question for M3 iteration:** Should we pre-install `node_modules` during worktree creation? M2 findings showed the agent had to run `npm install` itself. With `standard-pr` blocking network, this won't work. Options:
+
 1. Copy `node_modules` from the source repo during `worktree create` (fast if source has them)
 2. Run `npm install` before applying sandbox (adds latency)
 3. Accept that `standard-pr` requires pre-installed deps and document this
@@ -304,15 +307,18 @@ For tasks where the agent should analyze code but not modify it: code review, ar
 ```
 
 **What it allows:**
+
 - Read all files in the worktree and standard system paths
 - Full network access (web browsing, API calls, package registry queries)
 - Read safehouse-granted paths (toolchain caches, git config, etc.)
 
 **What it blocks:**
+
 - Writing any files (worktree is mounted read-only)
 - No git commits, no file creation, no build artifact generation
 
 **Implementation note:** Since safehouse's `--add-dirs` grants read-write, we need a different approach for read-only worktree mounting. Two options:
+
 1. Use `--add-dirs-ro` instead of `--add-dirs` for the worktree path (preferred — no SBPL overlay needed)
 2. Use `--add-dirs` and append an SBPL deny overlay for writes
 
@@ -344,10 +350,12 @@ For trusted tasks that need both filesystem mutation and network access: setting
 ```
 
 **What it allows:**
+
 - Everything `standard-pr` allows, plus full network access
 - `git push`, `npm install`, web API calls, etc.
 
 **What it blocks:**
+
 - Writing outside the worktree (safehouse default)
 - Accessing paths not in safehouse's curated profiles
 
@@ -355,16 +363,16 @@ For trusted tasks that need both filesystem mutation and network access: setting
 
 ### Template Comparison Matrix
 
-| Capability | `standard-pr` | `research-only` | `permissive` |
-|-----------|:---:|:---:|:---:|
-| Read worktree files | Yes | Yes | Yes |
-| Write worktree files | Yes | No | Yes |
-| Run build/test tools | Yes | No | Yes |
-| Git commit (local) | Yes | No | Yes |
-| Git push | No | No | Yes |
-| npm install (from registry) | No | No | Yes |
-| Web access | No | Yes | Yes |
-| Write outside worktree | No | No | No |
+| Capability                  | `standard-pr` | `research-only` | `permissive` |
+| --------------------------- | :-----------: | :-------------: | :----------: |
+| Read worktree files         |      Yes      |       Yes       |     Yes      |
+| Write worktree files        |      Yes      |       No        |     Yes      |
+| Run build/test tools        |      Yes      |       No        |     Yes      |
+| Git commit (local)          |      Yes      |       No        |     Yes      |
+| Git push                    |      No       |       No        |     Yes      |
+| npm install (from registry) |      No       |       No        |     Yes      |
+| Web access                  |      No       |       Yes       |     Yes      |
+| Write outside worktree      |      No       |       No        |      No      |
 
 ---
 
@@ -375,7 +383,7 @@ For trusted tasks that need both filesystem mutation and network access: setting
 A simple registry that holds the built-in templates and provides lookup/listing for the session manager and IPC layer.
 
 ```typescript
-import type { PolicyTemplate, PolicyTemplateSummary } from "./types.js";
+import type { PolicyTemplate, PolicyTemplateSummary } from './types.js';
 
 const BUILT_IN_TEMPLATES: PolicyTemplate[] = [
   standardPrTemplate,
@@ -387,7 +395,7 @@ export class PolicyTemplateRegistry {
   private templates: Map<string, PolicyTemplate>;
 
   constructor() {
-    this.templates = new Map(BUILT_IN_TEMPLATES.map(t => [t.id, t]));
+    this.templates = new Map(BUILT_IN_TEMPLATES.map((t) => [t.id, t]));
   }
 
   /** Get a template by ID. Throws if not found. */
@@ -399,7 +407,7 @@ export class PolicyTemplateRegistry {
 
   /** List all available templates (summaries for UI). */
   list(): PolicyTemplateSummary[] {
-    return Array.from(this.templates.values()).map(t => ({
+    return Array.from(this.templates.values()).map((t) => ({
       id: t.id,
       name: t.name,
       description: t.description,
@@ -408,7 +416,7 @@ export class PolicyTemplateRegistry {
 
   /** Default template ID for new sessions. */
   get defaultId(): string {
-    return "standard-pr";
+    return 'standard-pr';
   }
 }
 ```
@@ -420,8 +428,8 @@ export class PolicyTemplateRegistry {
 Maps a `PolicyTemplate` + session context into a concrete `SandboxConfig`. This replaces the role of `defaultSandboxConfig()` as the source of sandbox configuration.
 
 ```typescript
-import type { PolicyTemplate } from "./types.js";
-import type { SandboxConfig } from "./sandbox.js";
+import type { PolicyTemplate } from './types.js';
+import type { SandboxConfig } from './sandbox.js';
 
 interface SessionContext {
   sessionId: string;
@@ -445,7 +453,7 @@ export function policyToSandboxConfig(
   const readOnlyDirs: string[] = [...(ctx.readOnlyDirs ?? [])];
 
   // Worktree access
-  if (template.filesystem.worktreeAccess === "read-write") {
+  if (template.filesystem.worktreeAccess === 'read-write') {
     writableDirs.push(ctx.worktreePath);
   } else {
     readOnlyDirs.push(ctx.worktreePath);
@@ -454,7 +462,7 @@ export function policyToSandboxConfig(
   // Git common dir (always writable when worktree is writable,
   // read-only when worktree is read-only)
   if (ctx.gitCommonDir) {
-    if (template.filesystem.worktreeAccess === "read-write") {
+    if (template.filesystem.worktreeAccess === 'read-write') {
       writableDirs.push(ctx.gitCommonDir);
     } else {
       readOnlyDirs.push(ctx.gitCommonDir);
@@ -467,18 +475,18 @@ export function policyToSandboxConfig(
 
   // Environment variables
   const BASE_ENV = [
-    "ANTHROPIC_API_KEY",
-    "NODE_OPTIONS",
-    "NODE_PATH",
-    "EDITOR",
-    "VISUAL",
-    "GIT_AUTHOR_NAME",
-    "GIT_AUTHOR_EMAIL",
-    "GIT_COMMITTER_NAME",
-    "GIT_COMMITTER_EMAIL",
+    'ANTHROPIC_API_KEY',
+    'NODE_OPTIONS',
+    'NODE_PATH',
+    'EDITOR',
+    'VISUAL',
+    'GIT_AUTHOR_NAME',
+    'GIT_AUTHOR_EMAIL',
+    'GIT_COMMITTER_NAME',
+    'GIT_COMMITTER_EMAIL',
   ];
   const envPassthrough = [
-    ...BASE_ENV.filter(v => !template.env.exclude.includes(v)),
+    ...BASE_ENV.filter((v) => !template.env.exclude.includes(v)),
     ...template.env.additional,
   ];
 
@@ -566,7 +574,7 @@ async createSession(
 ```typescript
 interface SessionState {
   // ... existing fields ...
-  policyId: string;          // NEW — which template was selected
+  policyId: string; // NEW — which template was selected
 }
 ```
 
@@ -575,8 +583,8 @@ interface SessionState {
 ```typescript
 export interface SessionSummary {
   // ... existing fields ...
-  policyId: string | null;    // NEW
-  policyName: string | null;  // NEW — human-readable for UI
+  policyId: string | null; // NEW
+  policyName: string | null; // NEW — human-readable for UI
 }
 ```
 
@@ -593,7 +601,7 @@ export interface SandboxConfig {
   readOnlyDirs: string[];
   envPassthrough: string[];
   policyOutputPath: string;
-  appendProfileContent?: string;  // NEW — SBPL content for --append-profile
+  appendProfileContent?: string; // NEW — SBPL content for --append-profile
 }
 ```
 
@@ -628,12 +636,12 @@ export interface SessionSummary {
 
 ```typescript
 // In main/index.ts
-ipcMain.handle("policies:list", () => {
+ipcMain.handle('policies:list', () => {
   return sessionManager.policyRegistry.list();
 });
 
 // Updated: createSession now accepts policyId
-ipcMain.handle("sessions:create", (_event, projectDir, agentType, policyId) => {
+ipcMain.handle('sessions:create', (_event, projectDir, agentType, policyId) => {
   return sessionManager.createSession(projectDir, agentType, policyId);
 });
 ```
@@ -686,6 +694,7 @@ Replace the current "click New Session → pick directory → session starts" fl
 ```
 
 **Component:** `NewSessionDialog.tsx` — a modal or inline panel with:
+
 - Directory picker (existing `dialog:selectDirectory` call)
 - Policy radio group (fetched via `policies:list` on mount)
 - Create button (calls `sessions:create` with selected directory and policy)
@@ -733,6 +742,7 @@ This is a tooltip or small popover, not a full panel. Enough to confirm what the
 Templates that include `appendProfile` content (like `standard-pr`'s network deny rule) need the SBPL content written to a temp file that safehouse can reference.
 
 **Lifecycle:**
+
 1. **Session creation:** `policyToSandboxConfig()` populates `appendProfileContent` on the `SandboxConfig`.
 2. **Before spawn:** If `appendProfileContent` is present, write it to `{POLICY_DIR}/{sessionId}-append.sb`.
 3. **Safehouse invocation:** `buildSafehouseArgs()` includes `--append-profile={path}`.
@@ -756,12 +766,14 @@ The most impactful policy difference is network access. Here's how the `standard
 This is appended to safehouse's base profile via `--append-profile`. Since SBPL profiles are additive (deny rules can be added on top of allow rules), this effectively blocks all network access regardless of what safehouse's base profile allows.
 
 **Verification approach:** After implementing, test that:
+
 - `curl https://example.com` fails with EPERM under `standard-pr`
 - `git push` fails under `standard-pr`
 - Both succeed under `permissive`
 - The sandbox monitor captures network-outbound violations
 
-**Edge case: localhost.** The network deny overlay blocks *all* network, including localhost. This could break:
+**Edge case: localhost.** The network deny overlay blocks _all_ network, including localhost. This could break:
+
 - ACP communication (but ACP uses stdio, not network — safe)
 - Any MCP servers running on localhost (if configured in the future)
 
@@ -800,6 +812,7 @@ The transition should be non-breaking:
 The `standard-pr` template blocks network access, but many coding tasks require installed dependencies. If the worktree doesn't have `node_modules` (or equivalent), the agent can't install them.
 
 **Options:**
+
 1. **Symlink or copy `node_modules` during worktree creation.** Fast if source repo has them. Could be a worktree manager enhancement.
 2. **Run `npm install` before applying sandbox.** Adds latency to session creation.
 3. **Accept the constraint.** Document that `standard-pr` assumes pre-installed deps. Users who need to install packages should use `permissive`.
@@ -808,7 +821,7 @@ The `standard-pr` template blocks network access, but many coding tasks require 
 
 ### SBPL append profile ordering
 
-Safehouse's `--append-profile` loads the custom SBPL rules *after* the base profile. We need to verify that deny rules in the append profile override allow rules in the base profile. SBPL evaluation is last-match-wins for same-specificity rules, so an explicit `(deny network-outbound)` should override an earlier `(allow network-outbound)`.
+Safehouse's `--append-profile` loads the custom SBPL rules _after_ the base profile. We need to verify that deny rules in the append profile override allow rules in the base profile. SBPL evaluation is last-match-wins for same-specificity rules, so an explicit `(deny network-outbound)` should override an earlier `(allow network-outbound)`.
 
 **Mitigation:** Test this empirically in the first implementation phase. If ordering is an issue, we may need to use `--append-profile` with a more specific deny rule.
 
@@ -821,6 +834,7 @@ The `research-only` template wants read-only worktree access. Safehouse's `--add
 ### Template extensibility for containers
 
 The `PolicyTemplate` type is designed to be backend-agnostic, but the `appendProfile` and `safehouseIntegrations` fields are safehouse-specific. When we migrate to containers:
+
 - `filesystem` maps to bind mounts and volume configurations
 - `network` maps to Docker network policies
 - `env` maps to container environment variables

--- a/docs/history/policy-templates/findings.md
+++ b/docs/history/policy-templates/findings.md
@@ -6,7 +6,7 @@ Phase 7 empirical validation revealed two key limitations of OS-level sandboxing
 
 1. **Network deny is incompatible with Claude Code.** SBPL deny rules are all-or-nothing — they block the agent's own Anthropic API traffic, making sessions non-functional. Domain-based filtering requires an application-layer proxy (Milestone 6).
 
-2. **Safehouse's `--enable=all-agents` grants broad temp directory access.** The agent profiles grant write access to temp directories (`/tmp`, `/var/folders/...`), which is where worktrees live. This means filesystem policies can't restrict writes *within* temp. Writes to paths outside the sandbox (e.g., home directory) are correctly blocked.
+2. **Safehouse's `--enable=all-agents` grants broad temp directory access.** The agent profiles grant write access to temp directories (`/tmp`, `/var/folders/...`), which is where worktrees live. This means filesystem policies can't restrict writes _within_ temp. Writes to paths outside the sandbox (e.g., home directory) are correctly blocked.
 
 The policy template system, registry, IPC layer, session manager integration, and UI all work end-to-end. The `research-only` template was updated to reflect what's actually enforceable: worktree-scoped writes (not read-only), with writes outside the sandbox blocked.
 
@@ -50,6 +50,7 @@ The policy template system, registry, IPC layer, session manager integration, an
 ### Network filtering requires Milestone 6
 
 SBPL deny rules are absolute. Meaningful network restriction requires an **application-layer proxy**:
+
 - SBPL blocks all network except localhost proxy ports
 - Proxy allows agent API traffic (e.g., `api.anthropic.com`)
 - Proxy enforces domain allowlists from the policy template
@@ -58,6 +59,7 @@ SBPL deny rules are absolute. Meaningful network restriction requires an **appli
 ### Filesystem differentiation is limited by safehouse's agent profiles
 
 Safehouse's `--enable=all-agents` grants write access to temp directories where worktrees live. To achieve true read-only worktree enforcement, we'd need either:
+
 - Worktrees in a non-temp location (complicates cleanup)
 - Custom safehouse profiles that don't grant temp broadly
 - Container-based sandboxing (Milestone roadmap discusses this migration)
@@ -67,6 +69,7 @@ For now, all three templates have the same effective filesystem behavior: rw wor
 ### What works today
 
 Despite the limitations above, the sandbox **does** provide meaningful protection:
+
 - Agent cannot write to arbitrary paths outside the worktree/temp (home directory, system files, etc.)
 - Agent cannot access other users' files
 - All child processes inherit sandbox constraints

--- a/docs/history/policy-templates/plan.md
+++ b/docs/history/policy-templates/plan.md
@@ -70,13 +70,13 @@ export interface PolicyTemplate {
 }
 
 export interface FilesystemPolicy {
-  worktreeAccess: "read-write" | "read-only";
+  worktreeAccess: 'read-write' | 'read-only';
   additionalWritableDirs: string[];
   additionalReadOnlyDirs: string[];
 }
 
 export interface NetworkPolicy {
-  access: "full" | "none" | "filtered";
+  access: 'full' | 'none' | 'filtered';
   allowedDomains?: string[];
 }
 
@@ -97,13 +97,13 @@ Also update `SessionSummary` to include policy info:
 ```typescript
 export interface SessionSummary {
   id: string;
-  status: "initializing" | "ready" | "error" | "closed";
+  status: 'initializing' | 'ready' | 'error' | 'closed';
   messageCount: number;
   agentType: AgentType;
   projectDir: string;
   sandboxed: boolean;
-  policyId: string | null;     // NEW
-  policyName: string | null;   // NEW
+  policyId: string | null; // NEW
+  policyName: string | null; // NEW
 }
 ```
 
@@ -113,29 +113,29 @@ Define the three built-in templates as exported constants. Separating template d
 
 ```typescript
 // src/main/policy-templates.ts
-import type { PolicyTemplate } from "./types.js";
+import type { PolicyTemplate } from './types.js';
 
 /**
  * Standard PR implementation: read-write worktree, no network.
  * The tightest practical boundary for offline coding tasks.
  */
 export const standardPrTemplate: PolicyTemplate = {
-  id: "standard-pr",
-  name: "Standard PR",
-  description: "Read-write worktree, standard toolchains, no network",
+  id: 'standard-pr',
+  name: 'Standard PR',
+  description: 'Read-write worktree, standard toolchains, no network',
   filesystem: {
-    worktreeAccess: "read-write",
+    worktreeAccess: 'read-write',
     additionalWritableDirs: [],
     additionalReadOnlyDirs: [],
   },
   network: {
-    access: "none",
+    access: 'none',
   },
   env: {
     additional: [],
     exclude: [],
   },
-  safehouseIntegrations: ["all-agents"],
+  safehouseIntegrations: ['all-agents'],
 };
 
 /**
@@ -143,22 +143,22 @@ export const standardPrTemplate: PolicyTemplate = {
  * For code review, analysis, and web research tasks.
  */
 export const researchOnlyTemplate: PolicyTemplate = {
-  id: "research-only",
-  name: "Research Only",
-  description: "Read-only filesystem, full network access",
+  id: 'research-only',
+  name: 'Research Only',
+  description: 'Read-only filesystem, full network access',
   filesystem: {
-    worktreeAccess: "read-only",
+    worktreeAccess: 'read-only',
     additionalWritableDirs: [],
     additionalReadOnlyDirs: [],
   },
   network: {
-    access: "full",
+    access: 'full',
   },
   env: {
     additional: [],
     exclude: [],
   },
-  safehouseIntegrations: ["all-agents"],
+  safehouseIntegrations: ['all-agents'],
 };
 
 /**
@@ -167,22 +167,22 @@ export const researchOnlyTemplate: PolicyTemplate = {
  * Equivalent to the M2 default safehouse configuration.
  */
 export const permissiveTemplate: PolicyTemplate = {
-  id: "permissive",
-  name: "Permissive",
-  description: "Read-write worktree, toolchains, full network access",
+  id: 'permissive',
+  name: 'Permissive',
+  description: 'Read-write worktree, toolchains, full network access',
   filesystem: {
-    worktreeAccess: "read-write",
+    worktreeAccess: 'read-write',
     additionalWritableDirs: [],
     additionalReadOnlyDirs: [],
   },
   network: {
-    access: "full",
+    access: 'full',
   },
   env: {
     additional: [],
     exclude: [],
   },
-  safehouseIntegrations: ["all-agents"],
+  safehouseIntegrations: ['all-agents'],
 };
 ```
 
@@ -190,12 +190,12 @@ export const permissiveTemplate: PolicyTemplate = {
 
 ```typescript
 // src/main/policy-registry.ts
-import type { PolicyTemplate, PolicyTemplateSummary } from "./types.js";
+import type { PolicyTemplate, PolicyTemplateSummary } from './types.js';
 import {
   standardPrTemplate,
   researchOnlyTemplate,
   permissiveTemplate,
-} from "./policy-templates.js";
+} from './policy-templates.js';
 
 const BUILT_IN_TEMPLATES: PolicyTemplate[] = [
   standardPrTemplate,
@@ -225,7 +225,7 @@ export class PolicyTemplateRegistry {
   }
 
   get defaultId(): string {
-    return "standard-pr";
+    return 'standard-pr';
   }
 }
 ```
@@ -249,12 +249,12 @@ The mapper function that replaces `defaultSandboxConfig()` as the source of sand
 
 ```typescript
 // src/main/policy-sandbox.ts
-import { join } from "node:path";
-import { tmpdir } from "node:os";
-import type { PolicyTemplate } from "./types.js";
-import type { SandboxConfig } from "./sandbox.js";
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { PolicyTemplate } from './types.js';
+import type { SandboxConfig } from './sandbox.js';
 
-const POLICY_DIR = join(tmpdir(), "glitterball-sandbox");
+const POLICY_DIR = join(tmpdir(), 'glitterball-sandbox');
 
 export interface SessionContext {
   sessionId: string;
@@ -264,15 +264,15 @@ export interface SessionContext {
 }
 
 const BASE_ENV = [
-  "ANTHROPIC_API_KEY",
-  "NODE_OPTIONS",
-  "NODE_PATH",
-  "EDITOR",
-  "VISUAL",
-  "GIT_AUTHOR_NAME",
-  "GIT_AUTHOR_EMAIL",
-  "GIT_COMMITTER_NAME",
-  "GIT_COMMITTER_EMAIL",
+  'ANTHROPIC_API_KEY',
+  'NODE_OPTIONS',
+  'NODE_PATH',
+  'EDITOR',
+  'VISUAL',
+  'GIT_AUTHOR_NAME',
+  'GIT_AUTHOR_EMAIL',
+  'GIT_COMMITTER_NAME',
+  'GIT_COMMITTER_EMAIL',
 ];
 
 export function policyToSandboxConfig(
@@ -283,7 +283,7 @@ export function policyToSandboxConfig(
   const readOnlyDirs: string[] = [...(ctx.readOnlyDirs ?? [])];
 
   // Worktree access mode
-  if (template.filesystem.worktreeAccess === "read-write") {
+  if (template.filesystem.worktreeAccess === 'read-write') {
     writableDirs.push(ctx.worktreePath);
   } else {
     readOnlyDirs.push(ctx.worktreePath);
@@ -291,7 +291,7 @@ export function policyToSandboxConfig(
 
   // Git common dir follows worktree access mode
   if (ctx.gitCommonDir) {
-    if (template.filesystem.worktreeAccess === "read-write") {
+    if (template.filesystem.worktreeAccess === 'read-write') {
       writableDirs.push(ctx.gitCommonDir);
     } else {
       readOnlyDirs.push(ctx.gitCommonDir);
@@ -312,11 +312,11 @@ export function policyToSandboxConfig(
   let appendProfileContent: string | undefined;
   const profileParts: string[] = [];
 
-  if (template.network.access === "none") {
+  if (template.network.access === 'none') {
     profileParts.push(
-      ";; Block all outbound network access.",
-      "(deny network-outbound)",
-      "(deny network-bind)",
+      ';; Block all outbound network access.',
+      '(deny network-outbound)',
+      '(deny network-bind)',
     );
   }
 
@@ -325,7 +325,7 @@ export function policyToSandboxConfig(
   }
 
   if (profileParts.length > 0) {
-    appendProfileContent = "(version 1)\n" + profileParts.join("\n") + "\n";
+    appendProfileContent = '(version 1)\n' + profileParts.join('\n') + '\n';
   }
 
   return {
@@ -352,53 +352,50 @@ export interface SandboxConfig {
   readOnlyDirs: string[];
   envPassthrough: string[];
   policyOutputPath: string;
-  appendProfileContent?: string;  // NEW
+  appendProfileContent?: string; // NEW
 }
 ```
 
 Update `buildSafehouseArgs()` to write the append profile to a file and pass `--append-profile`:
 
 ```typescript
-export function buildSafehouseArgs(
-  config: SandboxConfig,
-  command: string[],
-): string[] {
+export function buildSafehouseArgs(config: SandboxConfig, command: string[]): string[] {
   const args: string[] = [];
 
   args.push(`--output=${config.policyOutputPath}`);
-  args.push("--enable=all-agents");
+  args.push('--enable=all-agents');
   args.push(`--workdir=${config.workdir}`);
 
   if (config.writableDirs.length > 0) {
-    args.push(`--add-dirs=${config.writableDirs.join(":")}`);
+    args.push(`--add-dirs=${config.writableDirs.join(':')}`);
   }
   if (config.readOnlyDirs.length > 0) {
-    args.push(`--add-dirs-ro=${config.readOnlyDirs.join(":")}`);
+    args.push(`--add-dirs-ro=${config.readOnlyDirs.join(':')}`);
   }
   if (config.envPassthrough.length > 0) {
-    args.push(`--env-pass=${config.envPassthrough.join(",")}`);
+    args.push(`--env-pass=${config.envPassthrough.join(',')}`);
   }
 
   // NEW: append profile overlay
   if (config.appendProfileContent) {
-    const appendPath = config.policyOutputPath.replace(/\.sb$/, "-append.sb");
+    const appendPath = config.policyOutputPath.replace(/\.sb$/, '-append.sb');
     args.push(`--append-profile=${appendPath}`);
   }
 
-  args.push("--");
+  args.push('--');
   args.push(...command);
   return args;
 }
 ```
 
-**Important:** `buildSafehouseArgs()` only builds the arg list — it doesn't write files. The append profile file must be written *before* spawning safehouse. This write happens in the session manager (Phase 3) alongside the `ensurePolicyDir()` call.
+**Important:** `buildSafehouseArgs()` only builds the arg list — it doesn't write files. The append profile file must be written _before_ spawning safehouse. This write happens in the session manager (Phase 3) alongside the `ensurePolicyDir()` call.
 
 ### 2.3 Add append-profile file lifecycle helpers
 
 Add to `src/main/sandbox.ts`:
 
 ```typescript
-import { writeFile } from "node:fs/promises";
+import { writeFile } from 'node:fs/promises';
 
 /**
  * Write the append profile file if the config includes custom SBPL content.
@@ -406,15 +403,15 @@ import { writeFile } from "node:fs/promises";
  */
 export async function writeAppendProfile(config: SandboxConfig): Promise<void> {
   if (!config.appendProfileContent) return;
-  const appendPath = config.policyOutputPath.replace(/\.sb$/, "-append.sb");
-  await writeFile(appendPath, config.appendProfileContent, "utf-8");
+  const appendPath = config.policyOutputPath.replace(/\.sb$/, '-append.sb');
+  await writeFile(appendPath, config.appendProfileContent, 'utf-8');
 }
 
 /**
  * Clean up a session's policy file(s), including any append profile.
  */
 export async function cleanupPolicy(policyPath: string): Promise<void> {
-  const appendPath = policyPath.replace(/\.sb$/, "-append.sb");
+  const appendPath = policyPath.replace(/\.sb$/, '-append.sb');
   await rm(policyPath, { force: true }).catch(() => {});
   await rm(appendPath, { force: true }).catch(() => {});
 }
@@ -423,16 +420,14 @@ export async function cleanupPolicy(policyPath: string): Promise<void> {
 Update `cleanupOrphanPolicies()` to also clean `*-append.sb` files (already covered since it removes all `.sb` files matching session IDs — just ensure the `-append.sb` suffix is also caught):
 
 ```typescript
-export async function cleanupOrphanPolicies(
-  activeSessionIds: Set<string>,
-): Promise<void> {
-  const { readdir } = await import("node:fs/promises");
+export async function cleanupOrphanPolicies(activeSessionIds: Set<string>): Promise<void> {
+  const { readdir } = await import('node:fs/promises');
   try {
     const entries = await readdir(POLICY_DIR);
     for (const entry of entries) {
-      if (entry.endsWith(".sb")) {
+      if (entry.endsWith('.sb')) {
         // Extract session ID from both "uuid.sb" and "uuid-append.sb"
-        const sessionId = entry.replace(/-append\.sb$/, "").replace(/\.sb$/, "");
+        const sessionId = entry.replace(/-append\.sb$/, '').replace(/\.sb$/, '');
         if (!activeSessionIds.has(sessionId)) {
           await rm(join(POLICY_DIR, entry), { force: true });
         }
@@ -456,64 +451,72 @@ A standalone test script that exercises the mapping from templates to sandbox co
 //
 // Usage: npx tsx scripts/test-policy-sandbox.ts
 
-import { PolicyTemplateRegistry } from "../src/main/policy-registry.js";
-import { policyToSandboxConfig } from "../src/main/policy-sandbox.js";
-import { buildSafehouseArgs } from "../src/main/sandbox.js";
+import { PolicyTemplateRegistry } from '../src/main/policy-registry.js';
+import { policyToSandboxConfig } from '../src/main/policy-sandbox.js';
+import { buildSafehouseArgs } from '../src/main/sandbox.js';
 
 const registry = new PolicyTemplateRegistry();
 const ctx = {
-  sessionId: "test-session-id",
-  worktreePath: "/tmp/test-worktree",
-  gitCommonDir: "/Users/test/project/.git",
-  readOnlyDirs: ["/path/to/agent-pkg"],
+  sessionId: 'test-session-id',
+  worktreePath: '/tmp/test-worktree',
+  gitCommonDir: '/Users/test/project/.git',
+  readOnlyDirs: ['/path/to/agent-pkg'],
 };
 
-console.log("=== Policy Template → Sandbox Config Tests ===\n");
+console.log('=== Policy Template → Sandbox Config Tests ===\n');
 
 for (const summary of registry.list()) {
   const template = registry.get(summary.id);
   const config = policyToSandboxConfig(template, ctx);
-  const args = buildSafehouseArgs(config, ["node", "/path/to/agent.js"]);
+  const args = buildSafehouseArgs(config, ['node', '/path/to/agent.js']);
 
   console.log(`--- ${summary.id} (${summary.name}) ---`);
   console.log(`  Description: ${summary.description}`);
-  console.log(`  Writable dirs: ${config.writableDirs.join(", ") || "(none)"}`);
-  console.log(`  Read-only dirs: ${config.readOnlyDirs.join(", ") || "(none)"}`);
-  console.log(`  Env passthrough: ${config.envPassthrough.join(", ")}`);
-  console.log(`  Append profile: ${config.appendProfileContent ? "yes" : "no"}`);
+  console.log(`  Writable dirs: ${config.writableDirs.join(', ') || '(none)'}`);
+  console.log(`  Read-only dirs: ${config.readOnlyDirs.join(', ') || '(none)'}`);
+  console.log(`  Env passthrough: ${config.envPassthrough.join(', ')}`);
+  console.log(`  Append profile: ${config.appendProfileContent ? 'yes' : 'no'}`);
   if (config.appendProfileContent) {
-    console.log(`  Append profile content:\n${config.appendProfileContent.split("\n").map(l => "    " + l).join("\n")}`);
+    console.log(
+      `  Append profile content:\n${config.appendProfileContent
+        .split('\n')
+        .map((l) => '    ' + l)
+        .join('\n')}`,
+    );
   }
-  console.log(`  Safehouse args: safehouse ${args.join(" ")}`);
+  console.log(`  Safehouse args: safehouse ${args.join(' ')}`);
 
   // Assertions
-  const hasAppendProfile = args.some((a) => a.startsWith("--append-profile="));
+  const hasAppendProfile = args.some((a) => a.startsWith('--append-profile='));
   const hasWorktreeWritable = config.writableDirs.includes(ctx.worktreePath);
   const hasWorktreeReadOnly = config.readOnlyDirs.includes(ctx.worktreePath);
 
-  if (summary.id === "standard-pr") {
-    console.assert(hasWorktreeWritable, "standard-pr: worktree should be writable");
-    console.assert(!hasWorktreeReadOnly, "standard-pr: worktree should not be read-only");
-    console.assert(hasAppendProfile, "standard-pr: should have append profile (network deny)");
-    console.assert(config.appendProfileContent!.includes("deny network-outbound"),
-      "standard-pr: append profile should deny network");
-  } else if (summary.id === "research-only") {
-    console.assert(!hasWorktreeWritable, "research-only: worktree should not be writable");
-    console.assert(hasWorktreeReadOnly, "research-only: worktree should be read-only");
-    console.assert(!hasAppendProfile, "research-only: should not have append profile");
-  } else if (summary.id === "permissive") {
-    console.assert(hasWorktreeWritable, "permissive: worktree should be writable");
-    console.assert(!hasWorktreeReadOnly, "permissive: worktree should not be read-only");
-    console.assert(!hasAppendProfile, "permissive: should not have append profile");
+  if (summary.id === 'standard-pr') {
+    console.assert(hasWorktreeWritable, 'standard-pr: worktree should be writable');
+    console.assert(!hasWorktreeReadOnly, 'standard-pr: worktree should not be read-only');
+    console.assert(hasAppendProfile, 'standard-pr: should have append profile (network deny)');
+    console.assert(
+      config.appendProfileContent!.includes('deny network-outbound'),
+      'standard-pr: append profile should deny network',
+    );
+  } else if (summary.id === 'research-only') {
+    console.assert(!hasWorktreeWritable, 'research-only: worktree should not be writable');
+    console.assert(hasWorktreeReadOnly, 'research-only: worktree should be read-only');
+    console.assert(!hasAppendProfile, 'research-only: should not have append profile');
+  } else if (summary.id === 'permissive') {
+    console.assert(hasWorktreeWritable, 'permissive: worktree should be writable');
+    console.assert(!hasWorktreeReadOnly, 'permissive: worktree should not be read-only');
+    console.assert(!hasAppendProfile, 'permissive: should not have append profile');
   }
 
   console.log(`  ✓ Assertions passed\n`);
 }
 
-console.log("=== All tests passed ===");
+console.log('=== All tests passed ===');
 ```
 
 Add to `package.json`:
+
 ```json
 "test:policy-sandbox": "tsx scripts/test-policy-sandbox.ts"
 ```
@@ -538,15 +541,15 @@ Wire the policy system into the session manager, replacing the hardcoded `defaul
 
 ```typescript
 // In session-manager.ts
-import { PolicyTemplateRegistry } from "./policy-registry.js";
-import { policyToSandboxConfig, type SessionContext } from "./policy-sandbox.js";
-import { writeAppendProfile } from "./sandbox.js";
+import { PolicyTemplateRegistry } from './policy-registry.js';
+import { policyToSandboxConfig, type SessionContext } from './policy-sandbox.js';
+import { writeAppendProfile } from './sandbox.js';
 
 export class SessionManager {
   private sessions = new Map<string, SessionState>();
   private worktreeManager = new WorktreeManager();
   private safehouseWarningLogged = false;
-  readonly policyRegistry = new PolicyTemplateRegistry();  // NEW — public for IPC access
+  readonly policyRegistry = new PolicyTemplateRegistry(); // NEW — public for IPC access
   // ...
 }
 ```
@@ -614,7 +617,7 @@ Update `SessionState`:
 ```typescript
 interface SessionState {
   // ... existing fields ...
-  policyId: string | null;  // NEW
+  policyId: string | null; // NEW
 }
 ```
 
@@ -694,7 +697,7 @@ Expose the policy system to the renderer process.
 In `src/main/index.ts`, after the existing IPC handlers:
 
 ```typescript
-ipcMain.handle("policies:list", () => {
+ipcMain.handle('policies:list', () => {
   return sessionManager.policyRegistry.list();
 });
 ```
@@ -702,14 +705,17 @@ ipcMain.handle("policies:list", () => {
 ### 4.2 Update `sessions:create` handler to accept `policyId`
 
 ```typescript
-ipcMain.handle("sessions:create", (_e, projectDir: unknown, agentType: unknown, policyId: unknown) => {
-  if (typeof projectDir !== "string") {
-    throw new Error("Invalid argument: projectDir must be a string");
-  }
-  const validAgentType = agentType === "echo" ? "echo" as const : "claude-code" as const;
-  const validPolicyId = typeof policyId === "string" ? policyId : undefined;
-  return sessionManager.createSession(projectDir, validAgentType, validPolicyId);
-});
+ipcMain.handle(
+  'sessions:create',
+  (_e, projectDir: unknown, agentType: unknown, policyId: unknown) => {
+    if (typeof projectDir !== 'string') {
+      throw new Error('Invalid argument: projectDir must be a string');
+    }
+    const validAgentType = agentType === 'echo' ? ('echo' as const) : ('claude-code' as const);
+    const validPolicyId = typeof policyId === 'string' ? policyId : undefined;
+    return sessionManager.createSession(projectDir, validAgentType, validPolicyId);
+  },
+);
 ```
 
 ### 4.3 Update preload bridge
@@ -717,29 +723,32 @@ ipcMain.handle("sessions:create", (_e, projectDir: unknown, agentType: unknown, 
 In `src/preload/index.ts`:
 
 ```typescript
-contextBridge.exposeInMainWorld("glitterball", {
+contextBridge.exposeInMainWorld('glitterball', {
   sessions: {
-    list: () => ipcRenderer.invoke("sessions:list"),
-    create: (projectDir: string, agentType?: string, policyId?: string) =>  // UPDATED
-      ipcRenderer.invoke("sessions:create", projectDir, agentType, policyId),
+    list: () => ipcRenderer.invoke('sessions:list'),
+    create: (
+      projectDir: string,
+      agentType?: string,
+      policyId?: string, // UPDATED
+    ) => ipcRenderer.invoke('sessions:create', projectDir, agentType, policyId),
     sendMessage: (sessionId: string, text: string) =>
-      ipcRenderer.invoke("sessions:sendMessage", sessionId, text),
-    closeSession: (sessionId: string) =>
-      ipcRenderer.invoke("sessions:close", sessionId),
+      ipcRenderer.invoke('sessions:sendMessage', sessionId, text),
+    closeSession: (sessionId: string) => ipcRenderer.invoke('sessions:close', sessionId),
     getSandboxViolations: (sessionId: string) =>
-      ipcRenderer.invoke("sessions:getSandboxViolations", sessionId),
+      ipcRenderer.invoke('sessions:getSandboxViolations', sessionId),
     onUpdate: (callback: (update: unknown) => void) => {
       const handler = (_event: Electron.IpcRendererEvent, update: unknown): void =>
         callback(update);
-      ipcRenderer.on("session-update", handler);
-      return () => ipcRenderer.removeListener("session-update", handler);
+      ipcRenderer.on('session-update', handler);
+      return () => ipcRenderer.removeListener('session-update', handler);
     },
   },
-  policies: {                                                              // NEW
-    list: () => ipcRenderer.invoke("policies:list"),
+  policies: {
+    // NEW
+    list: () => ipcRenderer.invoke('policies:list'),
   },
   dialog: {
-    selectDirectory: () => ipcRenderer.invoke("dialog:selectDirectory"),
+    selectDirectory: () => ipcRenderer.invoke('dialog:selectDirectory'),
   },
 });
 ```
@@ -749,22 +758,23 @@ contextBridge.exposeInMainWorld("glitterball", {
 ```typescript
 import type {
   AgentType,
-  PolicyTemplateSummary,     // NEW
+  PolicyTemplateSummary, // NEW
   SandboxViolationInfo,
   SessionSummary,
   SessionUpdate,
-} from "../../main/types";
+} from '../../main/types';
 
 interface GlitterballAPI {
   sessions: {
     list(): Promise<SessionSummary[]>;
-    create(projectDir: string, agentType?: AgentType, policyId?: string): Promise<SessionSummary>;  // UPDATED
+    create(projectDir: string, agentType?: AgentType, policyId?: string): Promise<SessionSummary>; // UPDATED
     sendMessage(sessionId: string, text: string): Promise<void>;
     closeSession(sessionId: string): Promise<void>;
     getSandboxViolations(sessionId: string): Promise<SandboxViolationInfo[]>;
     onUpdate(callback: (update: SessionUpdate) => void): () => void;
   };
-  policies: {                                          // NEW
+  policies: {
+    // NEW
     list(): Promise<PolicyTemplateSummary[]>;
   };
   dialog: {
@@ -889,13 +899,18 @@ Replace the current shield emoji badge:
 
 ```tsx
 // Current (M2):
-{s.sandboxed && <span className="sandbox-badge">&#x1F6E1;</span>}
+{
+  s.sandboxed && <span className="sandbox-badge">&#x1F6E1;</span>;
+}
 
 // New (M3):
-{s.policyName && <span className="policy-badge">{s.policyName}</span>}
+{
+  s.policyName && <span className="policy-badge">{s.policyName}</span>;
+}
 ```
 
 Style the policy badge with a background color or border to distinguish it from the session label. Consider color-coding by policy type:
+
 - `standard-pr` → blue/neutral (restrictive but productive)
 - `research-only` → green (safe, read-only)
 - `permissive` → amber/yellow (wider access, use with care)
@@ -905,21 +920,21 @@ Style the policy badge with a background color or border to distinguish it from 
 When the user hovers over the policy badge, show a tooltip with the template's capability summary. Use the `title` attribute for a simple implementation, or a lightweight custom tooltip component if more structure is needed.
 
 Simple approach:
+
 ```tsx
-<span
-  className="policy-badge"
-  title={`${s.policyName}\n${policyDescription(s.policyId)}`}
->
+<span className="policy-badge" title={`${s.policyName}\n${policyDescription(s.policyId)}`}>
   {s.policyName}
 </span>
 ```
 
 Where `policyDescription()` returns a brief summary like:
+
 - "Filesystem: read-write | Network: blocked"
 - "Filesystem: read-only | Network: full"
 - "Filesystem: read-write | Network: full"
 
 To get the description, the session list can either:
+
 1. Use the `policyName` field already on `SessionSummary` (simple, no extra data needed)
 2. Fetch the full template list once and look up by `policyId` (richer, needed for tooltip)
 
@@ -1020,24 +1035,24 @@ Run these checks after all phases are complete:
 
 ### New files
 
-| File | Purpose |
-|------|---------|
-| `src/main/policy-templates.ts` | Three built-in policy template definitions |
-| `src/main/policy-registry.ts` | `PolicyTemplateRegistry` class for template lookup/listing |
-| `src/main/policy-sandbox.ts` | `policyToSandboxConfig()` mapper: template → safehouse config |
-| `src/renderer/src/components/NewSessionDialog.tsx` | New session dialog with policy selector |
-| `scripts/test-policy-sandbox.ts` | Test harness for policy → sandbox config mapping |
+| File                                               | Purpose                                                       |
+| -------------------------------------------------- | ------------------------------------------------------------- |
+| `src/main/policy-templates.ts`                     | Three built-in policy template definitions                    |
+| `src/main/policy-registry.ts`                      | `PolicyTemplateRegistry` class for template lookup/listing    |
+| `src/main/policy-sandbox.ts`                       | `policyToSandboxConfig()` mapper: template → safehouse config |
+| `src/renderer/src/components/NewSessionDialog.tsx` | New session dialog with policy selector                       |
+| `scripts/test-policy-sandbox.ts`                   | Test harness for policy → sandbox config mapping              |
 
 ### Modified files
 
-| File | Changes |
-|------|---------|
-| `src/main/types.ts` | Add `PolicyTemplate`, `FilesystemPolicy`, `NetworkPolicy`, `EnvPolicy`, `PolicyTemplateSummary`; extend `SessionSummary` with `policyId`/`policyName` |
-| `src/main/sandbox.ts` | Add `appendProfileContent` to `SandboxConfig`; add `writeAppendProfile()`; update `buildSafehouseArgs()` for `--append-profile`; update `cleanupPolicy()` and `cleanupOrphanPolicies()` for append files |
-| `src/main/session-manager.ts` | Add `policyRegistry` field; update `createSession()` to accept `policyId` and use `policyToSandboxConfig()`; add `policyId` to `SessionState`; update `summarize()` for policy fields |
-| `src/main/index.ts` | Add `policies:list` IPC handler; update `sessions:create` handler to accept `policyId` |
-| `src/preload/index.ts` | Add `policies` namespace; update `create()` signature with `policyId` |
-| `src/renderer/src/env.d.ts` | Add `policies` to `GlitterballAPI`; update `create()` type; import `PolicyTemplateSummary` |
-| `src/renderer/src/App.tsx` | Add `showNewSessionDialog` state; render `NewSessionDialog`; fetch policy templates on mount |
-| `src/renderer/src/components/SessionList.tsx` | Replace shield emoji badge with policy name badge; add tooltip |
-| `package.json` | Add `test:policy-sandbox` script |
+| File                                          | Changes                                                                                                                                                                                                  |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/main/types.ts`                           | Add `PolicyTemplate`, `FilesystemPolicy`, `NetworkPolicy`, `EnvPolicy`, `PolicyTemplateSummary`; extend `SessionSummary` with `policyId`/`policyName`                                                    |
+| `src/main/sandbox.ts`                         | Add `appendProfileContent` to `SandboxConfig`; add `writeAppendProfile()`; update `buildSafehouseArgs()` for `--append-profile`; update `cleanupPolicy()` and `cleanupOrphanPolicies()` for append files |
+| `src/main/session-manager.ts`                 | Add `policyRegistry` field; update `createSession()` to accept `policyId` and use `policyToSandboxConfig()`; add `policyId` to `SessionState`; update `summarize()` for policy fields                    |
+| `src/main/index.ts`                           | Add `policies:list` IPC handler; update `sessions:create` handler to accept `policyId`                                                                                                                   |
+| `src/preload/index.ts`                        | Add `policies` namespace; update `create()` signature with `policyId`                                                                                                                                    |
+| `src/renderer/src/env.d.ts`                   | Add `policies` to `GlitterballAPI`; update `create()` type; import `PolicyTemplateSummary`                                                                                                               |
+| `src/renderer/src/App.tsx`                    | Add `showNewSessionDialog` state; render `NewSessionDialog`; fetch policy templates on mount                                                                                                             |
+| `src/renderer/src/components/SessionList.tsx` | Replace shield emoji badge with policy name badge; add tooltip                                                                                                                                           |
+| `package.json`                                | Add `test:policy-sandbox` script                                                                                                                                                                         |

--- a/docs/history/seatbelt-sandbox/design.md
+++ b/docs/history/seatbelt-sandbox/design.md
@@ -74,20 +74,21 @@ Milestone 1 established the pipeline: `SessionManager → spawn(agent) → ACP o
 
 ### What Changes from Milestone 1
 
-| Component | M1 | M2 |
-|-----------|----|----|
-| Agent spawning | `spawn("node", [agentBin], { cwd: worktree })` | `spawn("safehouse", [...sandboxArgs, "--", "node", agentBin], { cwd: worktree })` via agent-safehouse |
-| Filesystem enforcement | None (agent has full access) | Seatbelt profile: deny-default, allow worktree read/write, allow system read-only |
-| Network enforcement | None | Deny all network (as a starting constraint; Milestone 6 adds proxy-based allowlisting) |
-| Violation detection | None | `SandboxMonitor` tails macOS unified log for `Sandbox` events |
-| UI | Chat only | Chat + sandbox event log panel |
-| Session state | No sandbox info | Adds `sandboxProfile` path and `sandboxPid` for log correlation |
+| Component              | M1                                             | M2                                                                                                    |
+| ---------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Agent spawning         | `spawn("node", [agentBin], { cwd: worktree })` | `spawn("safehouse", [...sandboxArgs, "--", "node", agentBin], { cwd: worktree })` via agent-safehouse |
+| Filesystem enforcement | None (agent has full access)                   | Seatbelt profile: deny-default, allow worktree read/write, allow system read-only                     |
+| Network enforcement    | None                                           | Deny all network (as a starting constraint; Milestone 6 adds proxy-based allowlisting)                |
+| Violation detection    | None                                           | `SandboxMonitor` tails macOS unified log for `Sandbox` events                                         |
+| UI                     | Chat only                                      | Chat + sandbox event log panel                                                                        |
+| Session state          | No sandbox info                                | Adds `sandboxProfile` path and `sandboxPid` for log correlation                                       |
 
 ### Key Architectural Insight: Claude Code Handles Tools Internally
 
 As discovered in Milestone 1 ([sdk-deviations.md](../history/live-agent-integration/sdk-deviations.md)), Claude Code executes its Bash, Read, Write, and Edit tools within the agent process itself. It does **not** delegate tool execution to the ACP client.
 
 This means:
+
 - **All tool execution inherits the sandbox.** When Claude Code runs `git commit` or `python3 script.py`, those child processes are spawned from within the sandboxed process tree and automatically inherit all Seatbelt constraints.
 - **We don't need ACP-level interception for OS-level policies.** The sandbox enforces the boundary regardless of what the agent does internally.
 - **ACP-level interception becomes relevant in Milestone 5+** for application-layer semantics (e.g., "don't push to main") that can't be expressed as filesystem or network rules.
@@ -107,6 +108,7 @@ Our session manager spawns `safehouse [...flags] -- node <agent-bin>` instead of
 ### Session-specific sandbox configuration
 
 Each session provides safehouse with:
+
 - `--workdir=<worktree>` — enables git root auto-detection and worktree handling
 - `--add-dirs=<worktree>` — grants read-write access to the session's worktree
 - `--add-dirs=<gitCommonDir>` — grants write access to the parent repo's `.git` (needed for git operations from linked worktrees)
@@ -142,6 +144,7 @@ The log stream approach is primary because it catches violations from all child 
 Rather than generating SBPL profiles directly, we delegate to **[agent-safehouse](https://agent-safehouse.dev)** — an open-source CLI tool that maintains curated, community-tested macOS Seatbelt profiles for agent sandboxing. This avoids duplicating the substantial work of enumerating system runtime paths, Mach IPC services, device nodes, toolchain caches, and agent-specific state directories.
 
 **What safehouse provides:**
+
 - System runtime permissions (binaries, libraries, Mach IPC, PTY, devices)
 - Toolchain-specific paths (Node.js, Rust, Python, etc.)
 - Agent-specific state directories (Claude Code, Cursor, etc.)
@@ -150,6 +153,7 @@ Rather than generating SBPL profiles directly, we delegate to **[agent-safehouse
 - Ongoing community maintenance as macOS and agent tooling evolve
 
 **What we provide on top:**
+
 - Session-specific writable paths (worktree, git common dir) via `--add-dirs`
 - Environment variable passthrough for ACP via `--env-pass`
 - Policy file lifecycle management (persist via `--output`, clean up on session close)
@@ -180,10 +184,7 @@ export function defaultSandboxConfig(params: {
   gitCommonDir?: string;
 }): SandboxConfig;
 
-export function buildSafehouseArgs(
-  config: SandboxConfig,
-  command: string[],
-): string[];
+export function buildSafehouseArgs(config: SandboxConfig, command: string[]): string[];
 
 export async function isSafehouseAvailable(): Promise<boolean>;
 ```
@@ -193,16 +194,16 @@ export async function isSafehouseAvailable(): Promise<boolean>;
 Monitors the macOS unified log for sandbox violation events and emits them to the session manager.
 
 ```typescript
-import { spawn, type ChildProcess } from "node:child_process";
-import { EventEmitter } from "node:events";
+import { spawn, type ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
 
 export interface SandboxViolation {
   timestamp: Date;
   pid: number;
   processName: string;
-  operation: string;   // e.g., "file-write-data", "network-outbound"
-  path?: string;       // filesystem path, if applicable
-  raw: string;         // raw log line for debugging
+  operation: string; // e.g., "file-write-data", "network-outbound"
+  path?: string; // filesystem path, if applicable
+  raw: string; // raw log line for debugging
 }
 
 export class SandboxMonitor extends EventEmitter {
@@ -276,21 +277,16 @@ async createSession(projectDir: string, agentType: AgentType = "claude-code") {
 The `resolveClaudeCodeCommand()` function is updated to wrap the command in `safehouse`:
 
 ```typescript
-function resolveClaudeCodeCommand(
-  cwd: string,
-  sandboxConfig: SandboxConfig | null,
-): SpawnConfig {
-  const require = createRequire(app.getAppPath() + "/");
-  const binPath = require.resolve(
-    "@zed-industries/claude-agent-acp/dist/index.js"
-  );
+function resolveClaudeCodeCommand(cwd: string, sandboxConfig: SandboxConfig | null): SpawnConfig {
+  const require = createRequire(app.getAppPath() + '/');
+  const binPath = require.resolve('@zed-industries/claude-agent-acp/dist/index.js');
 
   if (sandboxConfig) {
-    const args = buildSafehouseArgs(sandboxConfig, ["node", binPath]);
-    return { cmd: "safehouse", args, cwd };
+    const args = buildSafehouseArgs(sandboxConfig, ['node', binPath]);
+    return { cmd: 'safehouse', args, cwd };
   }
 
-  return { cmd: "node", args: [binPath], cwd };
+  return { cmd: 'node', args: [binPath], cwd };
 }
 ```
 
@@ -338,11 +334,11 @@ export interface SandboxViolationInfo {
 
 export type SessionUpdate =
   // ... existing variants ...
-  | {
-      sessionId: string;
-      type: "sandbox-violation";
-      violation: SandboxViolationInfo;
-    };
+  {
+    sessionId: string;
+    type: 'sandbox-violation';
+    violation: SandboxViolationInfo;
+  };
 ```
 
 ### 5. IPC Bridge (updated: `src/preload/index.ts`)

--- a/docs/history/seatbelt-sandbox/findings.md
+++ b/docs/history/seatbelt-sandbox/findings.md
@@ -30,6 +30,7 @@ The safehouse integration with `--enable=all-agents` provides a comprehensive sa
 - **Notes**: Initial typecheck failed because the worktree lacked `node_modules` (worktrees don't carry installed dependencies). Agent diagnosed this and ran `npm install`. The Electron postinstall script failed due to sandbox blocking access to `~/Library/Caches/electron/`. Agent worked around by skipping the Electron binary. After install, typecheck passed cleanly.
 
 **Electron cache friction:**
+
 ```
 Error: EPERM: operation not permitted, open
   '<home>/Library/Caches/electron/.../electron-v41.0.3-darwin-arm64.zip'
@@ -68,11 +69,11 @@ Safehouse's curated profiles handle system runtime, Node.js toolchain, Claude Co
 
 ## Known Limitations
 
-| Issue | Severity | Workaround | Future Fix |
-|-------|----------|-----------|------------|
-| Electron cache blocked (`~/Library/Caches/electron/`) | Low | Agent skips Electron binary; only affects Electron app development | Could add `--add-dirs-ro` for `~/Library/Caches/electron/` if needed |
-| Monitor warmup noise | Cosmetic | Violations are informational only | Filter by agent process names in UI, or shorten warmup window |
-| Worktrees lack `node_modules` | Expected | Agent runs `npm install` in worktree | Could pre-install deps during worktree creation (Milestone 3 policy templates) |
+| Issue                                                 | Severity | Workaround                                                         | Future Fix                                                                     |
+| ----------------------------------------------------- | -------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| Electron cache blocked (`~/Library/Caches/electron/`) | Low      | Agent skips Electron binary; only affects Electron app development | Could add `--add-dirs-ro` for `~/Library/Caches/electron/` if needed           |
+| Monitor warmup noise                                  | Cosmetic | Violations are informational only                                  | Filter by agent process names in UI, or shorten warmup window                  |
+| Worktrees lack `node_modules`                         | Expected | Agent runs `npm install` in worktree                               | Could pre-install deps during worktree creation (Milestone 3 policy templates) |
 
 ## Application-Layer Gaps
 

--- a/docs/history/seatbelt-sandbox/plan.md
+++ b/docs/history/seatbelt-sandbox/plan.md
@@ -28,7 +28,7 @@ This plan breaks the [design](design.md) into concrete, sequentially-executable 
   - [x] 3.5 Write `scripts/test-sandbox-monitor.ts`
   - [x] 3.6 Smoke test: trigger a violation, verify monitor captures it
 - [x] **[Phase 4: UI Integration](#phase-4-ui-integration)**
-  - [x] 4.1 Add `SandboxViolationInfo` type and `sandbox-violation` SessionUpdate variant *(done in Phase 3)*
+  - [x] 4.1 Add `SandboxViolationInfo` type and `sandbox-violation` SessionUpdate variant _(done in Phase 3)_
   - [x] 4.2 Add IPC handler for violation history
   - [x] 4.3 Update preload bridge
   - [x] 4.4 Build `<SandboxLog />` component
@@ -60,6 +60,7 @@ This plan breaks the [design](design.md) into concrete, sequentially-executable 
 ### What was built
 
 **`src/main/sandbox.ts`** — Sandbox integration module with:
+
 - `SandboxConfig` interface — session-specific sandbox parameters
 - `defaultSandboxConfig()` — builds config with worktree write access, git common dir, env passthrough
 - `buildSafehouseArgs()` — constructs safehouse CLI arguments from config
@@ -67,6 +68,7 @@ This plan breaks the [design](design.md) into concrete, sequentially-executable 
 - `ensurePolicyDir()`, `cleanupPolicy()`, `cleanupOrphanPolicies()` — policy file lifecycle
 
 **`scripts/test-sandbox-profile.ts`** — Validation script testing 7 scenarios:
+
 1. Safehouse CLI availability
 2. `ls` in worktree via safehouse (allowed)
 3. Generated policy file inspection (rule counts)
@@ -76,6 +78,7 @@ This plan breaks the [design](design.md) into concrete, sequentially-executable 
 7. Stdio piping through safehouse (critical for ACP)
 
 **Key decisions:**
+
 - Safehouse is spawned as the command wrapper — it handles `sandbox-exec` internally
 - Policy files are persisted via `--output` so we control lifecycle (cleanup on session close)
 - `--workdir` enables safehouse's git root auto-detection and worktree handling
@@ -98,22 +101,17 @@ Wire the sandbox module into the session manager so that Claude Code sessions la
 - [ ] When sandbox is available, spawn via `safehouse` instead of bare `node`
 
 ```typescript
-function resolveClaudeCodeCommand(
-  cwd: string,
-  sandboxConfig: SandboxConfig | null,
-): SpawnConfig {
-  const require = createRequire(app.getAppPath() + "/");
-  const binPath = require.resolve(
-    "@zed-industries/claude-agent-acp/dist/index.js"
-  );
+function resolveClaudeCodeCommand(cwd: string, sandboxConfig: SandboxConfig | null): SpawnConfig {
+  const require = createRequire(app.getAppPath() + '/');
+  const binPath = require.resolve('@zed-industries/claude-agent-acp/dist/index.js');
 
   if (sandboxConfig) {
-    const args = buildSafehouseArgs(sandboxConfig, ["node", binPath]);
-    return { cmd: "safehouse", args, cwd };
+    const args = buildSafehouseArgs(sandboxConfig, ['node', binPath]);
+    return { cmd: 'safehouse', args, cwd };
   }
 
   // Unsandboxed fallback
-  return { cmd: "node", args: [binPath], cwd };
+  return { cmd: 'node', args: [binPath], cwd };
 }
 ```
 
@@ -125,7 +123,7 @@ function resolveAgentCommand(
   cwd: string,
   sandboxConfig: SandboxConfig | null,
 ): SpawnConfig {
-  if (agentType === "echo") {
+  if (agentType === 'echo') {
     return resolveEchoAgentCommand(); // unchanged — no sandbox for echo
   }
   return resolveClaudeCodeCommand(cwd, sandboxConfig);
@@ -146,7 +144,7 @@ Insert after the worktree creation block:
 ```typescript
 // Build sandbox config
 let sandboxConfig: SandboxConfig | null = null;
-if (agentType === "claude-code" && await isSafehouseAvailable()) {
+if (agentType === 'claude-code' && (await isSafehouseAvailable())) {
   await ensurePolicyDir();
   sandboxConfig = defaultSandboxConfig({
     sessionId: id,
@@ -156,11 +154,7 @@ if (agentType === "claude-code" && await isSafehouseAvailable()) {
 }
 
 // Spawn agent (sandboxed if config present)
-const { cmd, args, env, cwd } = resolveAgentCommand(
-  agentType,
-  workingDir,
-  sandboxConfig,
-);
+const { cmd, args, env, cwd } = resolveAgentCommand(agentType, workingDir, sandboxConfig);
 ```
 
 - [ ] Store sandbox config on the session state
@@ -173,8 +167,8 @@ const { cmd, args, env, cwd } = resolveAgentCommand(
 interface SessionState {
   // ... existing fields ...
   sandboxConfig: SandboxConfig | null;
-  sandboxMonitor: SandboxMonitor | null;   // wired in Phase 3
-  sandboxViolations: SandboxViolation[];   // populated in Phase 3
+  sandboxMonitor: SandboxMonitor | null; // wired in Phase 3
+  sandboxViolations: SandboxViolation[]; // populated in Phase 3
 }
 ```
 
@@ -201,10 +195,9 @@ if (session.sandboxConfig) {
 
 ```typescript
 // In WorktreeManager.create():
-const { stdout: commonDir } = await execFileAsync(
-  "git", ["rev-parse", "--git-common-dir"],
-  { cwd: worktreePath }
-);
+const { stdout: commonDir } = await execFileAsync('git', ['rev-parse', '--git-common-dir'], {
+  cwd: worktreePath,
+});
 return {
   path: worktreePath,
   branch,
@@ -234,28 +227,28 @@ This script replicates the structure of `scripts/test-claude-agent.ts` from M1, 
 //   - @zed-industries/claude-agent-acp installed
 //   - ANTHROPIC_API_KEY set or Claude Code OAuth active
 
-import { spawn } from "node:child_process";
-import { createRequire } from "node:module";
-import { randomUUID } from "node:crypto";
-import { rm } from "node:fs/promises";
-import { Writable, Readable } from "node:stream";
-import * as acp from "@agentclientprotocol/sdk";
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { randomUUID } from 'node:crypto';
+import { rm } from 'node:fs/promises';
+import { Writable, Readable } from 'node:stream';
+import * as acp from '@agentclientprotocol/sdk';
 import {
   defaultSandboxConfig,
   buildSafehouseArgs,
   isSafehouseAvailable,
   ensurePolicyDir,
   cleanupPolicy,
-} from "../src/main/sandbox.js";
+} from '../src/main/sandbox.js';
 
 const require = createRequire(import.meta.url);
 const worktreePath = process.argv[2] || process.cwd();
 const sessionId = randomUUID();
 
-console.log("=== Sandboxed Agent Test ===\n");
+console.log('=== Sandboxed Agent Test ===\n');
 
-if (!await isSafehouseAvailable()) {
-  console.log("safehouse not found. Install: brew install eugene1g/safehouse/agent-safehouse");
+if (!(await isSafehouseAvailable())) {
+  console.log('safehouse not found. Install: brew install eugene1g/safehouse/agent-safehouse');
   process.exit(1);
 }
 
@@ -266,22 +259,20 @@ console.log(`Worktree: ${worktreePath}`);
 console.log(`Policy: ${config.policyOutputPath}`);
 
 // Resolve agent binary
-const agentBin = require.resolve(
-  "@zed-industries/claude-agent-acp/dist/index.js"
-);
+const agentBin = require.resolve('@zed-industries/claude-agent-acp/dist/index.js');
 
 // Spawn via safehouse
-const args = buildSafehouseArgs(config, ["node", agentBin]);
-console.log(`\nSpawning: safehouse ${args.join(" ")}\n`);
+const args = buildSafehouseArgs(config, ['node', agentBin]);
+console.log(`\nSpawning: safehouse ${args.join(' ')}\n`);
 
-const agent = spawn("safehouse", args, {
-  stdio: ["pipe", "pipe", "pipe"],
+const agent = spawn('safehouse', args, {
+  stdio: ['pipe', 'pipe', 'pipe'],
   cwd: worktreePath,
 });
 
-agent.stderr?.on("data", (d: Buffer) => process.stderr.write(d));
-agent.on("error", (err) => console.error("Spawn error:", err));
-agent.on("exit", (code) => console.log(`\nAgent exited: code ${code}`));
+agent.stderr?.on('data', (d: Buffer) => process.stderr.write(d));
+agent.on('error', (err) => console.error('Spawn error:', err));
+agent.on('exit', (code) => console.log(`\nAgent exited: code ${code}`));
 
 // ACP setup
 const output = Writable.toWeb(agent.stdin!) as WritableStream<Uint8Array>;
@@ -292,20 +283,17 @@ const connection = new acp.ClientSideConnection(
   (_agentInfo) => ({
     async sessionUpdate(params) {
       const update = params.update;
-      if (
-        update.sessionUpdate === "agent_message_chunk" &&
-        update.content.type === "text"
-      ) {
+      if (update.sessionUpdate === 'agent_message_chunk' && update.content.type === 'text') {
         process.stdout.write(update.content.text);
       } else {
         console.log(`\n  [${update.sessionUpdate}]`);
       }
     },
     async requestPermission(params) {
-      const opt = params.options.find((o) => o.kind === "allow_once");
+      const opt = params.options.find((o) => o.kind === 'allow_once');
       return {
         outcome: {
-          outcome: "selected" as const,
+          outcome: 'selected' as const,
           optionId: (opt ?? params.options[0]).optionId,
         },
       };
@@ -315,7 +303,7 @@ const connection = new acp.ClientSideConnection(
 );
 
 try {
-  console.log("Initializing ACP...");
+  console.log('Initializing ACP...');
   await connection.initialize({
     protocolVersion: acp.PROTOCOL_VERSION,
     clientCapabilities: {
@@ -323,7 +311,7 @@ try {
       fs: { readTextFile: true, writeTextFile: true },
     },
   });
-  console.log("✓ Initialize succeeded");
+  console.log('✓ Initialize succeeded');
 
   const sessionResp = await connection.newSession({
     cwd: worktreePath,
@@ -331,26 +319,27 @@ try {
   });
   console.log(`✓ New session: ${sessionResp.sessionId}`);
 
-  const prompt = "List the files in the current directory. Be brief.";
+  const prompt = 'List the files in the current directory. Be brief.';
   console.log(`\nPrompt: "${prompt}"\n--- Response ---`);
   const resp = await connection.prompt({
     sessionId: sessionResp.sessionId,
-    prompt: [{ type: "text", text: prompt }],
+    prompt: [{ type: 'text', text: prompt }],
   });
   console.log(`\n--- End (stop: ${resp.stopReason}) ---`);
-  console.log("\n✓ Sandboxed agent completed successfully");
+  console.log('\n✓ Sandboxed agent completed successfully');
 } catch (err) {
-  console.error("\n✗ Error:", err);
+  console.error('\n✗ Error:', err);
   process.exitCode = 1;
 } finally {
   agent.kill();
   await cleanupPolicy(config.policyOutputPath);
 }
 
-console.log("\n=== Done ===");
+console.log('\n=== Done ===');
 ```
 
 Add to `package.json` scripts:
+
 ```json
 "test:sandboxed-agent": "tsx scripts/test-sandboxed-agent.ts"
 ```
@@ -384,9 +373,9 @@ Build the log-stream-based violation monitor. This is informational infrastructu
 - [ ] Create the file with types and class skeleton
 
 ```typescript
-import { spawn, type ChildProcess } from "node:child_process";
-import { EventEmitter } from "node:events";
-import { createInterface } from "node:readline";
+import { spawn, type ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { createInterface } from 'node:readline';
 
 export interface SandboxViolation {
   timestamp: Date;
@@ -403,8 +392,12 @@ export class SandboxMonitor extends EventEmitter {
   private knownPids: Set<number> = new Set();
   private pidRefreshTimer: ReturnType<typeof setInterval> | null = null;
 
-  start(pid: number): void { /* ... */ }
-  stop(): void { /* ... */ }
+  start(pid: number): void {
+    /* ... */
+  }
+  stop(): void {
+    /* ... */
+  }
 }
 ```
 
@@ -436,6 +429,7 @@ export class SandboxMonitor extends EventEmitter {
 - [ ] Verify the monitor catches them
 
 Add to `package.json` scripts:
+
 ```json
 "test:sandbox-monitor": "tsx scripts/test-sandbox-monitor.ts"
 ```
@@ -610,32 +604,32 @@ Run these checks after all phases are complete:
 
 ### New files
 
-| File | Purpose |
-|------|---------|
-| `src/main/sandbox.ts` | Safehouse integration: config, arg building, availability check, cleanup |
-| `src/main/sandbox-monitor.ts` | Unified log monitoring for sandbox violations |
-| `src/renderer/src/components/SandboxLog.tsx` | UI component for violation log display |
-| `scripts/test-sandbox-profile.ts` | Test harness for safehouse integration |
-| `scripts/test-sandboxed-agent.ts` | Test harness for sandboxed agent spawning |
-| `scripts/test-sandbox-monitor.ts` | Test harness for violation monitoring |
-| `docs/milestones/seatbelt-sandbox/findings.md` | Empirical findings from sandbox testing |
+| File                                           | Purpose                                                                  |
+| ---------------------------------------------- | ------------------------------------------------------------------------ |
+| `src/main/sandbox.ts`                          | Safehouse integration: config, arg building, availability check, cleanup |
+| `src/main/sandbox-monitor.ts`                  | Unified log monitoring for sandbox violations                            |
+| `src/renderer/src/components/SandboxLog.tsx`   | UI component for violation log display                                   |
+| `scripts/test-sandbox-profile.ts`              | Test harness for safehouse integration                                   |
+| `scripts/test-sandboxed-agent.ts`              | Test harness for sandboxed agent spawning                                |
+| `scripts/test-sandbox-monitor.ts`              | Test harness for violation monitoring                                    |
+| `docs/milestones/seatbelt-sandbox/findings.md` | Empirical findings from sandbox testing                                  |
 
 ### Modified files
 
-| File | Changes |
-|------|---------|
-| `src/main/session-manager.ts` | Sandbox config, safehouse spawn, monitor lifecycle, violation tracking |
-| `src/main/worktree-manager.ts` | Add `gitCommonDir` to `WorktreeInfo` |
-| `src/main/types.ts` | `SandboxViolationInfo`, `sandbox-violation` SessionUpdate variant |
-| `src/preload/index.ts` | `getSandboxViolations` IPC bridge method |
-| `src/renderer/src/env.d.ts` | Type declarations for new IPC methods |
-| `src/renderer/src/App.tsx` | Violation state management, `sandbox-violation` update handling |
-| `src/renderer/src/components/ChatPanel.tsx` | `<SandboxLog />` integration |
-| `src/renderer/src/components/SessionList.tsx` | Sandbox status badge |
-| `package.json` | New test scripts |
+| File                                          | Changes                                                                |
+| --------------------------------------------- | ---------------------------------------------------------------------- |
+| `src/main/session-manager.ts`                 | Sandbox config, safehouse spawn, monitor lifecycle, violation tracking |
+| `src/main/worktree-manager.ts`                | Add `gitCommonDir` to `WorktreeInfo`                                   |
+| `src/main/types.ts`                           | `SandboxViolationInfo`, `sandbox-violation` SessionUpdate variant      |
+| `src/preload/index.ts`                        | `getSandboxViolations` IPC bridge method                               |
+| `src/renderer/src/env.d.ts`                   | Type declarations for new IPC methods                                  |
+| `src/renderer/src/App.tsx`                    | Violation state management, `sandbox-violation` update handling        |
+| `src/renderer/src/components/ChatPanel.tsx`   | `<SandboxLog />` integration                                           |
+| `src/renderer/src/components/SessionList.tsx` | Sandbox status badge                                                   |
+| `package.json`                                | New test scripts                                                       |
 
 ### External dependencies
 
-| Dependency | Type | Install |
-|------------|------|---------|
+| Dependency        | Type                           | Install                                           |
+| ----------------- | ------------------------------ | ------------------------------------------------- |
 | `agent-safehouse` | CLI tool (runtime, macOS only) | `brew install eugene1g/safehouse/agent-safehouse` |

--- a/docs/history/workspaces-sidebar/design.md
+++ b/docs/history/workspaces-sidebar/design.md
@@ -22,12 +22,12 @@ The workspace model fixes both:
 
 ## Terminology
 
-| Old term | New term | Notes |
-|---|---|---|
-| Session | Workspace | A sandboxed agent environment (container + worktree + policy) |
-| Session list | Workspaces sidebar | The left panel |
-| New Session dialog | (removed for common case) | Quick-create via "+" button on repo |
-| — (new) | Repository | A persisted project entry in the sidebar |
+| Old term           | New term                  | Notes                                                         |
+| ------------------ | ------------------------- | ------------------------------------------------------------- |
+| Session            | Workspace                 | A sandboxed agent environment (container + worktree + policy) |
+| Session list       | Workspaces sidebar        | The left panel                                                |
+| New Session dialog | (removed for common case) | Quick-create via "+" button on repo                           |
+| — (new)            | Repository                | A persisted project entry in the sidebar                      |
 
 **Internal code naming**: The `SessionManager`, `SessionState`, `SessionSummary` types will be renamed to use "workspace" terminology. This is a mechanical rename — the behavior is unchanged.
 
@@ -37,13 +37,13 @@ The workspace model fixes both:
 
 ```typescript
 interface Repository {
-  id: string;                    // UUID
-  name: string;                  // Display name (e.g., "bouncer")
-  localPath: string;             // Path to the git repo on disk
-  githubRepo: string | null;     // e.g., "anthropics/bouncer" (auto-detected from git remote)
-  defaultPolicyId: string;       // e.g., "standard-pr"
-  defaultAgentType: AgentType;   // e.g., "claude-code"
-  createdAt: number;             // Timestamp
+  id: string; // UUID
+  name: string; // Display name (e.g., "bouncer")
+  localPath: string; // Path to the git repo on disk
+  githubRepo: string | null; // e.g., "anthropics/bouncer" (auto-detected from git remote)
+  defaultPolicyId: string; // e.g., "standard-pr"
+  defaultAgentType: AgentType; // e.g., "claude-code"
+  createdAt: number; // Timestamp
 }
 ```
 
@@ -56,7 +56,7 @@ The existing `SessionState` / `SessionSummary` types are renamed but structurall
 ```typescript
 interface WorkspaceSummary {
   // ... all existing SessionSummary fields, renamed ...
-  repositoryId: string;  // Links workspace to its parent repository
+  repositoryId: string; // Links workspace to its parent repository
 }
 ```
 
@@ -120,15 +120,15 @@ Only repositories are persisted. Workspaces are ephemeral — when the app resta
 
 ### Interactions
 
-| Action | Trigger | Behavior |
-|---|---|---|
-| Add repository | Click [+ Repo] header button | Opens directory browser → creates repo entry with auto-detected settings |
-| Create workspace | Click [+] on repo row | Immediately creates workspace with repo defaults. No dialog. |
-| Select workspace | Click workspace row | Shows workspace chat panel (same as current session select) |
-| Close workspace | Click × on workspace row | Closes workspace (same as current session close) |
-| Repo settings | Right-click repo → Settings | Opens a settings panel/dialog for editing repo defaults |
-| Remove repo | Right-click repo → Remove | Removes repo from sidebar (closes active workspaces first, with confirmation) |
-| Collapse/expand | Click disclosure triangle | Toggles workspace list visibility |
+| Action           | Trigger                      | Behavior                                                                      |
+| ---------------- | ---------------------------- | ----------------------------------------------------------------------------- |
+| Add repository   | Click [+ Repo] header button | Opens directory browser → creates repo entry with auto-detected settings      |
+| Create workspace | Click [+] on repo row        | Immediately creates workspace with repo defaults. No dialog.                  |
+| Select workspace | Click workspace row          | Shows workspace chat panel (same as current session select)                   |
+| Close workspace  | Click × on workspace row     | Closes workspace (same as current session close)                              |
+| Repo settings    | Right-click repo → Settings  | Opens a settings panel/dialog for editing repo defaults                       |
+| Remove repo      | Right-click repo → Remove    | Removes repo from sidebar (closes active workspaces first, with confirmation) |
+| Collapse/expand  | Click disclosure triangle    | Toggles workspace list visibility                                             |
 
 ## Add Repository Flow
 
@@ -200,6 +200,7 @@ export class RepositoryStore {
 ### Renamed: SessionManager → WorkspaceManager
 
 Mechanical rename of:
+
 - `SessionManager` → `WorkspaceManager`
 - `SessionState` → `WorkspaceState`
 - `SessionSummary` → `WorkspaceSummary`
@@ -229,12 +230,14 @@ private async _createWorkspace(
 ### IPC Changes
 
 **New channels**:
+
 - `repositories:list` → `Repository[]`
 - `repositories:add` → `(localPath: string) => Repository`
 - `repositories:update` → `(id: string, changes: Partial<Repository>) => void`
 - `repositories:remove` → `(id: string) => void`
 
 **Renamed channels**:
+
 - `sessions:list` → `workspaces:list`
 - `sessions:create` → `workspaces:create` (now takes `repositoryId` instead of `(projectDir, agentType, policyId)`)
 - `sessions:sendMessage` → `workspaces:sendMessage`
@@ -247,12 +250,15 @@ private async _createWorkspace(
 ### Renderer Changes
 
 **Removed**:
+
 - `NewSessionDialog.tsx` — no longer needed for the common case
 
 **Renamed**:
+
 - `SessionList.tsx` → `WorkspacesSidebar.tsx`
 
 **New/modified**:
+
 - `WorkspacesSidebar.tsx` — two-level hierarchy (repos → workspaces)
 - `RepoSettingsPanel.tsx` — inline settings for a repository (or small dialog)
 - `App.tsx` — state management updated for repos + workspaces

--- a/docs/history/workspaces-sidebar/plan.md
+++ b/docs/history/workspaces-sidebar/plan.md
@@ -75,51 +75,52 @@ This is the largest phase by file count but the simplest conceptually. It's a me
 
 ### Rename map
 
-| Old | New |
-|---|---|
-| `SessionSummary` | `WorkspaceSummary` |
-| `SessionState` | `WorkspaceState` |
-| `SessionManager` | `WorkspaceManager` |
-| `SessionUpdate` | `WorkspaceUpdate` |
-| `SessionSummary['status']` | `WorkspaceSummary['status']` |
-| `activeSessionId` | `activeWorkspaceId` |
-| `messagesBySession` | `messagesByWorkspace` |
-| `violationsBySession` | `violationsByWorkspace` |
-| `policyEventsBySession` | `policyEventsByWorkspace` |
-| `streamingTextRef` | (unchanged — not session-specific in name) |
-| `session-update` (IPC channel) | `workspace-update` |
-| `sessions:list` | `workspaces:list` |
-| `sessions:create` | `workspaces:create` |
-| `sessions:sendMessage` | `workspaces:sendMessage` |
-| `sessions:close` | `workspaces:close` |
-| `sessions:getSandboxViolations` | `workspaces:getSandboxViolations` |
-| `sessions:loadReplayData` | `workspaces:loadReplayData` |
-| `window.glitterball` | `window.bouncer` |
-| `SessionList` component | `WorkspacesSidebar` component |
-| `NewSessionDialog` component | (kept for now, renamed in Phase 6) |
-| `.session-list` CSS | `.workspaces-sidebar` |
-| `.session-item` CSS | `.workspace-item` |
-| `.new-session-btn` CSS | `.new-workspace-btn` |
+| Old                             | New                                        |
+| ------------------------------- | ------------------------------------------ |
+| `SessionSummary`                | `WorkspaceSummary`                         |
+| `SessionState`                  | `WorkspaceState`                           |
+| `SessionManager`                | `WorkspaceManager`                         |
+| `SessionUpdate`                 | `WorkspaceUpdate`                          |
+| `SessionSummary['status']`      | `WorkspaceSummary['status']`               |
+| `activeSessionId`               | `activeWorkspaceId`                        |
+| `messagesBySession`             | `messagesByWorkspace`                      |
+| `violationsBySession`           | `violationsByWorkspace`                    |
+| `policyEventsBySession`         | `policyEventsByWorkspace`                  |
+| `streamingTextRef`              | (unchanged — not session-specific in name) |
+| `session-update` (IPC channel)  | `workspace-update`                         |
+| `sessions:list`                 | `workspaces:list`                          |
+| `sessions:create`               | `workspaces:create`                        |
+| `sessions:sendMessage`          | `workspaces:sendMessage`                   |
+| `sessions:close`                | `workspaces:close`                         |
+| `sessions:getSandboxViolations` | `workspaces:getSandboxViolations`          |
+| `sessions:loadReplayData`       | `workspaces:loadReplayData`                |
+| `window.glitterball`            | `window.bouncer`                           |
+| `SessionList` component         | `WorkspacesSidebar` component              |
+| `NewSessionDialog` component    | (kept for now, renamed in Phase 6)         |
+| `.session-list` CSS             | `.workspaces-sidebar`                      |
+| `.session-item` CSS             | `.workspace-item`                          |
+| `.new-session-btn` CSS          | `.new-workspace-btn`                       |
 
 ### Files changed
 
-| File | Change |
-|---|---|
-| `src/main/types.ts` | Rename types |
-| `src/main/session-manager.ts` → `src/main/workspace-manager.ts` | Rename file + class + methods |
-| `src/main/index.ts` | Update imports and references |
-| `src/preload/index.ts` | Rename API surface (`glitterball` → `bouncer`, `sessions` → `workspaces`) |
-| `src/preload/index.d.ts` | Update type declarations |
-| `src/renderer/src/App.tsx` | Rename state vars, IPC references, component usage |
-| `src/renderer/src/components/SessionList.tsx` → `WorkspacesSidebar.tsx` | Rename file + component |
-| `src/renderer/src/components/ChatPanel.tsx` | Update prop types if referencing session types |
-| `src/renderer/src/components/MessageInput.tsx` | Update prop types if referencing session types |
-| `src/renderer/src/components/NewSessionDialog.tsx` | Update imports (keep component for now) |
-| `src/renderer/src/index.css` | Rename CSS classes |
+| File                                                                    | Change                                                                    |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `src/main/types.ts`                                                     | Rename types                                                              |
+| `src/main/session-manager.ts` → `src/main/workspace-manager.ts`         | Rename file + class + methods                                             |
+| `src/main/index.ts`                                                     | Update imports and references                                             |
+| `src/preload/index.ts`                                                  | Rename API surface (`glitterball` → `bouncer`, `sessions` → `workspaces`) |
+| `src/preload/index.d.ts`                                                | Update type declarations                                                  |
+| `src/renderer/src/App.tsx`                                              | Rename state vars, IPC references, component usage                        |
+| `src/renderer/src/components/SessionList.tsx` → `WorkspacesSidebar.tsx` | Rename file + component                                                   |
+| `src/renderer/src/components/ChatPanel.tsx`                             | Update prop types if referencing session types                            |
+| `src/renderer/src/components/MessageInput.tsx`                          | Update prop types if referencing session types                            |
+| `src/renderer/src/components/NewSessionDialog.tsx`                      | Update imports (keep component for now)                                   |
+| `src/renderer/src/index.css`                                            | Rename CSS classes                                                        |
 
 ### Approach
 
 Use TypeScript's compiler as a safety net:
+
 1. Rename the types first (in `types.ts`) — this breaks all consumers
 2. Fix each consumer file — TypeScript errors guide the work
 3. Rename IPC channels (string literals — must grep for these)
@@ -127,6 +128,7 @@ Use TypeScript's compiler as a safety net:
 5. Build, verify no errors, run the app
 
 ### Exit criteria
+
 - `npm run build` succeeds with zero errors
 - App runs and behaves identically to before
 - No remaining references to "session" in code (except `acpSessionId` in ACP protocol layer, which is external terminology)
@@ -160,7 +162,10 @@ export class RepositoryStore {
 
   constructor(configDir?: string) {
     // Default: ~/.config/bouncer
-    this.configPath = path.join(configDir ?? path.join(os.homedir(), '.config', 'bouncer'), 'repositories.json');
+    this.configPath = path.join(
+      configDir ?? path.join(os.homedir(), '.config', 'bouncer'),
+      'repositories.json',
+    );
   }
 
   async load(): Promise<void>;
@@ -174,6 +179,7 @@ export class RepositoryStore {
 ```
 
 **`add(localPath)`** implementation:
+
 1. Validate: `git -C {localPath} rev-parse --git-dir` (must be a git repo)
 2. Auto-detect name: `path.basename(localPath)`
 3. Auto-detect GitHub repo: `git -C {localPath} remote get-url origin` → parse `github.com:owner/repo` or `github.com/owner/repo`
@@ -181,11 +187,13 @@ export class RepositoryStore {
 5. Generate UUID, create `Repository`, append to list, save
 
 **`save()`** implementation:
+
 - `fs.mkdir(path.dirname(configPath), { recursive: true })` (ensure dir exists)
 - `fs.writeFile(configPath, JSON.stringify(repos, null, 2))`
 - Atomic write (write to temp file, rename) for crash safety
 
 **`load()`** implementation:
+
 - If file doesn't exist → empty list (first run)
 - Parse JSON, validate shape, populate `repos`
 
@@ -204,6 +212,7 @@ const workspaceManager = new WorkspaceManager(repoStore, ...);
 - Manual: add a repo, restart app, verify repo is still there
 
 ### Exit criteria
+
 - Repos persist across app restarts
 - Auto-detection correctly identifies repo name and GitHub URL
 - Invalid paths (not git repos) are rejected with a clear error
@@ -217,6 +226,7 @@ const workspaceManager = new WorkspaceManager(repoStore, ...);
 ### Changes to `src/main/index.ts`
 
 Add IPC handlers:
+
 ```typescript
 ipcMain.handle('repositories:list', () => repoStore.list());
 ipcMain.handle('repositories:add', (_, localPath: string) => repoStore.add(localPath));
@@ -241,6 +251,7 @@ bouncer: {
 ```
 
 ### Exit criteria
+
 - Renderer can call `window.bouncer.repositories.list()` and get back the persisted repo list
 - Add/update/remove from renderer persists to disk
 
@@ -253,6 +264,7 @@ bouncer: {
 ### Changes to `src/main/types.ts`
 
 Add to `WorkspaceSummary`:
+
 ```typescript
 repositoryId: string;
 ```
@@ -260,6 +272,7 @@ repositoryId: string;
 ### Changes to `src/main/workspace-manager.ts`
 
 New public method:
+
 ```typescript
 async createWorkspace(repositoryId: string): Promise<WorkspaceSummary> {
   const repo = this.repoStore.get(repositoryId);
@@ -284,6 +297,7 @@ workspaces: {
 ```
 
 ### Exit criteria
+
 - `workspaces.create(repoId)` creates a workspace using the repo's defaults
 - `WorkspaceSummary.repositoryId` is populated
 
@@ -334,22 +348,25 @@ function RepoGroup({ repo, workspaces, ... }) {
 ### Changes to `App.tsx`
 
 New state:
+
 ```typescript
 const [repos, setRepos] = useState<Repository[]>([]);
 ```
 
 On mount:
+
 ```typescript
 window.bouncer.repositories.list().then(setRepos);
 ```
 
 New handlers:
+
 ```typescript
 async function handleAddRepo() {
   const dir = await window.bouncer.dialog.selectDirectory();
   if (!dir) return;
   const repo = await window.bouncer.repositories.add(dir);
-  setRepos(prev => [...prev, repo]);
+  setRepos((prev) => [...prev, repo]);
 }
 
 async function handleCreateWorkspace(repositoryId: string) {
@@ -361,6 +378,7 @@ async function handleCreateWorkspace(repositoryId: string) {
 ### CSS changes
 
 New classes for the hierarchy layout:
+
 - `.sidebar-header` — fixed top bar with title and add button
 - `.repo-group` — container for a repo and its workspaces
 - `.repo-row` — the repository entry (flex: triangle, name, + button)
@@ -368,6 +386,7 @@ New classes for the hierarchy layout:
 - `.repo-row .create-btn` — the [+] button on repo rows
 
 ### Exit criteria
+
 - Sidebar shows repos with workspaces grouped underneath
 - [+ Repo] opens directory browser and adds repo
 - [+] on repo creates workspace with defaults
@@ -380,15 +399,18 @@ New classes for the hierarchy layout:
 **Goal**: Clean up the now-unused session creation dialog.
 
 ### Files removed
+
 - `src/renderer/src/components/NewSessionDialog.tsx`
 
 ### Changes
+
 - `App.tsx`: remove `showNewSession` state, dialog rendering, `handleCreateSession` handler
 - `index.ts`: optionally remove `dialog:selectDirectory` IPC if not used elsewhere (still needed for [+ Repo])
 
 Actually, `dialog.selectDirectory` is still needed for the [+ Repo] flow. Keep it.
 
 ### Exit criteria
+
 - No modal dialog anywhere in the app
 - Clean build, no dead imports
 
@@ -403,6 +425,7 @@ Actually, `dialog.selectDirectory` is still needed for the [+ Repo] flow. Keep i
 A small inline panel or popover that opens when the user right-clicks a repo and selects "Settings".
 
 Contents:
+
 - **Name**: text input (saves on blur/enter)
 - **Local path**: read-only, monospace text
 - **GitHub repo**: text input (auto-detected, editable)
@@ -412,16 +435,19 @@ Contents:
 ### Context menu
 
 Add a right-click context menu to repo rows:
+
 - "Settings" → opens settings panel
 - "Remove" → confirmation dialog if active workspaces exist, then `repositories.remove(id)`
 
 Electron context menus can be done via:
+
 - `onContextMenu` event → IPC to main → `Menu.buildFromTemplate().popup()`
 - Or: pure renderer-side context menu component
 
 Recommend renderer-side for simplicity — no IPC round-trip, easier to style consistently.
 
 ### Exit criteria
+
 - Right-click on repo shows context menu
 - Settings panel lets user change name, GitHub repo, default policy, default agent type
 - Changes persist and affect subsequent workspace creation
@@ -454,6 +480,7 @@ Recommend renderer-side for simplicity — no IPC round-trip, easier to style co
 - [ ] Collapse/expand: disclosure triangles work, auto-expand on workspace creation
 
 ### Exit criteria
+
 - All validation checklist items pass
 - Roadmap updated with M8
 
@@ -489,28 +516,28 @@ All phases are sequential — each builds on the previous. Phase 6 can happen an
 
 ## Risk Checkpoints
 
-| After Phase | Check |
-|---|---|
-| Phase 1 | App builds and runs identically (pure refactor) |
-| Phase 2 | Repos persist to disk and survive restart |
-| Phase 3 | Renderer can CRUD repos via IPC |
-| Phase 4 | Workspace creation via repo ID works end-to-end |
-| Phase 5 | Sidebar shows grouped hierarchy, quick-create works |
-| Phase 6 | Dialog removed, no dead code |
-| Phase 7 | Settings changes affect new workspace creation |
-| Phase 8 | Full PR workflow, edge cases handled |
+| After Phase | Check                                               |
+| ----------- | --------------------------------------------------- |
+| Phase 1     | App builds and runs identically (pure refactor)     |
+| Phase 2     | Repos persist to disk and survive restart           |
+| Phase 3     | Renderer can CRUD repos via IPC                     |
+| Phase 4     | Workspace creation via repo ID works end-to-end     |
+| Phase 5     | Sidebar shows grouped hierarchy, quick-create works |
+| Phase 6     | Dialog removed, no dead code                        |
+| Phase 7     | Settings changes affect new workspace creation      |
+| Phase 8     | Full PR workflow, edge cases handled                |
 
 ---
 
 ## Estimated Scope
 
-| Phase | Files changed | Complexity |
-|---|---|---|
-| Phase 1 (rename) | ~15 files | Low (mechanical) |
-| Phase 2 (repo store) | 3 new/modified | Low |
-| Phase 3 (IPC) | 3 modified | Low |
-| Phase 4 (link) | 4 modified | Low |
-| Phase 5 (sidebar UI) | 3 modified | Medium (main UI work) |
-| Phase 6 (remove dialog) | 2 modified, 1 deleted | Low |
-| Phase 7 (repo settings) | 2 new/modified | Medium |
-| Phase 8 (polish) | 3 modified | Low |
+| Phase                   | Files changed         | Complexity            |
+| ----------------------- | --------------------- | --------------------- |
+| Phase 1 (rename)        | ~15 files             | Low (mechanical)      |
+| Phase 2 (repo store)    | 3 new/modified        | Low                   |
+| Phase 3 (IPC)           | 3 modified            | Low                   |
+| Phase 4 (link)          | 4 modified            | Low                   |
+| Phase 5 (sidebar UI)    | 3 modified            | Medium (main UI work) |
+| Phase 6 (remove dialog) | 2 modified, 1 deleted | Low                   |
+| Phase 7 (repo settings) | 2 new/modified        | Medium                |
+| Phase 8 (polish)        | 3 modified            | Low                   |

--- a/docs/reference/acp-reference.md
+++ b/docs/reference/acp-reference.md
@@ -12,10 +12,10 @@ ACP standardizes communication between **code editors/IDEs** (clients) and **AI 
 
 ## Key Packages
 
-| Package | Purpose |
-|---------|---------|
-| `@agentclientprotocol/sdk` | Core SDK — `ClientSideConnection` (for harness) and `AgentSideConnection` (for agents) |
-| `@zed-industries/claude-agent-acp` | Official ACP adapter for Claude Code |
+| Package                            | Purpose                                                                                |
+| ---------------------------------- | -------------------------------------------------------------------------------------- |
+| `@agentclientprotocol/sdk`         | Core SDK — `ClientSideConnection` (for harness) and `AgentSideConnection` (for agents) |
+| `@zed-industries/claude-agent-acp` | Official ACP adapter for Claude Code                                                   |
 
 SDKs also exist for Python, Rust, Kotlin, and Java.
 
@@ -31,51 +31,52 @@ ACP uses **JSON-RPC 2.0** over bidirectional channels.
 
 ### Client → Agent Requests
 
-| Request | Purpose |
-|---------|---------|
-| `InitializeRequest` | Negotiate protocol version, exchange capabilities |
-| `AuthenticateRequest` | Authentication |
-| `NewSessionRequest` | Create a new conversation session |
-| `LoadSessionRequest` | Resume a previous session |
-| `ListSessionsRequest` | List existing sessions |
-| `SetSessionModeRequest` | Switch agent operating mode |
-| `SetSessionConfigOptionRequest` | Update session configuration |
-| `PromptRequest` (`session/prompt`) | Send user message with context |
+| Request                            | Purpose                                           |
+| ---------------------------------- | ------------------------------------------------- |
+| `InitializeRequest`                | Negotiate protocol version, exchange capabilities |
+| `AuthenticateRequest`              | Authentication                                    |
+| `NewSessionRequest`                | Create a new conversation session                 |
+| `LoadSessionRequest`               | Resume a previous session                         |
+| `ListSessionsRequest`              | List existing sessions                            |
+| `SetSessionModeRequest`            | Switch agent operating mode                       |
+| `SetSessionConfigOptionRequest`    | Update session configuration                      |
+| `PromptRequest` (`session/prompt`) | Send user message with context                    |
 
 ### Agent → Client Requests
 
-| Request | Purpose |
-|---------|---------|
-| `ReadTextFileRequest` | Agent reads a file via the editor |
-| `WriteTextFileRequest` | Agent writes a file via the editor |
-| `RequestPermissionRequest` | Agent asks user for permission |
-| `CreateTerminalRequest` | Agent creates a terminal |
-| `TerminalOutputRequest` | Get terminal output |
-| `KillTerminalRequest` | Kill a running command |
-| `WaitForTerminalExitRequest` | Wait for command completion |
-| `ReleaseTerminalRequest` | Close a terminal |
+| Request                      | Purpose                            |
+| ---------------------------- | ---------------------------------- |
+| `ReadTextFileRequest`        | Agent reads a file via the editor  |
+| `WriteTextFileRequest`       | Agent writes a file via the editor |
+| `RequestPermissionRequest`   | Agent asks user for permission     |
+| `CreateTerminalRequest`      | Agent creates a terminal           |
+| `TerminalOutputRequest`      | Get terminal output                |
+| `KillTerminalRequest`        | Kill a running command             |
+| `WaitForTerminalExitRequest` | Wait for command completion        |
+| `ReleaseTerminalRequest`     | Close a terminal                   |
 
 ### Notifications
 
-| Notification | Direction | Purpose |
-|-------------|-----------|---------|
+| Notification                             | Direction      | Purpose                                        |
+| ---------------------------------------- | -------------- | ---------------------------------------------- |
 | `SessionNotification` (`session/update`) | Agent → Client | Stream content, tool calls, plans in real-time |
-| `CancelNotification` (`session/cancel`) | Client → Agent | Cancel an ongoing turn |
-| `ExtRequest` / `ExtNotification` | Either | Custom extension methods |
+| `CancelNotification` (`session/cancel`)  | Client → Agent | Cancel an ongoing turn                         |
+| `ExtRequest` / `ExtNotification`         | Either         | Custom extension methods                       |
 
 ### MCP-over-ACP
 
 ACP supports tunneling MCP connections through the ACP channel:
 
-| Message | Purpose |
-|---------|---------|
-| `mcp/connect` | Initiate MCP connection over ACP |
-| `mcp/message` | Exchange MCP protocol messages |
-| `mcp/disconnect` | Close MCP connection |
+| Message          | Purpose                          |
+| ---------------- | -------------------------------- |
+| `mcp/connect`    | Initiate MCP connection over ACP |
+| `mcp/message`    | Exchange MCP protocol messages   |
+| `mcp/disconnect` | Close MCP connection             |
 
 ## Streaming Model
 
 When a client sends `PromptRequest`, the agent streams back `SessionNotification` messages containing:
+
 - Text content chunks as generated
 - Tool call updates (pending → in_progress → completed/failed)
 - Plan updates (multi-step execution plans with status per entry)
@@ -94,24 +95,29 @@ The turn concludes when the agent sends `PromptResponse` with a `StopReason` (e.
 ## Relevance to Bouncer
 
 ### Session management
+
 Each Bouncer session maps to an ACP session. `NewSessionRequest` creates a session; `PromptRequest` sends user messages; `SessionNotification` streams responses to the chat UI.
 
 ### Sandbox policy interception
+
 `RequestPermissionRequest` is the natural interception point for policy enforcement. When the agent asks for permission, the session manager can evaluate the request against the sandbox policy before prompting the user (or auto-approving).
 
 ### Terminal sandboxing
+
 `CreateTerminalRequest` is how the agent runs shell commands. The session manager handles this by spawning the shell inside the Seatbelt sandbox. `TerminalOutputRequest` captures output; `KillTerminalRequest` and `WaitForTerminalExitRequest` manage lifecycle.
 
 ### File operations
+
 `ReadTextFileRequest` and `WriteTextFileRequest` can be mediated by the session manager to enforce filesystem boundaries at the ACP level, in addition to OS-level enforcement.
 
 ### Agent swappability
+
 The `AgentSideConnection` interface allows swapping between a real Claude Code agent (`@zed-industries/claude-agent-acp`) and a deterministic replay agent for testing, without changing the harness code.
 
 ## Relationship to Other Protocols
 
-| Protocol | Scope | Relationship |
-|----------|-------|-------------|
-| **MCP** (Model Context Protocol) | Agent ↔ tools/data (behind agent) | Complementary. ACP reuses MCP JSON types. ACP sits "in front of" the agent; MCP sits "behind." |
-| **LSP** (Language Server Protocol) | Editor ↔ language server | Analogous design. ACP is "LSP for AI coding agents." |
-| **A2A** (Agent-to-Agent) | Agent ↔ agent | Different scope. ACP is agent-to-editor, not agent-to-agent. |
+| Protocol                           | Scope                             | Relationship                                                                                   |
+| ---------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------- |
+| **MCP** (Model Context Protocol)   | Agent ↔ tools/data (behind agent) | Complementary. ACP reuses MCP JSON types. ACP sits "in front of" the agent; MCP sits "behind." |
+| **LSP** (Language Server Protocol) | Editor ↔ language server          | Analogous design. ACP is "LSP for AI coding agents."                                           |
+| **A2A** (Agent-to-Agent)           | Agent ↔ agent                     | Different scope. ACP is agent-to-editor, not agent-to-agent.                                   |

--- a/docs/reference/claude-code-history-analysis.md
+++ b/docs/reference/claude-code-history-analysis.md
@@ -3,6 +3,7 @@
 ## Overview
 
 The `~/.claude/` directory is Claude Code's primary data store for:
+
 - User configuration and preferences
 - Session transcripts and history
 - File checkpoints and backups
@@ -57,12 +58,12 @@ Additionally, `~/.claude.json` (in home directory root, **not** inside `~/.claud
 }
 ```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `display` | string | The user's prompt text |
+| Field            | Type   | Description                        |
+| ---------------- | ------ | ---------------------------------- |
+| `display`        | string | The user's prompt text             |
 | `pastedContents` | object | Any pasted content (files, images) |
-| `timestamp` | number | Unix timestamp (milliseconds) |
-| `project` | string | Absolute path to project directory |
+| `timestamp`      | number | Unix timestamp (milliseconds)      |
+| `project`        | string | Absolute path to project directory |
 
 **Dev Journal Use**: Quick activity timeline - shows what was worked on and when, without full conversation context.
 
@@ -75,6 +76,7 @@ Additionally, `~/.claude.json` (in home directory root, **not** inside `~/.claud
 **Purpose**: Aggregated usage metrics computed from session data.
 
 **Structure**:
+
 ```json
 {
   "version": 1,
@@ -142,6 +144,7 @@ Session UUID: 31f3f224-f440-41ac-9244-b27ff054116d
 **Purpose**: Complete conversation transcripts organized by project.
 
 **Structure**:
+
 ```
 projects/
 ├── -Users-sam-Projects-dev-journal/     # Path encoded (/ → -)
@@ -157,6 +160,7 @@ projects/
 #### Message Types
 
 **User Message**:
+
 ```json
 {
   "type": "user",
@@ -180,6 +184,7 @@ projects/
 ```
 
 **Assistant Message**:
+
 ```json
 {
   "type": "assistant",
@@ -195,6 +200,7 @@ projects/
 ```
 
 **File History Snapshot**:
+
 ```json
 {
   "type": "file-history-snapshot",
@@ -215,6 +221,7 @@ projects/
 ```
 
 **Queue Operation** (prompt queuing):
+
 ```json
 {
   "type": "queue-operation",
@@ -225,33 +232,33 @@ projects/
 }
 ```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `operation` | string | `"enqueue"` or `"dequeue"` |
-| `content` | string | The queued prompt text |
+| Field       | Type   | Description                             |
+| ----------- | ------ | --------------------------------------- |
+| `operation` | string | `"enqueue"` or `"dequeue"`              |
+| `content`   | string | The queued prompt text                  |
 | `sessionId` | string | Session this queue operation belongs to |
 
 #### Key Fields Reference
 
-| Field | Description |
-|-------|-------------|
-| `type` | Message type: `user`, `assistant`, `file-history-snapshot`, `queue-operation` |
-| `uuid` | Unique identifier for this message |
-| `parentUuid` | Links response to its prompt (message chain) |
-| `sessionId` | Session identifier (links to other directories) |
-| `isSidechain` | Whether this is part of a side conversation branch (always `true` for sub-agents) |
-| `isMeta` | Whether this is a meta/system message (e.g., command output) |
-| `userType` | User type identifier (e.g., `"external"`) |
-| `cwd` | Working directory at time of message |
-| `gitBranch` | Active git branch |
-| `timestamp` | ISO 8601 timestamp |
-| `thinkingMetadata` | Extended thinking settings: `level`, `disabled`, `triggers` (array) |
-| `toolUseMessages` | Array of tool calls and results |
-| `todos` | Task list state at this message |
-| `slug` | Whimsical session/agent name (e.g., `"sunny-hatching-neumann"`) |
-| `requestId` | API request ID (assistant messages only, e.g., `"req_011CWfFS..."`) |
-| `toolUseResult` | Short summary of tool result (user messages with tool results) |
-| `agentId` | Sub-agent short ID (e.g., `"ac2a8dd"`, matches `agent-{id}.jsonl` filename) |
+| Field              | Description                                                                       |
+| ------------------ | --------------------------------------------------------------------------------- |
+| `type`             | Message type: `user`, `assistant`, `file-history-snapshot`, `queue-operation`     |
+| `uuid`             | Unique identifier for this message                                                |
+| `parentUuid`       | Links response to its prompt (message chain)                                      |
+| `sessionId`        | Session identifier (links to other directories)                                   |
+| `isSidechain`      | Whether this is part of a side conversation branch (always `true` for sub-agents) |
+| `isMeta`           | Whether this is a meta/system message (e.g., command output)                      |
+| `userType`         | User type identifier (e.g., `"external"`)                                         |
+| `cwd`              | Working directory at time of message                                              |
+| `gitBranch`        | Active git branch                                                                 |
+| `timestamp`        | ISO 8601 timestamp                                                                |
+| `thinkingMetadata` | Extended thinking settings: `level`, `disabled`, `triggers` (array)               |
+| `toolUseMessages`  | Array of tool calls and results                                                   |
+| `todos`            | Task list state at this message                                                   |
+| `slug`             | Whimsical session/agent name (e.g., `"sunny-hatching-neumann"`)                   |
+| `requestId`        | API request ID (assistant messages only, e.g., `"req_011CWfFS..."`)               |
+| `toolUseResult`    | Short summary of tool result (user messages with tool results)                    |
+| `agentId`          | Sub-agent short ID (e.g., `"ac2a8dd"`, matches `agent-{id}.jsonl` filename)       |
 
 **Dev Journal Use**: **Primary source** - contains full context of what was accomplished, reasoning, tool usage, and file modifications.
 
@@ -260,11 +267,13 @@ projects/
 The `message.content` field is polymorphic depending on message type:
 
 **User messages (regular prompt)**:
+
 ```json
 "message": { "role": "user", "content": "Help me implement..." }
 ```
 
 **User messages (tool results)**:
+
 ```json
 "message": {
   "role": "user",
@@ -275,6 +284,7 @@ The `message.content` field is polymorphic depending on message type:
 ```
 
 **Assistant messages** (array with multiple content types):
+
 ```json
 "message": {
   "role": "assistant",
@@ -286,12 +296,12 @@ The `message.content` field is polymorphic depending on message type:
 }
 ```
 
-| Content Type | Fields | Description |
-|--------------|--------|-------------|
-| `text` | `text` | Plain text response |
-| `thinking` | `thinking`, `signature` | Extended thinking content (when enabled) |
-| `tool_use` | `id`, `name`, `input` | Tool invocation |
-| `tool_result` | `tool_use_id`, `content`, `is_error` | Tool execution result |
+| Content Type  | Fields                               | Description                              |
+| ------------- | ------------------------------------ | ---------------------------------------- |
+| `text`        | `text`                               | Plain text response                      |
+| `thinking`    | `thinking`, `signature`              | Extended thinking content (when enabled) |
+| `tool_use`    | `id`, `name`, `input`                | Tool invocation                          |
+| `tool_result` | `tool_use_id`, `content`, `is_error` | Tool execution result                    |
 
 #### Tool Use and Permission Decisions
 
@@ -310,12 +320,12 @@ There is no explicit field distinguishing a one-time "Yes" approval from a tool 
 **"Allow All" / Permission Mode Changes**:
 When the user grants blanket permission (e.g., "Yes, allow all edits"), this is reflected as a change in the **`permissionMode`** field on subsequent user-type records. Common values:
 
-| Value | Meaning |
-|---|---|
-| `"default"` | Each tool use may prompt for permission |
-| `"acceptEdits"` | File edits are auto-approved |
-| `"plan"` | Plan mode (exploration only, edits blocked) |
-| `"bypassPermissions"` | All tools auto-approved |
+| Value                 | Meaning                                     |
+| --------------------- | ------------------------------------------- |
+| `"default"`           | Each tool use may prompt for permission     |
+| `"acceptEdits"`       | File edits are auto-approved                |
+| `"plan"`              | Plan mode (exploration only, edits blocked) |
+| `"bypassPermissions"` | All tools auto-approved                     |
 
 Permission mode changes are session-wide and appear on user-type records going forward — they are not recorded as a per-tool-use decision.
 
@@ -334,6 +344,7 @@ Not all `is_error: true` results are user rejections. System-level errors (e.g.,
 **Purpose**: Versioned backups of files edited during sessions for undo/rollback.
 
 **Structure**:
+
 ```
 file-history/
 └── 31f3f224-f440-41ac-9244-b27ff054116d/    # Session UUID
@@ -345,14 +356,15 @@ file-history/
 
 **File Naming**: `{contentHash}@v{versionNumber}`
 
-| Component | Description |
-|-----------|-------------|
-| `contentHash` | 16-character hex hash of file content (e.g., `59e0b9c43163e850`) |
-| `versionNumber` | Sequential version within session (1, 2, 3...) |
+| Component       | Description                                                      |
+| --------------- | ---------------------------------------------------------------- |
+| `contentHash`   | 16-character hex hash of file content (e.g., `59e0b9c43163e850`) |
+| `versionNumber` | Sequential version within session (1, 2, 3...)                   |
 
 **Content**: Raw file content at that version
 
 **Correlation**:
+
 - Directory name = `sessionId` from session transcript
 - `backupFileName` in `file-history-snapshot` messages points to these files
 
@@ -360,23 +372,24 @@ file-history/
 
 The `backupFileName` field in `trackedFileBackups` entries can be:
 
-| Value | When it occurs | Meaning |
-|-------|---------------|---------|
-| `"hash@v1"` | Editing existing files | Backup file exists in `file-history/{sessionId}/` |
-| `null` | **Newly created files** (common at v1) | No previous content to back up |
-| `null` | Edge cases (rare, any version) | Backup creation failed or was skipped |
+| Value       | When it occurs                         | Meaning                                           |
+| ----------- | -------------------------------------- | ------------------------------------------------- |
+| `"hash@v1"` | Editing existing files                 | Backup file exists in `file-history/{sessionId}/` |
+| `null`      | **Newly created files** (common at v1) | No previous content to back up                    |
+| `null`      | Edge cases (rare, any version)         | Backup creation failed or was skipped             |
 
 **Example**: When Claude creates a new file, the first snapshot has `backupFileName: null`:
+
 ```json
 {
   "trackedFileBackups": {
     "new-file.md": {
-      "backupFileName": null,   // No backup - file didn't exist before
+      "backupFileName": null, // No backup - file didn't exist before
       "version": 1,
       "backupTime": "2025-12-11T15:50:50.185Z"
     },
     "existing-file.md": {
-      "backupFileName": "fe8c3c23062c0e71@v1",  // Backup of original content
+      "backupFileName": "fe8c3c23062c0e71@v1", // Backup of original content
       "version": 1,
       "backupTime": "2025-12-11T15:52:13.999Z"
     }
@@ -393,6 +406,7 @@ The `backupFileName` field in `trackedFileBackups` entries can be:
 **Purpose**: Persisted todo lists created during sessions.
 
 **Structure**:
+
 ```
 todos/
 ├── 31f3f224-...-agent-31f3f224-....json    # {sessionId}-agent-{agentId}.json
@@ -410,6 +424,7 @@ todos/
 **Purpose**: Markdown implementation plans created during plan mode.
 
 **Structure**:
+
 ```
 plans/
 ├── cosmic-plotting-bunny.md      # Auto-generated whimsical names
@@ -418,17 +433,22 @@ plans/
 ```
 
 **Content Example**:
+
 ```markdown
 # Chat Exchange Details Modal
 
 ## Goal
+
 Add a clickable link to each message that opens a modal...
 
 ## Approach
+
 Extend sessionStorage to store per-message metadata...
 
 ## Data Structure
+
 ### New sessionStorage key: `chat-rag-message-metadata`
+
 ...
 ```
 
@@ -443,6 +463,7 @@ Extend sessionStorage to store per-message metadata...
 **Purpose**: Debug output for troubleshooting sessions.
 
 **Structure**:
+
 ```
 debug/
 ├── 31f3f224-f440-41ac-9244-b27ff054116d.txt
@@ -452,6 +473,7 @@ debug/
 **Naming**: `{sessionId}.txt`
 
 **Format**: Plain text with timestamped debug entries:
+
 ```
 2025-12-30T00:25:27.892Z [DEBUG] [SLOW OPERATION DETECTED] execSyncWithDefaults (21.7ms): security find-generic-password
 2025-12-30T00:25:27.920Z [DEBUG] Watching for changes in setting files /Users/sam/.claude...
@@ -465,6 +487,7 @@ debug/
 **Purpose**: Per-session environment variable storage.
 
 **Structure**:
+
 ```
 session-env/
 ├── 31f3f224-f440-41ac-9244-b27ff054116d/
@@ -480,6 +503,7 @@ session-env/
 **Purpose**: Captures shell environment for session restoration.
 
 **Structure**:
+
 ```
 shell-snapshots/
 ├── snapshot-zsh-1752622750085-qza877.sh
@@ -497,6 +521,7 @@ shell-snapshots/
 **Purpose**: User-defined slash commands (invoked with `/command-name`).
 
 **Structure**:
+
 ```
 commands/
 ├── brainstorm.md
@@ -524,6 +549,7 @@ description: I've got an idea I want to talk through with you.
 **Purpose**: Skills with multiple files, scripts, and more complex logic.
 
 **Structure**:
+
 ```
 skills/
 ├── dev-journal -> /path/to/skill/directory    # Can be symlinks
@@ -535,6 +561,7 @@ skills/
 ```
 
 **SKILL.md Format**:
+
 ```markdown
 ---
 name: dev-journal
@@ -554,6 +581,7 @@ allowed-tools: Bash Read Write
 **Purpose**: Plugin marketplace integration and installed plugins.
 
 **Structure**:
+
 ```
 plugins/
 ├── cache/                           # Installed plugin files
@@ -567,6 +595,7 @@ plugins/
 ```
 
 **installed_plugins.json Example**:
+
 ```json
 {
   "version": 2,
@@ -595,6 +624,7 @@ plugins/
 **Purpose**: Global user settings applied to all projects.
 
 **Key Sections**:
+
 ```json
 {
   "permissions": {
@@ -616,7 +646,6 @@ plugins/
 }
 ```
 
-
 ---
 
 ## `~/.claude.json` (Root Level)
@@ -629,14 +658,14 @@ plugins/
 
 ### Data Categories
 
-| Category | Fields | Description |
-|----------|--------|-------------|
-| **User Preferences** | `theme`, `preferredNotifChannel`, `showExpandedTodos` | UI and notification settings |
-| **OAuth Session** | `oauthAccount.accountUuid`, `emailAddress`, `organizationUuid` | Authentication state |
-| **MCP Server Configs** | `mcpServers` | User-scope MCP server definitions with credentials |
-| **Per-Project State** | `projects.{path}.*` | Trust dialogs, last session, costs, project-level MCP servers |
-| **Feature Flags** | `cachedStatsigGates`, `cachedGrowthBookFeatures` | A/B testing and feature rollout caches |
-| **Usage Tracking** | `numStartups`, `tipsHistory`, `memoryUsageCount` | Onboarding and tip display state |
+| Category               | Fields                                                         | Description                                                   |
+| ---------------------- | -------------------------------------------------------------- | ------------------------------------------------------------- |
+| **User Preferences**   | `theme`, `preferredNotifChannel`, `showExpandedTodos`          | UI and notification settings                                  |
+| **OAuth Session**      | `oauthAccount.accountUuid`, `emailAddress`, `organizationUuid` | Authentication state                                          |
+| **MCP Server Configs** | `mcpServers`                                                   | User-scope MCP server definitions with credentials            |
+| **Per-Project State**  | `projects.{path}.*`                                            | Trust dialogs, last session, costs, project-level MCP servers |
+| **Feature Flags**      | `cachedStatsigGates`, `cachedGrowthBookFeatures`               | A/B testing and feature rollout caches                        |
+| **Usage Tracking**     | `numStartups`, `tipsHistory`, `memoryUsageCount`               | Onboarding and tip display state                              |
 
 ### Structure
 
@@ -682,18 +711,18 @@ plugins/
 
 ### Per-Project State Fields
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `allowedTools` | array | Project-specific tool permissions |
-| `hasTrustDialogAccepted` | boolean | Whether user accepted project trust dialog |
-| `mcpServers` | object | Project-scope MCP server configurations |
-| `lastSessionId` | string | UUID of most recent session in this project |
-| `lastCost` | number | API cost of last session (USD) |
-| `lastAPIDuration` | number | API response time of last request (ms) |
-| `lastDuration` | number | Total duration of last session (ms) |
-| `exampleFiles` | array | Auto-detected representative files for context |
-| `hasCompletedProjectOnboarding` | boolean | Project onboarding completion state |
-| `dontCrawlDirectory` | boolean | Disable automatic directory indexing |
+| Field                           | Type    | Description                                    |
+| ------------------------------- | ------- | ---------------------------------------------- |
+| `allowedTools`                  | array   | Project-specific tool permissions              |
+| `hasTrustDialogAccepted`        | boolean | Whether user accepted project trust dialog     |
+| `mcpServers`                    | object  | Project-scope MCP server configurations        |
+| `lastSessionId`                 | string  | UUID of most recent session in this project    |
+| `lastCost`                      | number  | API cost of last session (USD)                 |
+| `lastAPIDuration`               | number  | API response time of last request (ms)         |
+| `lastDuration`                  | number  | Total duration of last session (ms)            |
+| `exampleFiles`                  | array   | Auto-detected representative files for context |
+| `hasCompletedProjectOnboarding` | boolean | Project onboarding completion state            |
+| `dontCrawlDirectory`            | boolean | Disable automatic directory indexing           |
 
 ---
 
@@ -709,16 +738,16 @@ These two files serve **complementary, non-duplicative** roles:
 
 ### Comparison
 
-| Aspect | `~/.claude.json` | `~/.claude/settings.json` |
-|--------|-----------------|------------------------|
-| **Location** | `~/` (home root) | `~/.claude/` |
-| **Purpose** | Runtime state, caches, auth | Security rules, hooks, model |
-| **Manual editing** | ❌ Not recommended | ✅ Intended for editing |
-| **What it tracks** | *What has happened* | *What should happen* |
-| **MCP servers** | User-scope definitions | N/A |
-| **Permissions** | N/A | `allow`, `deny`, `ask` rules |
-| **Per-project** | Trust, sessions, costs | Use `.claude/settings.json` in projects |
-| **Git tracking** | Never commit | Project-level can be committed |
+| Aspect             | `~/.claude.json`            | `~/.claude/settings.json`               |
+| ------------------ | --------------------------- | --------------------------------------- |
+| **Location**       | `~/` (home root)            | `~/.claude/`                            |
+| **Purpose**        | Runtime state, caches, auth | Security rules, hooks, model            |
+| **Manual editing** | ❌ Not recommended          | ✅ Intended for editing                 |
+| **What it tracks** | _What has happened_         | _What should happen_                    |
+| **MCP servers**    | User-scope definitions      | N/A                                     |
+| **Permissions**    | N/A                         | `allow`, `deny`, `ask` rules            |
+| **Per-project**    | Trust, sessions, costs      | Use `.claude/settings.json` in projects |
+| **Git tracking**   | Never commit                | Project-level can be committed          |
 
 ### Why Two Files?
 
@@ -805,13 +834,13 @@ Sub-agent messages inherit the parent `sessionId` but add:
 
 ### Data Sources by Use Case
 
-| Need | Primary Source | Secondary Source |
-|------|----------------|------------------|
-| "What did I work on today?" | `history.jsonl` | `projects/*.jsonl` |
-| "What files did I change?" | `file-history/` | Session transcripts |
-| "What problems did I solve?" | `projects/*.jsonl` | - |
-| "How much did I use Claude?" | `stats-cache.json` | - |
-| "What was my plan?" | `plans/*.md` | Session transcripts |
+| Need                         | Primary Source     | Secondary Source    |
+| ---------------------------- | ------------------ | ------------------- |
+| "What did I work on today?"  | `history.jsonl`    | `projects/*.jsonl`  |
+| "What files did I change?"   | `file-history/`    | Session transcripts |
+| "What problems did I solve?" | `projects/*.jsonl` | -                   |
+| "How much did I use Claude?" | `stats-cache.json` | -                   |
+| "What was my plan?"          | `plans/*.md`       | Session transcripts |
 
 ### Recommended Extraction Flow
 

--- a/docs/reference/m5-app-layer-design.md
+++ b/docs/reference/m5-app-layer-design.md
@@ -10,15 +10,15 @@ OS-level sandboxes (Seatbelt, containers) enforce filesystem and network boundar
 
 The capability envelope for a PR session:
 
-| Capability | Access Level | Enforcement Layer |
-|---|---|---|
-| Worktree filesystem | Full read-write | OS sandbox (existing) |
-| Git: commit, branch, push to session branch | Allow | Git hooks (M5) |
-| Git: push to main/master | Deny | Git hooks (M5), network proxy (M7) |
-| `gh pr create/edit` for session's PR | Allow | `gh` shim (M5), network proxy (M7) |
-| `gh pr view`, `gh issue list/view`, repo reads | Allow (read-only) | `gh` shim (M5), network proxy (M7) |
-| `gh pr merge/close` for other PRs | Deny | `gh` shim (M5), network proxy (M7) |
-| Network: github.com, npm registry, etc. | Allowlisted domains | Network proxy (M7) |
+| Capability                                     | Access Level        | Enforcement Layer                  |
+| ---------------------------------------------- | ------------------- | ---------------------------------- |
+| Worktree filesystem                            | Full read-write     | OS sandbox (existing)              |
+| Git: commit, branch, push to session branch    | Allow               | Git hooks (M5)                     |
+| Git: push to main/master                       | Deny                | Git hooks (M5), network proxy (M7) |
+| `gh pr create/edit` for session's PR           | Allow               | `gh` shim (M5), network proxy (M7) |
+| `gh pr view`, `gh issue list/view`, repo reads | Allow (read-only)   | `gh` shim (M5), network proxy (M7) |
+| `gh pr merge/close` for other PRs              | Deny                | `gh` shim (M5), network proxy (M7) |
+| Network: github.com, npm registry, etc.        | Allowlisted domains | Network proxy (M7)                 |
 
 **Policy is static per session** — the PR identity (repo, branch, PR number) is known at session start. Dynamic policy (e.g., agent spawns sub-sessions) is deferred.
 
@@ -90,13 +90,13 @@ Each layer addresses a different part of the threat model. Each milestone makes 
 
 ### Role evolution across milestones
 
-| Mechanism | M5 Role | M6 Role | M7 Role |
-|---|---|---|---|
-| `gh` shim | Security (best-effort) | Security (stronger) | UX + fast-reject |
-| Git hooks | Security (best-effort) | Security (stronger, read-only) | UX |
-| Container | N/A | Filesystem isolation | Filesystem + network routing |
-| Network proxy | N/A | N/A | **Authoritative security** |
-| ACP | Observability | Observability | Observability |
+| Mechanism     | M5 Role                | M6 Role                        | M7 Role                      |
+| ------------- | ---------------------- | ------------------------------ | ---------------------------- |
+| `gh` shim     | Security (best-effort) | Security (stronger)            | UX + fast-reject             |
+| Git hooks     | Security (best-effort) | Security (stronger, read-only) | UX                           |
+| Container     | N/A                    | Filesystem isolation           | Filesystem + network routing |
+| Network proxy | N/A                    | N/A                            | **Authoritative security**   |
+| ACP           | Observability          | Observability                  | Observability                |
 
 ## Key Design Decisions
 
@@ -112,11 +112,11 @@ Each layer addresses a different part of the threat model. Each milestone makes 
 
 Git hooks are inherently bypassable (agent can `--no-verify`, unset `core.hooksPath`, or delete hook files). Mitigation options in containers:
 
-| Approach | Prevents deletion | Prevents config override | Prevents `--no-verify` |
-|---|---|---|---|
-| Read-only hook mount | Yes | No | No |
-| Read-only system gitconfig | Yes | Partially (can override at local level) | No |
-| Read-only `.git/config` | Yes | Yes | No (but breaks normal git ops) |
-| Network proxy | N/A | N/A | Yes (enforcement is external) |
+| Approach                   | Prevents deletion | Prevents config override                | Prevents `--no-verify`         |
+| -------------------------- | ----------------- | --------------------------------------- | ------------------------------ |
+| Read-only hook mount       | Yes               | No                                      | No                             |
+| Read-only system gitconfig | Yes               | Partially (can override at local level) | No                             |
+| Read-only `.git/config`    | Yes               | Yes                                     | No (but breaks normal git ops) |
+| Network proxy              | N/A               | N/A                                     | Yes (enforcement is external)  |
 
 **Conclusion**: Only the network proxy (M7) fully closes the git hook bypass gap. In M5-M6, git hooks are a guardrail, not a boundary.

--- a/docs/reference/orbstack-perf-investigation.md
+++ b/docs/reference/orbstack-perf-investigation.md
@@ -16,12 +16,12 @@ Tested OrbStack bind-mount performance for a representative Node.js project to v
 
 ## Results
 
-| Operation | Native (ms) | OrbStack Bind Mount (ms) | Ratio |
-|---|---|---|---|
-| `git status` | 44 | 7 | 0.16x (faster) |
-| `find . -type f` (6,578 files) | 41 | 63 | 1.5x |
-| `find node_modules` (4,599 files) | 23 | 31 | 1.3x |
-| `tsc --noEmit` | 410 | 173 | 0.4x (faster) |
+| Operation                         | Native (ms) | OrbStack Bind Mount (ms) | Ratio          |
+| --------------------------------- | ----------- | ------------------------ | -------------- |
+| `git status`                      | 44          | 7                        | 0.16x (faster) |
+| `find . -type f` (6,578 files)    | 41          | 63                       | 1.5x           |
+| `find node_modules` (4,599 files) | 23          | 31                       | 1.3x           |
+| `tsc --noEmit`                    | 410         | 173                      | 0.4x (faster)  |
 
 ## Analysis
 

--- a/docs/reference/sandboxing-landscape.md
+++ b/docs/reference/sandboxing-landscape.md
@@ -6,17 +6,17 @@ Research conducted March 2026 to inform Bouncer's architecture.
 
 Every mature sandboxing system defines a **boundary upfront** and lets the process run freely within it. None try to inspect each action and decide "is this one okay?"
 
-| System | Abstraction Level | Policy Model |
-|--------|-------------------|-------------|
-| Capsicum/CloudABI | Object capabilities (fd rights) | Boundary upfront — capabilities granted at process start |
-| Seccomp-BPF | Syscall numbers + args | BPF filter installed upfront, inspects each syscall against fixed program |
-| Landlock | Filesystem paths, network ports | Boundary upfront — stackable rulesets, unprivileged |
-| macOS Seatbelt | Mach/BSD operations + paths | Boundary upfront — SBPL profile compiled at process launch |
-| WASI | Module imports | Boundary upfront — host-granted capability handles |
-| Containers (Docker) | Namespaces + layered policies | Boundary upfront — multi-layer (seccomp + AppArmor + netpol) |
-| gVisor | Syscall emulation | Each syscall intercepted + emulated by user-space kernel |
-| Firecracker | Hardware virtualization (KVM) | Hardware-enforced boundary — VM config at creation |
-| Agent sandboxes (E2B, etc.) | VM or container boundary | Boundary upfront — SDK/API at creation |
+| System                      | Abstraction Level               | Policy Model                                                              |
+| --------------------------- | ------------------------------- | ------------------------------------------------------------------------- |
+| Capsicum/CloudABI           | Object capabilities (fd rights) | Boundary upfront — capabilities granted at process start                  |
+| Seccomp-BPF                 | Syscall numbers + args          | BPF filter installed upfront, inspects each syscall against fixed program |
+| Landlock                    | Filesystem paths, network ports | Boundary upfront — stackable rulesets, unprivileged                       |
+| macOS Seatbelt              | Mach/BSD operations + paths     | Boundary upfront — SBPL profile compiled at process launch                |
+| WASI                        | Module imports                  | Boundary upfront — host-granted capability handles                        |
+| Containers (Docker)         | Namespaces + layered policies   | Boundary upfront — multi-layer (seccomp + AppArmor + netpol)              |
+| gVisor                      | Syscall emulation               | Each syscall intercepted + emulated by user-space kernel                  |
+| Firecracker                 | Hardware virtualization (KVM)   | Hardware-enforced boundary — VM config at creation                        |
+| Agent sandboxes (E2B, etc.) | VM or container boundary        | Boundary upfront — SDK/API at creation                                    |
 
 This pattern directly informed Bouncer's pivot from per-action tool-use classification to boundary-based sandboxing.
 
@@ -43,6 +43,7 @@ Filters are inherited by child processes and can only be made more restrictive. 
 Operates at the filesystem and network access level. A process creates a "ruleset" specifying handled access types, adds rules mapping paths/ports to allowed operations, then enforces the ruleset on itself via `landlock_restrict_self()`.
 
 Key properties:
+
 - **Unprivileged** — any process can sandbox itself without root
 - **Stackable** — each enforcement adds a layer; access granted only if all layers permit
 - **Filesystem + network** — since Linux 6.7, controls both path access and network ports

--- a/docs/reference/seatbelt-reference.md
+++ b/docs/reference/seatbelt-reference.md
@@ -9,12 +9,14 @@ sandbox-exec [options] command [arguments...]
 ```
 
 Options:
+
 - `-f profile-file` — read sandbox profile from a file
 - `-n profile-name` — use a built-in profile by name
 - `-p profile-string` — specify profile inline
 - `-D key=value` — set a profile parameter (repeatable)
 
 Examples:
+
 ```bash
 # Run a command with a profile file
 sandbox-exec -f myprofile.sb /bin/ls /tmp
@@ -130,6 +132,7 @@ Also searchable in Console.app under "Sandbox".
 ### External detection strategy for Bouncer
 
 There is no callback API for sandbox violations. Options:
+
 1. Parse the macOS unified log stream (as above)
 2. Detect `EPERM` errors in ACP tool-call results
 3. Both — log stream for comprehensive monitoring, EPERM for immediate feedback
@@ -149,10 +152,12 @@ Apple has never publicly documented SBPL syntax. Everything known comes from rev
 ### Network filtering is coarse
 
 Seatbelt can:
+
 - Block all network or allow all network
 - Filter to localhost vs. everything: `(allow network* (remote ip "localhost:*"))`
 
 Seatbelt **cannot**:
+
 - Filter by remote domain name
 - Filter by specific remote IP address (only `localhost` or `*`)
 - Filter by specific port for remote hosts
@@ -174,17 +179,20 @@ Since the tool is deprecated, Apple could change behavior without notice. There 
 ## How Others Use It
 
 ### Claude Code (`@anthropic-ai/sandbox-runtime`)
+
 - Dynamically generated profiles scoped to CWD
 - All network blocked except localhost proxy ports
 - HTTP and SOCKS5 proxies outside sandbox enforce domain allowlists
 - Source: https://github.com/anthropic-experimental/sandbox-runtime
 
 ### Cursor
+
 - Dynamically generates SBPL from workspace settings, admin settings, and `.cursorignore`
 - Denies write access to sensitive config (`.vscode/`, `.cursor/`, `.git/config`, git hooks)
 - Source: https://cursor.com/blog/agent-sandboxing
 
 ### OpenAI Codex
+
 - Base policy file inspired by Chromium's sandbox
 - Dynamically constructs profiles from `SandboxPolicy` struct
 - Carves out `.git` directories as read-only

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -100,28 +100,29 @@ The project is structured as an **Electron app** (formerly codenamed "Glitter Ba
 
 ### Key Technologies
 
-| Component | Technology | Notes |
-|-----------|-----------|-------|
-| App shell | Electron | Native app, no server to spin up |
-| UI | React + TypeScript | Chat interface + session management |
-| Agent protocol | ACP (`@agentclientprotocol/sdk`) | JSON-RPC over stdio; sessions, streaming, tool calls, permission requests |
-| Claude Code adapter | `@zed-industries/claude-agent-acp` | Official ACP adapter for Claude Code |
-| OS sandbox (primary) | Containers (Docker/OrbStack) | Isolated filesystem, read-only policy mounts, cross-platform |
-| OS sandbox (fallback) | [agent-safehouse](https://agent-safehouse.dev) | Curated Seatbelt profiles, macOS only; used when Docker unavailable |
-| Worktree management | git CLI | `git worktree add/remove` per session |
-| App-layer policy (M5) | CLI wrappers (`gh` shim, git hooks) | Policy enforcement at the tool level |
-| Container sandbox (M6) | OrbStack (Docker-compatible) | Isolated filesystem, read-only policy mounts |
-| Network boundary (M7) | HTTP proxy + container networking | Authoritative policy enforcement, domain allowlisting |
+| Component              | Technology                                     | Notes                                                                     |
+| ---------------------- | ---------------------------------------------- | ------------------------------------------------------------------------- |
+| App shell              | Electron                                       | Native app, no server to spin up                                          |
+| UI                     | React + TypeScript                             | Chat interface + session management                                       |
+| Agent protocol         | ACP (`@agentclientprotocol/sdk`)               | JSON-RPC over stdio; sessions, streaming, tool calls, permission requests |
+| Claude Code adapter    | `@zed-industries/claude-agent-acp`             | Official ACP adapter for Claude Code                                      |
+| OS sandbox (primary)   | Containers (Docker/OrbStack)                   | Isolated filesystem, read-only policy mounts, cross-platform              |
+| OS sandbox (fallback)  | [agent-safehouse](https://agent-safehouse.dev) | Curated Seatbelt profiles, macOS only; used when Docker unavailable       |
+| Worktree management    | git CLI                                        | `git worktree add/remove` per session                                     |
+| App-layer policy (M5)  | CLI wrappers (`gh` shim, git hooks)            | Policy enforcement at the tool level                                      |
+| Container sandbox (M6) | OrbStack (Docker-compatible)                   | Isolated filesystem, read-only policy mounts                              |
+| Network boundary (M7)  | HTTP proxy + container networking              | Authoritative policy enforcement, domain allowlisting                     |
 
 ### Sandbox Primitive: Seatbelt vs. Containers
 
 The project's sandbox enforcement layer is designed to be swappable. We currently use macOS Seatbelt (via agent-safehouse) for fast iteration, with a planned migration to containers. This section captures the tradeoff analysis.
 
-**The carveout problem with Seatbelt.** Seatbelt works by starting with "deny everything" and adding back exceptions for every path the agent needs — toolchain caches, shell config, git config, SSH keys, system libraries, Mach IPC services, etc. Every new tool integration is another set of paths to enumerate. Agent-safehouse demonstrates this vividly: separate profile modules for Node, Rust, Python, Go, Java, Ruby, Perl, PHP, Bun, Deno, plus optional integrations for Docker, kubectl, Playwright, Xcode, and more. The profile library *is* the product, and it's always chasing the long tail.
+**The carveout problem with Seatbelt.** Seatbelt works by starting with "deny everything" and adding back exceptions for every path the agent needs — toolchain caches, shell config, git config, SSH keys, system libraries, Mach IPC services, etc. Every new tool integration is another set of paths to enumerate. Agent-safehouse demonstrates this vividly: separate profile modules for Node, Rust, Python, Go, Java, Ruby, Perl, PHP, Bun, Deno, plus optional integrations for Docker, kubectl, Playwright, Xcode, and more. The profile library _is_ the product, and it's always chasing the long tail.
 
 **Containers flip the model.** Instead of subtracting from the host, you build up a known-good environment. The agent gets its own filesystem root with exactly the tools it needs, and the boundary is "nothing outside the container" rather than "everything except these enumerated paths." You don't need to know where pnpm stores its cache on macOS vs. Linux — the container has its own copy. Adding a toolchain means updating a Dockerfile, not discovering and whitelisting a dozen host paths.
 
 **Where containers are clearly better:**
+
 - **Cross-platform**: Docker works on macOS, Linux, and Windows. Seatbelt is macOS-only.
 - **Reproducibility**: A container image is a snapshot. Same image = identical environment across sessions and machines.
 - **The carveout problem goes away**: No need to enumerate global paths. The container has its own copies of everything.
@@ -129,6 +130,7 @@ The project's sandbox enforcement layer is designed to be swappable. We currentl
 - **Ecosystem maturity**: E2B, Daytona, Modal, and Kubernetes Agent Sandbox all use containers or VMs.
 
 **Where Seatbelt/safehouse is clearly better:**
+
 - **Startup latency**: Near-zero overhead vs. 500ms-2s for container start.
 - **Host integration**: Agent sees the user's actual git config, SSH keys, shell environment. In a container, these must be explicitly mounted or copied.
 - **Simplicity for prototyping**: A single CLI call vs. Docker daemon, images, volumes, networking config.
@@ -197,6 +199,7 @@ The project's sandbox enforcement layer is designed to be swappable. We currentl
 **Design use case**: A session where the agent creates and iterates on a pull request. The PR identity (repo, branch, PR number) is static for the session — known at session start. See [M5 design investigation](reference/m5-app-layer-design.md) for the full analysis.
 
 **`gh` shim:**
+
 - A policy-aware wrapper placed on the agent's `PATH` that intercepts `gh` commands
 - Parses the `gh` subcommand grammar and enforces session policy:
   - **Allow**: `gh pr create`, `gh pr edit` (for this session's PR), `gh pr view`, `gh issue list/view`, repo metadata reads
@@ -206,16 +209,19 @@ The project's sandbox enforcement layer is designed to be swappable. We currentl
 - GitHub auth: read the user's existing `gh auth` token (zero setup); consider OAuth device flow as a future upgrade for tighter scoping
 
 **Git hooks:**
+
 - `pre-push` hook restricting which remote refs the agent can push to (e.g., allow `agent/feature-branch`, deny `main`/`master`)
 - Installed in the worktree during session setup via `core.hooksPath` pointing to a Bouncer-managed directory
 - On Seatbelt, these are guardrails (the agent could bypass them); the container migration (M6) makes them harder to tamper with via read-only mounts
 
 **ACP observability:**
+
 - Log `gh` and `git` invocations (allowed and denied) via ACP for UI visibility
 - Surface policy violations in the session event log
 - ACP is the observability layer, not the enforcement layer
 
 **Known gaps (addressed in M6-M7):**
+
 - Agent can bypass the `gh` shim via `curl` to `api.github.com` (closed by M7 network proxy)
 - Agent can bypass git hooks via `--no-verify` or by unsetting `core.hooksPath` (mitigated by M6 read-only mounts, closed by M7 network proxy)
 - The real `gh` binary is still accessible on the host filesystem (closed by M6 container isolation)
@@ -227,6 +233,7 @@ The project's sandbox enforcement layer is designed to be swappable. We currentl
 **Status**: Complete. See [design](history/container-migration/design.md) and [implementation plan](history/container-migration/plan.md).
 
 **What was built:**
+
 - `docker/agent.Dockerfile`: agent container image based on `docker/sandbox-templates:claude-code`, with Rust toolchain and no real `gh` binary
 - `src/main/container.ts`: Docker availability detection, content-hash-tagged image builds, container spawn/teardown/orphan cleanup with label-based discovery
 - `src/main/policy-container.ts`: converts PolicyTemplate + session context into ContainerConfig with the full mount table (worktree, git common dir, agent binary, node_modules, hooks, shim, policy state, gitconfig, credential helper, Claude config)
@@ -244,6 +251,7 @@ The project's sandbox enforcement layer is designed to be swappable. We currentl
 **Status**: Complete. See [design](history/network-boundary/design.md) and [implementation plan](history/network-boundary/plan.md).
 
 **What was built:**
+
 - `src/main/proxy-tls.ts`: Self-signed CA generation and per-hostname certificate minting for TLS MITM
 - `src/main/proxy.ts`: HTTP proxy server with domain allowlisting, HTTPS CONNECT tunneling, and selective TLS MITM
 - `src/main/proxy-github.ts`: GitHub-specific MITM handler — REST API policy enforcement and git push ref enforcement
@@ -255,12 +263,12 @@ The project's sandbox enforcement layer is designed to be swappable. We currentl
 
 **Enforcement roles after M7:**
 
-| Mechanism | Role |
-|---|---|
-| `gh` shim | UX (better error messages) + fast-reject optimization |
-| Git hooks | UX (better error messages) |
-| Network proxy | **Authoritative security boundary** |
-| ACP | Observability and session event logging |
+| Mechanism     | Role                                                  |
+| ------------- | ----------------------------------------------------- |
+| `gh` shim     | UX (better error messages) + fast-reject optimization |
+| Git hooks     | UX (better error messages)                            |
+| Network proxy | **Authoritative security boundary**                   |
+| ACP           | Observability and session event logging               |
 
 ### Milestone 8: Workspaces Sidebar
 
@@ -269,6 +277,7 @@ The project's sandbox enforcement layer is designed to be swappable. We currentl
 **Status**: Complete. See [design](history/workspaces-sidebar/design.md) and [implementation plan](history/workspaces-sidebar/plan.md).
 
 **What was built:**
+
 - Terminology rename: "session" → "workspace", "glitterball" → "bouncer" across the entire codebase
 - `src/main/repository-store.ts`: Persistent repository list at `~/.config/bouncer/repositories.json` with auto-detection of repo name and GitHub remote
 - `Repository` type with configurable defaults (policy template, agent type)

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,25 +1,25 @@
-import { resolve } from 'path'
-import { defineConfig, externalizeDepsPlugin } from 'electron-vite'
-import react from '@vitejs/plugin-react'
+import { resolve } from 'path';
+import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   main: {
-    plugins: [externalizeDepsPlugin()]
+    plugins: [externalizeDepsPlugin()],
   },
   preload: {
     plugins: [externalizeDepsPlugin()],
     build: {
       rollupOptions: {
-        output: { format: 'cjs', entryFileNames: '[name].cjs' }
-      }
-    }
+        output: { format: 'cjs', entryFileNames: '[name].cjs' },
+      },
+    },
   },
   renderer: {
     resolve: {
       alias: {
-        '@renderer': resolve('src/renderer/src')
-      }
+        '@renderer': resolve('src/renderer/src'),
+      },
     },
-    plugins: [react()]
-  }
-})
+    plugins: [react()],
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@vitejs/plugin-react": "^5.2.0",
         "electron": "^41.0.3",
         "electron-vite": "^5.0.0",
+        "prettier": "^3.8.1",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vite": "^7.3.1"
@@ -96,7 +97,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1713,7 +1713,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1848,7 +1847,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3841,7 +3839,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3876,6 +3873,21 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/progress": {
@@ -3927,7 +3939,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4993,7 +5004,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5577,7 +5587,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "test:proxy-network": "tsx scripts/test-proxy-network.ts",
     "test:github-policy-engine": "tsx scripts/test-github-policy-engine.ts",
     "test:proxy-github": "tsx scripts/test-proxy-github.ts",
-    "test:proxy-e2e": "tsx scripts/test-proxy-e2e.ts"
+    "test:proxy-e2e": "tsx scripts/test-proxy-e2e.ts",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
@@ -51,6 +53,7 @@
     "@vitejs/plugin-react": "^5.2.0",
     "electron": "^41.0.3",
     "electron-vite": "^5.0.0",
+    "prettier": "^3.8.1",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vite": "^7.3.1"

--- a/scripts/replay-test.ts
+++ b/scripts/replay-test.ts
@@ -18,41 +18,41 @@
  *
  * If neither --session nor --sessions is specified, all sessions are replayed (batch mode).
  */
-import { spawn } from "node:child_process";
-import { createRequire } from "node:module";
-import { randomUUID } from "node:crypto";
-import { writeFileSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-import { homedir, userInfo } from "node:os";
-import { Writable, Readable } from "node:stream";
-import * as acp from "@agentclientprotocol/sdk";
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { randomUUID } from 'node:crypto';
+import { writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { homedir, userInfo } from 'node:os';
+import { Writable, Readable } from 'node:stream';
+import * as acp from '@agentclientprotocol/sdk';
 
-import { loadDataset } from "../src/main/dataset-loader.js";
-import { buildScaffoldPlan, applyScaffold } from "../src/main/replay-scaffold.js";
-import { WorktreeManager } from "../src/main/worktree-manager.js";
-import { PolicyTemplateRegistry } from "../src/main/policy-registry.js";
-import { policyToSandboxConfig } from "../src/main/policy-sandbox.js";
+import { loadDataset } from '../src/main/dataset-loader.js';
+import { buildScaffoldPlan, applyScaffold } from '../src/main/replay-scaffold.js';
+import { WorktreeManager } from '../src/main/worktree-manager.js';
+import { PolicyTemplateRegistry } from '../src/main/policy-registry.js';
+import { policyToSandboxConfig } from '../src/main/policy-sandbox.js';
 import {
   buildSafehouseArgs,
   isSafehouseAvailable,
   ensurePolicyDir,
   writeAppendProfile,
   cleanupPolicy,
-} from "../src/main/sandbox.js";
-import type { ReplayToolCall, ReplayResult } from "../src/main/types.js";
+} from '../src/main/sandbox.js';
+import type { ReplayToolCall, ReplayResult } from '../src/main/types.js';
 
 // --- CLI arg parsing ---
 
 function parseArgs(argv: string[]) {
   const args = argv.slice(2);
   const opts = {
-    policy: "standard-pr",
-    session: "",
-    sessions: "" as string,
+    policy: 'standard-pr',
+    session: '',
+    sessions: '' as string,
     projectDir: process.cwd(),
-    dataset: join(process.cwd(), "data", "tool-use-dataset.jsonl"),
-    output: "",
+    dataset: join(process.cwd(), 'data', 'tool-use-dataset.jsonl'),
+    output: '',
     concurrency: 4,
     noSandbox: false,
   };
@@ -67,22 +67,36 @@ function parseArgs(argv: string[]) {
       return args[++i];
     };
     switch (flag) {
-      case "--policy": opts.policy = next(); break;
-      case "--session": opts.session = next(); break;
-      case "--sessions": opts.sessions = next(); break;
-      case "--project-dir": opts.projectDir = next(); break;
-      case "--dataset": opts.dataset = next(); break;
-      case "--output": opts.output = next(); break;
-      case "--concurrency": {
+      case '--policy':
+        opts.policy = next();
+        break;
+      case '--session':
+        opts.session = next();
+        break;
+      case '--sessions':
+        opts.sessions = next();
+        break;
+      case '--project-dir':
+        opts.projectDir = next();
+        break;
+      case '--dataset':
+        opts.dataset = next();
+        break;
+      case '--output':
+        opts.output = next();
+        break;
+      case '--concurrency': {
         const val = parseInt(next(), 10);
         if (Number.isNaN(val) || val < 1) {
-          console.error("--concurrency must be an integer >= 1");
+          console.error('--concurrency must be an integer >= 1');
           process.exit(1);
         }
         opts.concurrency = val;
         break;
       }
-      case "--no-sandbox": opts.noSandbox = true; break;
+      case '--no-sandbox':
+        opts.noSandbox = true;
+        break;
       default:
         console.error(`Unknown option: ${args[i]}`);
         process.exit(1);
@@ -94,7 +108,11 @@ function parseArgs(argv: string[]) {
 // --- De-anonymization ---
 
 function getSafeUsername(): string {
-  try { return userInfo().username; } catch { return process.env.USER || process.env.USERNAME || "unknown"; }
+  try {
+    return userInfo().username;
+  } catch {
+    return process.env.USER || process.env.USERNAME || 'unknown';
+  }
 }
 
 function makeDeanonymize(worktreePath: string) {
@@ -142,7 +160,10 @@ interface ReplayReport {
 function computeByToolBreakdown(
   results: ReplayResult[],
 ): Record<string, { allowed: number; blocked: number; skipped: number; error: number }> {
-  const byTool: Record<string, { allowed: number; blocked: number; skipped: number; error: number }> = {};
+  const byTool: Record<
+    string,
+    { allowed: number; blocked: number; skipped: number; error: number }
+  > = {};
   for (const r of results) {
     if (!byTool[r.tool]) {
       byTool[r.tool] = { allowed: 0, blocked: 0, skipped: 0, error: 0 };
@@ -158,13 +179,13 @@ function buildReport(
   datasetPath: string,
 ): ReplayReport {
   const allResults = sessionResults.flatMap((s) => s.results);
-  const allowed = allResults.filter((r) => r.replay_outcome === "allowed").length;
-  const blocked = allResults.filter((r) => r.replay_outcome === "blocked").length;
-  const skipped = allResults.filter((r) => r.replay_outcome === "skipped").length;
-  const error = allResults.filter((r) => r.replay_outcome === "error").length;
+  const allowed = allResults.filter((r) => r.replay_outcome === 'allowed').length;
+  const blocked = allResults.filter((r) => r.replay_outcome === 'blocked').length;
+  const skipped = allResults.filter((r) => r.replay_outcome === 'skipped').length;
+  const error = allResults.filter((r) => r.replay_outcome === 'error').length;
 
   const falseBlocks = allResults.filter(
-    (r) => r.replay_outcome === "blocked" && r.original_outcome === "approved",
+    (r) => r.replay_outcome === 'blocked' && r.original_outcome === 'approved',
   ).length;
   const actionable = allowed + blocked;
 
@@ -228,14 +249,14 @@ async function replaySession(
       });
       await writeAppendProfile(sandboxConfig);
     } else if (!noSandbox) {
-      process.stderr.write("  Warning: safehouse not available, running unsandboxed\n");
+      process.stderr.write('  Warning: safehouse not available, running unsandboxed\n');
     }
 
     // Resolve replay agent spawn args
     const require = createRequire(import.meta.url);
-    const tsxBin = require.resolve("tsx/cli");
+    const tsxBin = require.resolve('tsx/cli');
     const scriptDir = dirname(fileURLToPath(import.meta.url));
-    const agentScript = join(scriptDir, "..", "src", "agents", "replay-agent.ts");
+    const agentScript = join(scriptDir, '..', 'src', 'agents', 'replay-agent.ts');
     let cmd = process.execPath;
     let args = [tsxBin, agentScript];
     const env: Record<string, string> = {
@@ -244,18 +265,18 @@ async function replaySession(
 
     if (sandboxConfig) {
       const safehouseArgs = buildSafehouseArgs(sandboxConfig, [cmd, ...args]);
-      cmd = "safehouse";
+      cmd = 'safehouse';
       args = safehouseArgs;
     }
 
     // Spawn agent
     agentProcess = spawn(cmd, args, {
-      stdio: ["pipe", "pipe", "pipe"],
+      stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env, ...env },
       cwd: worktree.path,
     });
 
-    agentProcess.stderr?.on("data", (data: Buffer) => {
+    agentProcess.stderr?.on('data', (data: Buffer) => {
       process.stderr.write(data);
     });
 
@@ -270,7 +291,7 @@ async function replaySession(
       (_agent) => ({
         async sessionUpdate(params) {
           const update = params.update;
-          if (update.sessionUpdate === "tool_call") {
+          if (update.sessionUpdate === 'tool_call') {
             const meta = update._meta as { replay?: ReplayResult } | undefined;
             if (meta?.replay) {
               results.push(meta.replay);
@@ -278,7 +299,7 @@ async function replaySession(
           }
         },
         async requestPermission(_params) {
-          return { outcome: { outcome: "cancelled" as const } };
+          return { outcome: { outcome: 'cancelled' as const } };
         },
       }),
       stream,
@@ -297,7 +318,7 @@ async function replaySession(
     // Send tool calls
     await connection.prompt({
       sessionId: acpSession.sessionId,
-      prompt: [{ type: "text", text: JSON.stringify(toolCalls) }],
+      prompt: [{ type: 'text', text: JSON.stringify(toolCalls) }],
     });
 
     return {
@@ -333,7 +354,9 @@ async function replayBatch(
     while (index < entries.length) {
       const i = index++;
       const [sessionId, toolCalls] = entries[i];
-      process.stderr.write(`[${i + 1}/${entries.length}] ${sessionId} (${toolCalls.length} calls)...\n`);
+      process.stderr.write(
+        `[${i + 1}/${entries.length}] ${sessionId} (${toolCalls.length} calls)...\n`,
+      );
       try {
         results[i] = await replaySession(sessionId, toolCalls, policyId, projectDir, noSandbox);
       } catch (err) {
@@ -359,7 +382,9 @@ async function replayBatch(
 function printSummary(report: ReplayReport) {
   const s = report.summary;
   process.stderr.write(`\n=== ${report.metadata.policyId} ===\n`);
-  process.stderr.write(`Sessions: ${report.metadata.sessionsCompleted} completed, ${report.metadata.sessionsFailed} failed\n`);
+  process.stderr.write(
+    `Sessions: ${report.metadata.sessionsCompleted} completed, ${report.metadata.sessionsFailed} failed\n`,
+  );
   process.stderr.write(`Tool calls: ${s.totalToolCalls} total\n`);
   process.stderr.write(`  Allowed: ${s.allowed} (${pct(s.allowed, s.totalToolCalls)})\n`);
   process.stderr.write(`  Blocked: ${s.blocked} (${pct(s.blocked, s.totalToolCalls)})\n`);
@@ -380,17 +405,17 @@ function printSummary(report: ReplayReport) {
       const total = counts.allowed + counts.blocked + counts.skipped + counts.error;
       process.stderr.write(
         `  ${tool.padEnd(12)} ${String(total).padStart(5)} total | ` +
-        `${String(counts.allowed).padStart(5)} allowed | ` +
-        `${String(counts.blocked).padStart(4)} blocked | ` +
-        `${String(counts.skipped).padStart(4)} skipped | ` +
-        `${String(counts.error).padStart(4)} error\n`,
+          `${String(counts.allowed).padStart(5)} allowed | ` +
+          `${String(counts.blocked).padStart(4)} blocked | ` +
+          `${String(counts.skipped).padStart(4)} skipped | ` +
+          `${String(counts.error).padStart(4)} error\n`,
       );
     }
   }
 }
 
 function pct(n: number, total: number): string {
-  return total > 0 ? `${((n / total) * 100).toFixed(1)}%` : "0.0%";
+  return total > 0 ? `${((n / total) * 100).toFixed(1)}%` : '0.0%';
 }
 
 // --- Main ---
@@ -412,10 +437,10 @@ try {
     targetSessions = new Map([[opts.session, toolCalls]]);
   } else if (opts.sessions) {
     targetSessions = new Map<string, ReplayToolCall[]>();
-    for (const id of opts.sessions.split(",")) {
+    for (const id of opts.sessions.split(',')) {
       const trimmed = id.trim();
       if (!trimmed) {
-        console.error("Empty session ID in --sessions");
+        console.error('Empty session ID in --sessions');
         process.exit(1);
       }
       const toolCalls = allSessions.get(trimmed);
@@ -433,18 +458,21 @@ try {
 
   // Resolve which policies to run against
   const registry = new PolicyTemplateRegistry();
-  if (opts.policy !== "all") {
+  if (opts.policy !== 'all') {
     try {
       registry.get(opts.policy);
     } catch {
       console.error(`Unknown policy: ${opts.policy}`);
-      console.error(`Available: ${registry.list().map((p) => p.id).join(", ")}, or "all"`);
+      console.error(
+        `Available: ${registry
+          .list()
+          .map((p) => p.id)
+          .join(', ')}, or "all"`,
+      );
       process.exit(1);
     }
   }
-  const policyIds = opts.policy === "all"
-    ? registry.list().map((p) => p.id)
-    : [opts.policy];
+  const policyIds = opts.policy === 'all' ? registry.list().map((p) => p.id) : [opts.policy];
 
   // Run each policy
   const allReports: Record<string, ReplayReport> = {};
@@ -455,11 +483,21 @@ try {
     if (targetSessions.size === 1) {
       const [sessionId, toolCalls] = targetSessions.entries().next().value!;
       process.stderr.write(`Replaying ${sessionId} (${toolCalls.length} tool calls)...\n`);
-      const result = await replaySession(sessionId, toolCalls, policyId, opts.projectDir, opts.noSandbox);
+      const result = await replaySession(
+        sessionId,
+        toolCalls,
+        policyId,
+        opts.projectDir,
+        opts.noSandbox,
+      );
       sessionResults = [result];
     } else {
       sessionResults = await replayBatch(
-        targetSessions, policyId, opts.projectDir, opts.concurrency, opts.noSandbox,
+        targetSessions,
+        policyId,
+        opts.projectDir,
+        opts.concurrency,
+        opts.noSandbox,
       );
     }
 
@@ -472,12 +510,12 @@ try {
   const output = policyIds.length === 1 ? allReports[policyIds[0]] : allReports;
   const reportJson = JSON.stringify(output, null, 2);
   if (opts.output) {
-    writeFileSync(opts.output, reportJson, "utf-8");
+    writeFileSync(opts.output, reportJson, 'utf-8');
     process.stderr.write(`\nReport written to ${opts.output}\n`);
   } else {
     console.log(reportJson);
   }
 } catch (err) {
-  console.error("Fatal:", err);
+  console.error('Fatal:', err);
   process.exit(1);
 }

--- a/scripts/test-app-layer-policy.ts
+++ b/scripts/test-app-layer-policy.ts
@@ -8,13 +8,13 @@
 //
 // Usage: npx tsx scripts/test-app-layer-policy.ts
 
-import assert from "node:assert/strict";
-import { existsSync, statSync } from "node:fs";
-import { readFile, mkdtemp, rm } from "node:fs/promises";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
+import assert from 'node:assert/strict';
+import { existsSync, statSync } from 'node:fs';
+import { readFile, mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import {
   detectGitHubRepo,
   buildSessionPolicy,
@@ -27,14 +27,9 @@ import {
   shimBinDir,
   findRealGh,
   cleanupOrphanGitHubArtifacts,
-} from "../src/main/github-policy.js";
-import {
-  installHooks,
-  cleanupHooks,
-  hooksDir,
-  allowedRefsPath,
-} from "../src/main/hooks.js";
-import { POLICY_DIR } from "../src/main/sandbox.js";
+} from '../src/main/github-policy.js';
+import { installHooks, cleanupHooks, hooksDir, allowedRefsPath } from '../src/main/hooks.js';
+import { POLICY_DIR } from '../src/main/sandbox.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -64,71 +59,87 @@ interface TestRepo {
 }
 
 async function createTestRepo(): Promise<TestRepo> {
-  const baseDir = await mkdtemp(join(tmpdir(), "bouncer-app-layer-test-"));
-  const bareDir = join(baseDir, "bare.git");
-  const mainDir = join(baseDir, "main");
-  const worktreeDir = join(baseDir, "worktree");
-  const branch = "bouncer/test-session";
+  const baseDir = await mkdtemp(join(tmpdir(), 'bouncer-app-layer-test-'));
+  const bareDir = join(baseDir, 'bare.git');
+  const mainDir = join(baseDir, 'main');
+  const worktreeDir = join(baseDir, 'worktree');
+  const branch = 'bouncer/test-session';
 
   // Create a bare repo as the push target
-  await execFileAsync("git", ["init", "--bare", "--initial-branch=main", bareDir]);
+  await execFileAsync('git', ['init', '--bare', '--initial-branch=main', bareDir]);
 
   // Clone it and set up for testing
-  await execFileAsync("git", ["clone", bareDir, mainDir]);
-  await execFileAsync("git", ["-C", mainDir, "config", "user.email", "test@test.com"]);
-  await execFileAsync("git", ["-C", mainDir, "config", "user.name", "Test"]);
-  await execFileAsync("git", ["-C", mainDir, "checkout", "-b", "main"]);
-  await execFileAsync("git", ["-C", mainDir, "commit", "--allow-empty", "-m", "init"]);
-  await execFileAsync("git", ["-C", mainDir, "push", "-u", "origin", "main"]);
+  await execFileAsync('git', ['clone', bareDir, mainDir]);
+  await execFileAsync('git', ['-C', mainDir, 'config', 'user.email', 'test@test.com']);
+  await execFileAsync('git', ['-C', mainDir, 'config', 'user.name', 'Test']);
+  await execFileAsync('git', ['-C', mainDir, 'checkout', '-b', 'main']);
+  await execFileAsync('git', ['-C', mainDir, 'commit', '--allow-empty', '-m', 'init']);
+  await execFileAsync('git', ['-C', mainDir, 'push', '-u', 'origin', 'main']);
 
   // Create worktree
-  await execFileAsync("git", ["-C", mainDir, "worktree", "add", "-b", branch, worktreeDir]);
+  await execFileAsync('git', ['-C', mainDir, 'worktree', 'add', '-b', branch, worktreeDir]);
 
   // Add a "local" remote for actual pushes (shared across all worktrees).
   // Then repoint origin to a GitHub URL so detectGitHubRepo works.
-  await execFileAsync("git", ["-C", mainDir, "remote", "add", "local", bareDir]);
-  await execFileAsync("git", ["-C", mainDir, "remote", "set-url", "origin", "https://github.com/test-owner/test-repo.git"]);
+  await execFileAsync('git', ['-C', mainDir, 'remote', 'add', 'local', bareDir]);
+  await execFileAsync('git', [
+    '-C',
+    mainDir,
+    'remote',
+    'set-url',
+    'origin',
+    'https://github.com/test-owner/test-repo.git',
+  ]);
 
   return { bareDir, mainDir, worktreeDir, branch };
 }
 
 async function cleanupTestRepo(repo: TestRepo): Promise<void> {
   try {
-    await execFileAsync("git", ["-C", repo.mainDir, "worktree", "remove", "--force", repo.worktreeDir]);
-  } catch { /* may be gone */ }
-  await rm(join(repo.bareDir, ".."), { recursive: true, force: true });
+    await execFileAsync('git', [
+      '-C',
+      repo.mainDir,
+      'worktree',
+      'remove',
+      '--force',
+      repo.worktreeDir,
+    ]);
+  } catch {
+    /* may be gone */
+  }
+  await rm(join(repo.bareDir, '..'), { recursive: true, force: true });
 }
 
 // ==========================================================
 // Tests
 // ==========================================================
 
-console.log("=== Application-Layer Policy Integration Tests ===\n");
+console.log('=== Application-Layer Policy Integration Tests ===\n');
 
 const sessionId = `test-app-layer-${Date.now()}`;
 let repo: TestRepo;
 
 // --- Setup ---
 
-console.log("Setup:");
+console.log('Setup:');
 
-await test("create test repo with GitHub remote", async () => {
+await test('create test repo with GitHub remote', async () => {
   repo = await createTestRepo();
   assert.ok(existsSync(repo.worktreeDir));
 });
 
 // --- Full lifecycle ---
 
-console.log("\nPolicy lifecycle:");
+console.log('\nPolicy lifecycle:');
 
-await test("detect GitHub repo from worktree", async () => {
+await test('detect GitHub repo from worktree', async () => {
   const detected = await detectGitHubRepo(repo.worktreeDir);
-  assert.equal(detected, "test-owner/test-repo");
+  assert.equal(detected, 'test-owner/test-repo');
 });
 
-await test("build and write policy state", async () => {
-  const policy = buildSessionPolicy("test-owner/test-repo", repo.branch);
-  assert.equal(policy.repo, "test-owner/test-repo");
+await test('build and write policy state', async () => {
+  const policy = buildSessionPolicy('test-owner/test-repo', repo.branch);
+  assert.equal(policy.repo, 'test-owner/test-repo');
   assert.deepEqual(policy.allowedPushRefs, [repo.branch]);
   assert.equal(policy.canCreatePr, true);
   assert.equal(policy.ownedPrNumber, null);
@@ -140,80 +151,91 @@ await test("build and write policy state", async () => {
   assert.deepEqual(loaded, policy);
 });
 
-await test("install gh shim", async () => {
-  const ghShimTs = join(process.cwd(), "src", "main", "gh-shim.ts");
+await test('install gh shim', async () => {
+  const ghShimTs = join(process.cwd(), 'src', 'main', 'gh-shim.ts');
   const dir = await installGhShim(sessionId, ghShimTs, process.execPath);
 
   assert.equal(dir, shimBinDir(sessionId));
-  assert.ok(existsSync(join(dir, "gh")), "gh shim should exist");
+  assert.ok(existsSync(join(dir, 'gh')), 'gh shim should exist');
 
   // Verify it's executable
-  const stats = statSync(join(dir, "gh"));
-  assert.ok(stats.mode & 0o111, "gh shim should be executable");
+  const stats = statSync(join(dir, 'gh'));
+  assert.ok(stats.mode & 0o111, 'gh shim should be executable');
 
   // Verify it references the right paths
-  const content = await readFile(join(dir, "gh"), "utf-8");
-  assert.ok(content.includes("gh-shim-bundle.js"), "should reference the bundled shim");
+  const content = await readFile(join(dir, 'gh'), 'utf-8');
+  assert.ok(content.includes('gh-shim-bundle.js'), 'should reference the bundled shim');
 });
 
-await test("install hooks", async () => {
+await test('install hooks', async () => {
   await installHooks(sessionId, repo.worktreeDir, [repo.branch]);
 
-  assert.ok(existsSync(hooksDir(sessionId)), "hooks dir should exist");
-  assert.ok(existsSync(allowedRefsPath(sessionId)), "allowed-refs should exist");
+  assert.ok(existsSync(hooksDir(sessionId)), 'hooks dir should exist');
+  assert.ok(existsSync(allowedRefsPath(sessionId)), 'allowed-refs should exist');
 
-  const { stdout } = await execFileAsync("git", ["-C", repo.worktreeDir, "config", "core.hooksPath"]);
+  const { stdout } = await execFileAsync('git', [
+    '-C',
+    repo.worktreeDir,
+    'config',
+    'core.hooksPath',
+  ]);
   assert.equal(stdout.trim(), hooksDir(sessionId));
 });
 
-console.log("\nArtifact verification:");
+console.log('\nArtifact verification:');
 
-await test("all artifacts exist", async () => {
-  assert.ok(existsSync(policyStatePath(sessionId)), "policy state file");
-  assert.ok(existsSync(shimBinDir(sessionId)), "shim bin dir");
-  assert.ok(existsSync(join(shimBinDir(sessionId), "gh")), "gh shim script");
-  assert.ok(existsSync(hooksDir(sessionId)), "hooks dir");
-  assert.ok(existsSync(join(hooksDir(sessionId), "pre-push")), "pre-push hook");
-  assert.ok(existsSync(allowedRefsPath(sessionId)), "allowed-refs file");
+await test('all artifacts exist', async () => {
+  assert.ok(existsSync(policyStatePath(sessionId)), 'policy state file');
+  assert.ok(existsSync(shimBinDir(sessionId)), 'shim bin dir');
+  assert.ok(existsSync(join(shimBinDir(sessionId), 'gh')), 'gh shim script');
+  assert.ok(existsSync(hooksDir(sessionId)), 'hooks dir');
+  assert.ok(existsSync(join(hooksDir(sessionId), 'pre-push')), 'pre-push hook');
+  assert.ok(existsSync(allowedRefsPath(sessionId)), 'allowed-refs file');
 });
 
-await test("push to allowed ref works through hooks", async () => {
-  await execFileAsync("git", ["-C", repo.worktreeDir, "commit", "--allow-empty", "-m", "test"]);
+await test('push to allowed ref works through hooks', async () => {
+  await execFileAsync('git', ['-C', repo.worktreeDir, 'commit', '--allow-empty', '-m', 'test']);
   // Push to the local bare remote (origin points to GitHub and would need auth)
-  await execFileAsync("git", ["-C", repo.worktreeDir, "push", "local", repo.branch]);
+  await execFileAsync('git', ['-C', repo.worktreeDir, 'push', 'local', repo.branch]);
 });
 
-await test("push to denied ref blocked by hooks", async () => {
+await test('push to denied ref blocked by hooks', async () => {
   try {
-    await execFileAsync("git", ["-C", repo.worktreeDir, "push", "local", "HEAD:refs/heads/unauthorized"]);
-    assert.fail("should have been denied");
+    await execFileAsync('git', [
+      '-C',
+      repo.worktreeDir,
+      'push',
+      'local',
+      'HEAD:refs/heads/unauthorized',
+    ]);
+    assert.fail('should have been denied');
   } catch (err: unknown) {
-    const stderr = (err as { stderr?: string }).stderr ?? "";
-    assert.ok(stderr.includes("[bouncer:git] DENY"));
+    const stderr = (err as { stderr?: string }).stderr ?? '';
+    assert.ok(stderr.includes('[bouncer:git] DENY'));
   }
 });
 
 // --- Cleanup ---
 
-console.log("\nCleanup:");
+console.log('\nCleanup:');
 
-await test("cleanup hooks", async () => {
+await test('cleanup hooks', async () => {
   await cleanupHooks(sessionId, repo.worktreeDir);
   assert.ok(!existsSync(hooksDir(sessionId)));
   assert.ok(!existsSync(allowedRefsPath(sessionId)));
 });
 
-await test("cleanup policy state", async () => {
+await test('cleanup policy state', async () => {
   await cleanupPolicyState(sessionId);
   assert.ok(!existsSync(policyStatePath(sessionId)));
 });
 
-await test("cleanup gh shim", async () => {
+await test('cleanup gh shim', async () => {
   await cleanupGhShim(sessionId);
   assert.ok(!existsSync(shimBinDir(sessionId)));
 });
 
-await test("all artifacts removed", async () => {
+await test('all artifacts removed', async () => {
   assert.ok(!existsSync(policyStatePath(sessionId)));
   assert.ok(!existsSync(shimBinDir(sessionId)));
   assert.ok(!existsSync(hooksDir(sessionId)));
@@ -222,34 +244,34 @@ await test("all artifacts removed", async () => {
 
 // --- Orphan cleanup ---
 
-console.log("\nOrphan cleanup:");
+console.log('\nOrphan cleanup:');
 
 const orphanId = `orphan-${Date.now()}`;
 
-await test("orphan artifacts are cleaned up", async () => {
+await test('orphan artifacts are cleaned up', async () => {
   // Create artifacts for a fake session
-  await writePolicyState(orphanId, buildSessionPolicy("owner/repo", "branch"));
-  await installGhShim(orphanId, "/fake/path.ts", "/fake/node");
+  await writePolicyState(orphanId, buildSessionPolicy('owner/repo', 'branch'));
+  await installGhShim(orphanId, '/fake/path.ts', '/fake/node');
   assert.ok(existsSync(policyStatePath(orphanId)));
   assert.ok(existsSync(shimBinDir(orphanId)));
 
   // Clean up orphans (orphanId not in active set)
   await cleanupOrphanGitHubArtifacts(new Set());
-  assert.ok(!existsSync(policyStatePath(orphanId)), "orphan policy state should be removed");
-  assert.ok(!existsSync(shimBinDir(orphanId)), "orphan shim bin should be removed");
+  assert.ok(!existsSync(policyStatePath(orphanId)), 'orphan policy state should be removed');
+  assert.ok(!existsSync(shimBinDir(orphanId)), 'orphan shim bin should be removed');
 });
 
 // --- findRealGh ---
 
-console.log("\ngh detection:");
+console.log('\ngh detection:');
 
-await test("findRealGh returns a path or null", async () => {
+await test('findRealGh returns a path or null', async () => {
   const ghPath = await findRealGh();
   if (ghPath === null) {
-    console.log("    (gh not installed — returned null as expected)");
+    console.log('    (gh not installed — returned null as expected)');
   } else {
     assert.ok(ghPath.length > 0);
-    assert.ok(ghPath.includes("gh"));
+    assert.ok(ghPath.includes('gh'));
   }
 });
 

--- a/scripts/test-claude-agent.ts
+++ b/scripts/test-claude-agent.ts
@@ -10,28 +10,26 @@
  *   - @zed-industries/claude-agent-acp installed
  *   - ANTHROPIC_API_KEY set or Claude Code OAuth active (~/.claude.json)
  */
-import { spawn, type ChildProcess } from "node:child_process";
-import { createRequire } from "node:module";
-import { readFile, writeFile } from "node:fs/promises";
-import { randomUUID } from "node:crypto";
-import { Writable, Readable } from "node:stream";
-import * as acp from "@agentclientprotocol/sdk";
+import { spawn, type ChildProcess } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { readFile, writeFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { Writable, Readable } from 'node:stream';
+import * as acp from '@agentclientprotocol/sdk';
 
 const require = createRequire(import.meta.url);
 
 // --- Resolve the claude-agent-acp binary ---
-const agentBin = require.resolve(
-  "@zed-industries/claude-agent-acp/dist/index.js"
-);
+const agentBin = require.resolve('@zed-industries/claude-agent-acp/dist/index.js');
 
 const agent = spawn(process.execPath, [agentBin], {
-  stdio: ["pipe", "pipe", "inherit"], // stderr → console for debugging
+  stdio: ['pipe', 'pipe', 'inherit'], // stderr → console for debugging
   cwd: process.cwd(),
   env: { ...process.env },
 });
 
-agent.on("error", (err) => console.error("Agent spawn error:", err));
-agent.on("exit", (code) => console.log(`\nAgent exited with code ${code}`));
+agent.on('error', (err) => console.error('Agent spawn error:', err));
+agent.on('exit', (code) => console.log(`\nAgent exited with code ${code}`));
 
 const output = Writable.toWeb(agent.stdin!) as WritableStream<Uint8Array>;
 const input = Readable.toWeb(agent.stdout!) as ReadableStream<Uint8Array>;
@@ -52,77 +50,70 @@ const connection = new acp.ClientSideConnection(
   (_agentInterface) => ({
     async sessionUpdate(params) {
       const update = params.update;
-      if (
-        update.sessionUpdate === "agent_message_chunk" &&
-        update.content.type === "text"
-      ) {
+      if (update.sessionUpdate === 'agent_message_chunk' && update.content.type === 'text') {
         process.stdout.write(update.content.text);
       } else {
-        console.log("\n[sessionUpdate]", JSON.stringify(update, null, 2));
+        console.log('\n[sessionUpdate]', JSON.stringify(update, null, 2));
       }
     },
 
     async requestPermission(params) {
-      console.log("\n[requestPermission]", JSON.stringify(params, null, 2));
+      console.log('\n[requestPermission]', JSON.stringify(params, null, 2));
       // Auto-approve: select the first allow_once option
-      const allowOption = params.options.find(
-        (o) => o.kind === "allow_once"
-      );
+      const allowOption = params.options.find((o) => o.kind === 'allow_once');
       if (allowOption) {
         return {
-          outcome: { outcome: "selected" as const, optionId: allowOption.optionId },
+          outcome: { outcome: 'selected' as const, optionId: allowOption.optionId },
         };
       }
       // Fallback: select the first option
       return {
-        outcome: { outcome: "selected" as const, optionId: params.options[0].optionId },
+        outcome: { outcome: 'selected' as const, optionId: params.options[0].optionId },
       };
     },
 
     async readTextFile(params) {
       console.log(`\n[readTextFile] path=${params.path}`);
-      const content = await readFile(params.path, "utf-8");
+      const content = await readFile(params.path, 'utf-8');
       return { content };
     },
 
     async writeTextFile(params) {
       console.log(`\n[writeTextFile] path=${params.path}`);
-      await writeFile(params.path, params.content, "utf-8");
+      await writeFile(params.path, params.content, 'utf-8');
       return {};
     },
 
     async createTerminal(params) {
       console.log(
-        `\n[createTerminal] command=${params.command} args=${JSON.stringify(params.args ?? [])}`
+        `\n[createTerminal] command=${params.command} args=${JSON.stringify(params.args ?? [])}`,
       );
       const terminalId = `term-${randomUUID()}`;
       const proc = spawn(params.command, params.args ?? [], {
         cwd: params.cwd ?? process.cwd(),
         env: {
           ...process.env,
-          ...(params.env
-            ? Object.fromEntries(params.env.map((e) => [e.name, e.value]))
-            : {}),
+          ...(params.env ? Object.fromEntries(params.env.map((e) => [e.name, e.value])) : {}),
         },
-        stdio: ["pipe", "pipe", "pipe"],
+        stdio: ['pipe', 'pipe', 'pipe'],
       });
 
       const state: TerminalState = {
         process: proc,
-        output: "",
+        output: '',
         exitCode: null,
         exitPromise: new Promise<number>((resolve) => {
-          proc.on("exit", (code) => {
+          proc.on('exit', (code) => {
             state.exitCode = code ?? 1;
             resolve(code ?? 1);
           });
         }),
       };
 
-      proc.stdout?.on("data", (data: Buffer) => {
+      proc.stdout?.on('data', (data: Buffer) => {
         state.output += data.toString();
       });
-      proc.stderr?.on("data", (data: Buffer) => {
+      proc.stderr?.on('data', (data: Buffer) => {
         state.output += data.toString();
       });
 
@@ -134,7 +125,7 @@ const connection = new acp.ClientSideConnection(
       const term = terminals.get(params.terminalId);
       if (!term) throw new Error(`Unknown terminal: ${params.terminalId}`);
       const currentOutput = term.output;
-      term.output = "";
+      term.output = '';
       const result: acp.TerminalOutputResponse = {
         output: currentOutput,
         truncated: false,
@@ -143,7 +134,7 @@ const connection = new acp.ClientSideConnection(
         result.exitStatus = { exitCode: term.exitCode };
       }
       console.log(
-        `\n[terminalOutput] id=${params.terminalId} len=${currentOutput.length} exited=${term.exitCode !== null}`
+        `\n[terminalOutput] id=${params.terminalId} len=${currentOutput.length} exited=${term.exitCode !== null}`,
       );
       return result;
     },
@@ -152,7 +143,7 @@ const connection = new acp.ClientSideConnection(
       console.log(`\n[killTerminal] id=${params.terminalId}`);
       const term = terminals.get(params.terminalId);
       if (term && term.exitCode === null) {
-        term.process.kill("SIGTERM");
+        term.process.kill('SIGTERM');
       }
     },
 
@@ -160,9 +151,7 @@ const connection = new acp.ClientSideConnection(
       const term = terminals.get(params.terminalId);
       if (!term) return { exitCode: 1 };
       const exitCode = await term.exitPromise;
-      console.log(
-        `\n[waitForTerminalExit] id=${params.terminalId} exitCode=${exitCode}`
-      );
+      console.log(`\n[waitForTerminalExit] id=${params.terminalId} exitCode=${exitCode}`);
       return { exitCode };
     },
 
@@ -170,17 +159,17 @@ const connection = new acp.ClientSideConnection(
       console.log(`\n[releaseTerminal] id=${params.terminalId}`);
       const term = terminals.get(params.terminalId);
       if (term) {
-        if (term.exitCode === null) term.process.kill("SIGKILL");
+        if (term.exitCode === null) term.process.kill('SIGKILL');
         terminals.delete(params.terminalId);
       }
     },
   }),
-  stream
+  stream,
 );
 
 // --- Drive the protocol ---
 try {
-  console.log("Initializing...");
+  console.log('Initializing...');
   const initResp = await connection.initialize({
     protocolVersion: acp.PROTOCOL_VERSION,
     clientCapabilities: {
@@ -188,37 +177,33 @@ try {
       fs: { readTextFile: true, writeTextFile: true },
     },
   });
-  console.log(
-    "Initialized:",
-    JSON.stringify(initResp, null, 2)
-  );
+  console.log('Initialized:', JSON.stringify(initResp, null, 2));
 
-  console.log("\nCreating session...");
+  console.log('\nCreating session...');
   const sessionResp = await connection.newSession({
     cwd: process.cwd(),
     mcpServers: [],
   });
-  console.log("Session:", sessionResp.sessionId);
+  console.log('Session:', sessionResp.sessionId);
 
-  const prompt =
-    "What files are in the current directory? Just list the filenames, nothing else.";
+  const prompt = 'What files are in the current directory? Just list the filenames, nothing else.';
   console.log(`\nSending prompt: "${prompt}"\n`);
-  console.log("--- Response ---");
+  console.log('--- Response ---');
 
   const promptResp = await connection.prompt({
     sessionId: sessionResp.sessionId,
-    prompt: [{ type: "text", text: prompt }],
+    prompt: [{ type: 'text', text: prompt }],
   });
 
-  console.log("\n--- End Response ---");
+  console.log('\n--- End Response ---');
   console.log(`Stop reason: ${promptResp.stopReason}`);
 } catch (err) {
-  console.error("\nError:", err);
+  console.error('\nError:', err);
   process.exitCode = 1;
 } finally {
   // Clean up terminals
   for (const [, term] of terminals) {
-    if (term.exitCode === null) term.process.kill("SIGKILL");
+    if (term.exitCode === null) term.process.kill('SIGKILL');
   }
   agent.kill();
 }

--- a/scripts/test-dataset-loader.ts
+++ b/scripts/test-dataset-loader.ts
@@ -6,10 +6,15 @@
  *
  * Usage: npx tsx scripts/test-dataset-loader.ts
  */
-import { join } from "node:path";
-import { loadDataset, loadSession, datasetSummary, listSessions } from "../src/main/dataset-loader.js";
+import { join } from 'node:path';
+import {
+  loadDataset,
+  loadSession,
+  datasetSummary,
+  listSessions,
+} from '../src/main/dataset-loader.js';
 
-const datasetPath = join(process.cwd(), "data", "tool-use-dataset.jsonl");
+const datasetPath = join(process.cwd(), 'data', 'tool-use-dataset.jsonl');
 
 let exitCode = 0;
 
@@ -24,7 +29,7 @@ function check(label: string, condition: boolean) {
 
 try {
   // Load dataset
-  console.log("Loading dataset...");
+  console.log('Loading dataset...');
   const sessions = await loadDataset(datasetPath);
   const summary = datasetSummary(sessions);
 
@@ -33,47 +38,58 @@ try {
   console.log(`Tools: ${JSON.stringify(summary.toolDistribution)}`);
 
   // Verify expected counts
-  check("Session count is 296", summary.sessionCount === 296);
-  check("Record count is 11491", summary.recordCount === 11491);
+  check('Session count is 296', summary.sessionCount === 296);
+  check('Record count is 11491', summary.recordCount === 11491);
 
   // Verify all sessions have at least one call
   let emptyCount = 0;
   for (const [, calls] of sessions) {
     if (calls.length === 0) emptyCount++;
   }
-  check("No empty sessions", emptyCount === 0);
+  check('No empty sessions', emptyCount === 0);
 
   // Verify tool distribution has expected tools
-  const expectedTools = ["Read", "Write", "Edit", "Bash", "Grep", "Glob"];
+  const expectedTools = ['Read', 'Write', 'Edit', 'Bash', 'Grep', 'Glob'];
   for (const tool of expectedTools) {
     check(`Tool "${tool}" present in distribution`, tool in summary.toolDistribution);
   }
 
   // Test listSessions
-  console.log("\nTesting listSessions...");
+  console.log('\nTesting listSessions...');
   const list = await listSessions(datasetPath);
-  check("listSessions count matches", list.length === summary.sessionCount);
-  check("listSessions entries have callCount > 0", list.every((s) => s.callCount > 0));
-  check("listSessions entries have tools", list.every((s) => s.tools.length > 0));
-  check("listSessions entries have project", list.every((s) => s.project.length > 0));
+  check('listSessions count matches', list.length === summary.sessionCount);
+  check(
+    'listSessions entries have callCount > 0',
+    list.every((s) => s.callCount > 0),
+  );
+  check(
+    'listSessions entries have tools',
+    list.every((s) => s.tools.length > 0),
+  );
+  check(
+    'listSessions entries have project',
+    list.every((s) => s.project.length > 0),
+  );
 
   // Print a few examples
   console.log(`\nFirst 3 sessions:`);
   for (const s of list.slice(0, 3)) {
-    console.log(`  ${s.sessionId} (${s.project}): ${s.callCount} calls, tools: ${s.tools.join(", ")}`);
+    console.log(
+      `  ${s.sessionId} (${s.project}): ${s.callCount} calls, tools: ${s.tools.join(', ')}`,
+    );
   }
 
   // Test loadSession
-  console.log("\nTesting loadSession...");
+  console.log('\nTesting loadSession...');
   const testSessionId = list[0].sessionId;
   const sessionCalls = await loadSession(datasetPath, testSessionId);
-  check("loadSession returns non-empty", sessionCalls.length > 0);
-  check("loadSession count matches listSessions", sessionCalls.length === list[0].callCount);
+  check('loadSession returns non-empty', sessionCalls.length > 0);
+  check('loadSession count matches listSessions', sessionCalls.length === list[0].callCount);
 
-  const unknownCalls = await loadSession(datasetPath, "nonexistent-session");
-  check("loadSession returns empty for unknown session", unknownCalls.length === 0);
+  const unknownCalls = await loadSession(datasetPath, 'nonexistent-session');
+  check('loadSession returns empty for unknown session', unknownCalls.length === 0);
 } catch (err) {
-  console.error("Error:", err);
+  console.error('Error:', err);
   exitCode = 1;
 }
 

--- a/scripts/test-echo-agent.ts
+++ b/scripts/test-echo-agent.ts
@@ -6,16 +6,16 @@
  *
  * Usage: npx tsx scripts/test-echo-agent.ts
  */
-import { spawn } from "node:child_process";
-import { createRequire } from "node:module";
-import { Writable, Readable } from "node:stream";
-import * as acp from "@agentclientprotocol/sdk";
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { Writable, Readable } from 'node:stream';
+import * as acp from '@agentclientprotocol/sdk';
 
 const require = createRequire(import.meta.url);
-const tsxBin = require.resolve("tsx/cli");
+const tsxBin = require.resolve('tsx/cli');
 
-const agent = spawn(process.execPath, [tsxBin, "src/agents/echo-agent.ts"], {
-  stdio: ["pipe", "pipe", "inherit"],
+const agent = spawn(process.execPath, [tsxBin, 'src/agents/echo-agent.ts'], {
+  stdio: ['pipe', 'pipe', 'inherit'],
 });
 
 const output = Writable.toWeb(agent.stdin!) as WritableStream<Uint8Array>;
@@ -26,17 +26,17 @@ const connection = new acp.ClientSideConnection(
   (_agent) => ({
     async sessionUpdate(params) {
       const update = params.update;
-      if (update.sessionUpdate === "agent_message_chunk" && update.content.type === "text") {
+      if (update.sessionUpdate === 'agent_message_chunk' && update.content.type === 'text') {
         process.stdout.write(update.content.text);
       } else {
-        console.log("Update:", JSON.stringify(update));
+        console.log('Update:', JSON.stringify(update));
       }
     },
     async requestPermission(_params) {
-      return { outcome: { outcome: "cancelled" as const } };
+      return { outcome: { outcome: 'cancelled' as const } };
     },
   }),
-  stream
+  stream,
 );
 
 try {
@@ -45,34 +45,34 @@ try {
     protocolVersion: acp.PROTOCOL_VERSION,
     clientCapabilities: {},
   });
-  console.log("Initialized:", JSON.stringify(initResp));
+  console.log('Initialized:', JSON.stringify(initResp));
 
   // Create session
   const sessionResp = await connection.newSession({
     cwd: process.cwd(),
     mcpServers: [],
   });
-  console.log("Session:", sessionResp.sessionId);
+  console.log('Session:', sessionResp.sessionId);
 
   // Send prompt
-  console.log("\nSending: Hello world");
-  process.stdout.write("Response: ");
+  console.log('\nSending: Hello world');
+  process.stdout.write('Response: ');
   const promptResp = await connection.prompt({
     sessionId: sessionResp.sessionId,
-    prompt: [{ type: "text", text: "Hello world" }],
+    prompt: [{ type: 'text', text: 'Hello world' }],
   });
   console.log(`\nPrompt done: stopReason=${promptResp.stopReason}`);
 
   // Send a second prompt to verify session reuse
-  console.log("\nSending: Testing 1 2 3");
-  process.stdout.write("Response: ");
+  console.log('\nSending: Testing 1 2 3');
+  process.stdout.write('Response: ');
   const promptResp2 = await connection.prompt({
     sessionId: sessionResp.sessionId,
-    prompt: [{ type: "text", text: "Testing 1 2 3" }],
+    prompt: [{ type: 'text', text: 'Testing 1 2 3' }],
   });
   console.log(`\nPrompt done: stopReason=${promptResp2.stopReason}`);
 } catch (err) {
-  console.error("Error:", err);
+  console.error('Error:', err);
   process.exitCode = 1;
 } finally {
   agent.kill();

--- a/scripts/test-gh-shim.ts
+++ b/scripts/test-gh-shim.ts
@@ -5,15 +5,15 @@
 //
 // Usage: npx tsx scripts/test-gh-shim.ts
 
-import assert from "node:assert/strict";
+import assert from 'node:assert/strict';
 import {
   parseGhArgs,
   evaluatePolicy,
   parseApiEndpoint,
   type ParsedGhCommand,
   type PolicyDecision,
-} from "../src/main/gh-shim.js";
-import type { GitHubPolicy } from "../src/main/types.js";
+} from '../src/main/gh-shim.js';
+import type { GitHubPolicy } from '../src/main/types.js';
 
 let passed = 0;
 let failed = 0;
@@ -35,8 +35,8 @@ function test(name: string, fn: () => void | Promise<void>): Promise<void> {
 
 function makePolicy(overrides: Partial<GitHubPolicy> = {}): GitHubPolicy {
   return {
-    repo: "owner/repo",
-    allowedPushRefs: ["feature-branch"],
+    repo: 'owner/repo',
+    allowedPushRefs: ['feature-branch'],
     ownedPrNumber: null,
     canCreatePr: true,
     ...overrides,
@@ -51,517 +51,520 @@ function decide(args: string[], policy?: GitHubPolicy): PolicyDecision {
 // Parser Tests
 // ==========================================================
 
-console.log("=== gh Shim Tests ===\n");
-console.log("Parser:");
+console.log('=== gh Shim Tests ===\n');
+console.log('Parser:');
 
-await test("pr create --title foo", () => {
-  const p = parseGhArgs(["pr", "create", "--title", "foo"]);
-  assert.equal(p.command, "pr");
-  assert.equal(p.subcommand, "create");
+await test('pr create --title foo', () => {
+  const p = parseGhArgs(['pr', 'create', '--title', 'foo']);
+  assert.equal(p.command, 'pr');
+  assert.equal(p.subcommand, 'create');
 });
 
-await test("pr view 42", () => {
-  const p = parseGhArgs(["pr", "view", "42"]);
-  assert.equal(p.command, "pr");
-  assert.equal(p.subcommand, "view");
-  assert.ok(p.positionalArgs.includes("42"));
+await test('pr view 42', () => {
+  const p = parseGhArgs(['pr', 'view', '42']);
+  assert.equal(p.command, 'pr');
+  assert.equal(p.subcommand, 'view');
+  assert.ok(p.positionalArgs.includes('42'));
 });
 
-await test("pr edit --title new 42", () => {
-  const p = parseGhArgs(["pr", "edit", "--title", "new", "42"]);
-  assert.equal(p.command, "pr");
-  assert.equal(p.subcommand, "edit");
-  assert.ok(p.positionalArgs.includes("42"));
+await test('pr edit --title new 42', () => {
+  const p = parseGhArgs(['pr', 'edit', '--title', 'new', '42']);
+  assert.equal(p.command, 'pr');
+  assert.equal(p.subcommand, 'edit');
+  assert.ok(p.positionalArgs.includes('42'));
 });
 
-await test("-R other/repo pr list", () => {
-  const p = parseGhArgs(["-R", "other/repo", "pr", "list"]);
-  assert.equal(p.flags.repo, "other/repo");
-  assert.equal(p.command, "pr");
-  assert.equal(p.subcommand, "list");
+await test('-R other/repo pr list', () => {
+  const p = parseGhArgs(['-R', 'other/repo', 'pr', 'list']);
+  assert.equal(p.flags.repo, 'other/repo');
+  assert.equal(p.command, 'pr');
+  assert.equal(p.subcommand, 'list');
 });
 
-await test("api /repos/{owner}/{repo}/pulls --method GET", () => {
-  const p = parseGhArgs(["api", "/repos/{owner}/{repo}/pulls", "--method", "GET"]);
-  assert.equal(p.command, "api");
-  assert.equal(p.positionalArgs[0], "/repos/{owner}/{repo}/pulls");
-  assert.equal(p.flags.method, "GET");
+await test('api /repos/{owner}/{repo}/pulls --method GET', () => {
+  const p = parseGhArgs(['api', '/repos/{owner}/{repo}/pulls', '--method', 'GET']);
+  assert.equal(p.command, 'api');
+  assert.equal(p.positionalArgs[0], '/repos/{owner}/{repo}/pulls');
+  assert.equal(p.flags.method, 'GET');
 });
 
-await test("api graphql -f query=...", () => {
-  const p = parseGhArgs(["api", "graphql", "-f", "query=..."]);
-  assert.equal(p.command, "api");
-  assert.ok(p.positionalArgs.includes("graphql"));
+await test('api graphql -f query=...', () => {
+  const p = parseGhArgs(['api', 'graphql', '-f', 'query=...']);
+  assert.equal(p.command, 'api');
+  assert.ok(p.positionalArgs.includes('graphql'));
   assert.equal(p.flags.hasBodyParams, true);
   assert.equal(p.flags.fields.length, 1);
-  assert.equal(p.flags.fields[0].key, "query");
-  assert.equal(p.flags.fields[0].value, "...");
+  assert.equal(p.flags.fields[0].key, 'query');
+  assert.equal(p.flags.fields[0].value, '...');
 });
 
-await test("--help (global)", () => {
-  const p = parseGhArgs(["--help"]);
-  assert.equal(p.command, "--help");
+await test('--help (global)', () => {
+  const p = parseGhArgs(['--help']);
+  assert.equal(p.command, '--help');
 });
 
-await test("pr --help", () => {
-  const p = parseGhArgs(["pr", "--help"]);
-  assert.equal(p.command, "pr");
-  assert.equal(p.subcommand, "--help");
+await test('pr --help', () => {
+  const p = parseGhArgs(['pr', '--help']);
+  assert.equal(p.command, 'pr');
+  assert.equal(p.subcommand, '--help');
 });
 
-await test("bare args (no command)", () => {
+await test('bare args (no command)', () => {
   const p = parseGhArgs([]);
-  assert.equal(p.command, "--help");
+  assert.equal(p.command, '--help');
 });
 
-await test("--repo=other/repo pr list (= syntax)", () => {
-  const p = parseGhArgs(["--repo=other/repo", "pr", "list"]);
-  assert.equal(p.flags.repo, "other/repo");
-  assert.equal(p.command, "pr");
-  assert.equal(p.subcommand, "list");
+await test('--repo=other/repo pr list (= syntax)', () => {
+  const p = parseGhArgs(['--repo=other/repo', 'pr', 'list']);
+  assert.equal(p.flags.repo, 'other/repo');
+  assert.equal(p.command, 'pr');
+  assert.equal(p.subcommand, 'list');
 });
 
-await test("-Rother/repo pr list (concatenated short flag)", () => {
-  const p = parseGhArgs(["-Rother/repo", "pr", "list"]);
-  assert.equal(p.flags.repo, "other/repo");
-  assert.equal(p.command, "pr");
+await test('-Rother/repo pr list (concatenated short flag)', () => {
+  const p = parseGhArgs(['-Rother/repo', 'pr', 'list']);
+  assert.equal(p.flags.repo, 'other/repo');
+  assert.equal(p.command, 'pr');
 });
 
-await test("api endpoint --method=POST (= syntax)", () => {
-  const p = parseGhArgs(["api", "/repos/owner/repo/pulls", "--method=POST"]);
-  assert.equal(p.flags.method, "POST");
+await test('api endpoint --method=POST (= syntax)', () => {
+  const p = parseGhArgs(['api', '/repos/owner/repo/pulls', '--method=POST']);
+  assert.equal(p.flags.method, 'POST');
 });
 
-await test("api endpoint -XPOST (concatenated short flag)", () => {
-  const p = parseGhArgs(["api", "/repos/owner/repo/pulls", "-XPOST"]);
-  assert.equal(p.flags.method, "POST");
+await test('api endpoint -XPOST (concatenated short flag)', () => {
+  const p = parseGhArgs(['api', '/repos/owner/repo/pulls', '-XPOST']);
+  assert.equal(p.flags.method, 'POST');
 });
 
 // ==========================================================
 // API Endpoint Parser Tests
 // ==========================================================
 
-console.log("\nAPI endpoint parser:");
+console.log('\nAPI endpoint parser:');
 
-await test("/repos/owner/repo/pulls — GET", () => {
-  const m = parseApiEndpoint("/repos/owner/repo/pulls", { fields: [] });
-  assert.equal(m.resource, "pulls");
-  assert.equal(m.ownerRepo, "owner/repo");
-  assert.equal(m.method, "GET");
+await test('/repos/owner/repo/pulls — GET', () => {
+  const m = parseApiEndpoint('/repos/owner/repo/pulls', { fields: [] });
+  assert.equal(m.resource, 'pulls');
+  assert.equal(m.ownerRepo, 'owner/repo');
+  assert.equal(m.method, 'GET');
   assert.equal(m.isGraphQL, false);
 });
 
-await test("/repos/owner/repo/pulls/42 — GET", () => {
-  const m = parseApiEndpoint("/repos/owner/repo/pulls/42", { fields: [] });
-  assert.equal(m.resource, "pulls");
+await test('/repos/owner/repo/pulls/42 — GET', () => {
+  const m = parseApiEndpoint('/repos/owner/repo/pulls/42', { fields: [] });
+  assert.equal(m.resource, 'pulls');
   assert.equal(m.number, 42);
-  assert.equal(m.ownerRepo, "owner/repo");
+  assert.equal(m.ownerRepo, 'owner/repo');
 });
 
-await test("/repos/owner/repo/pulls/42/merge — PUT", () => {
-  const m = parseApiEndpoint("/repos/owner/repo/pulls/42/merge", { method: "PUT", fields: [] });
-  assert.equal(m.resource, "pulls");
+await test('/repos/owner/repo/pulls/42/merge — PUT', () => {
+  const m = parseApiEndpoint('/repos/owner/repo/pulls/42/merge', { method: 'PUT', fields: [] });
+  assert.equal(m.resource, 'pulls');
   assert.equal(m.number, 42);
-  assert.equal(m.subResource, "merge");
-  assert.equal(m.method, "PUT");
+  assert.equal(m.subResource, 'merge');
+  assert.equal(m.method, 'PUT');
 });
 
-await test("graphql — POST inferred from body params", () => {
-  const m = parseApiEndpoint("graphql", { hasBodyParams: true, fields: [] });
+await test('graphql — POST inferred from body params', () => {
+  const m = parseApiEndpoint('graphql', { hasBodyParams: true, fields: [] });
   assert.equal(m.isGraphQL, true);
-  assert.equal(m.method, "POST");
+  assert.equal(m.method, 'POST');
 });
 
-await test("/repos/{owner}/{repo}/pulls — placeholder", () => {
-  const m = parseApiEndpoint("/repos/{owner}/{repo}/pulls", { fields: [] });
-  assert.equal(m.resource, "pulls");
+await test('/repos/{owner}/{repo}/pulls — placeholder', () => {
+  const m = parseApiEndpoint('/repos/{owner}/{repo}/pulls', { fields: [] });
+  assert.equal(m.resource, 'pulls');
   assert.equal(m.ownerRepo, null); // placeholder
 });
 
-await test("/repos/owner/repo — repo metadata", () => {
-  const m = parseApiEndpoint("/repos/owner/repo", { fields: [] });
-  assert.equal(m.resource, "");
-  assert.equal(m.ownerRepo, "owner/repo");
+await test('/repos/owner/repo — repo metadata', () => {
+  const m = parseApiEndpoint('/repos/owner/repo', { fields: [] });
+  assert.equal(m.resource, '');
+  assert.equal(m.ownerRepo, 'owner/repo');
 });
 
 // ==========================================================
 // Policy Evaluation Tests — PR
 // ==========================================================
 
-console.log("\nPolicy evaluation — pr:");
+console.log('\nPolicy evaluation — pr:');
 
-await test("pr create (canCreatePr: true) → allow-and-capture-pr", () => {
-  const d = decide(["pr", "create", "--title", "foo"]);
-  assert.equal(d.action, "allow-and-capture-pr");
+await test('pr create (canCreatePr: true) → allow-and-capture-pr', () => {
+  const d = decide(['pr', 'create', '--title', 'foo']);
+  assert.equal(d.action, 'allow-and-capture-pr');
 });
 
-await test("pr create (canCreatePr: false) → deny", () => {
-  const d = decide(["pr", "create"], makePolicy({ canCreatePr: false }));
-  assert.equal(d.action, "deny");
+await test('pr create (canCreatePr: false) → deny', () => {
+  const d = decide(['pr', 'create'], makePolicy({ canCreatePr: false }));
+  assert.equal(d.action, 'deny');
 });
 
-await test("pr edit 42 (ownedPrNumber: 42) → allow", () => {
-  const d = decide(["pr", "edit", "42"], makePolicy({ ownedPrNumber: 42 }));
-  assert.equal(d.action, "allow");
+await test('pr edit 42 (ownedPrNumber: 42) → allow', () => {
+  const d = decide(['pr', 'edit', '42'], makePolicy({ ownedPrNumber: 42 }));
+  assert.equal(d.action, 'allow');
 });
 
-await test("pr edit 99 (ownedPrNumber: 42) → deny", () => {
-  const d = decide(["pr", "edit", "99"], makePolicy({ ownedPrNumber: 42 }));
-  assert.equal(d.action, "deny");
+await test('pr edit 99 (ownedPrNumber: 42) → deny', () => {
+  const d = decide(['pr', 'edit', '99'], makePolicy({ ownedPrNumber: 42 }));
+  assert.equal(d.action, 'deny');
 });
 
-await test("pr edit (no number, no owned PR) → deny", () => {
-  const d = decide(["pr", "edit", "--title", "new"]);
-  assert.equal(d.action, "deny");
+await test('pr edit (no number, no owned PR) → deny', () => {
+  const d = decide(['pr', 'edit', '--title', 'new']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("pr edit (no number, has owned PR) → allow", () => {
-  const d = decide(["pr", "edit", "--title", "new"], makePolicy({ ownedPrNumber: 42 }));
-  assert.equal(d.action, "allow");
+await test('pr edit (no number, has owned PR) → allow', () => {
+  const d = decide(['pr', 'edit', '--title', 'new'], makePolicy({ ownedPrNumber: 42 }));
+  assert.equal(d.action, 'allow');
 });
 
-await test("pr view 99 → allow (read-only)", () => {
-  const d = decide(["pr", "view", "99"]);
-  assert.equal(d.action, "allow");
+await test('pr view 99 → allow (read-only)', () => {
+  const d = decide(['pr', 'view', '99']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("pr list → allow", () => {
-  const d = decide(["pr", "list"]);
-  assert.equal(d.action, "allow");
+await test('pr list → allow', () => {
+  const d = decide(['pr', 'list']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("pr status → allow", () => {
-  const d = decide(["pr", "status"]);
-  assert.equal(d.action, "allow");
+await test('pr status → allow', () => {
+  const d = decide(['pr', 'status']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("pr checks → allow", () => {
-  const d = decide(["pr", "checks"]);
-  assert.equal(d.action, "allow");
+await test('pr checks → allow', () => {
+  const d = decide(['pr', 'checks']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("pr diff → allow", () => {
-  const d = decide(["pr", "diff"]);
-  assert.equal(d.action, "allow");
+await test('pr diff → allow', () => {
+  const d = decide(['pr', 'diff']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("pr comment (no number, has owned PR) → allow", () => {
-  const d = decide(["pr", "comment", "--body", "lgtm"], makePolicy({ ownedPrNumber: 42 }));
-  assert.equal(d.action, "allow");
+await test('pr comment (no number, has owned PR) → allow', () => {
+  const d = decide(['pr', 'comment', '--body', 'lgtm'], makePolicy({ ownedPrNumber: 42 }));
+  assert.equal(d.action, 'allow');
 });
 
-await test("pr comment (no number, no owned PR) → deny", () => {
-  const d = decide(["pr", "comment", "--body", "lgtm"]);
-  assert.equal(d.action, "deny");
+await test('pr comment (no number, no owned PR) → deny', () => {
+  const d = decide(['pr', 'comment', '--body', 'lgtm']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("pr comment 99 (not owned) → deny", () => {
-  const d = decide(["pr", "comment", "99", "--body", "x"], makePolicy({ ownedPrNumber: 42 }));
-  assert.equal(d.action, "deny");
+await test('pr comment 99 (not owned) → deny', () => {
+  const d = decide(['pr', 'comment', '99', '--body', 'x'], makePolicy({ ownedPrNumber: 42 }));
+  assert.equal(d.action, 'deny');
 });
 
-await test("pr ready (owned) → allow", () => {
-  const d = decide(["pr", "ready"], makePolicy({ ownedPrNumber: 42 }));
-  assert.equal(d.action, "allow");
+await test('pr ready (owned) → allow', () => {
+  const d = decide(['pr', 'ready'], makePolicy({ ownedPrNumber: 42 }));
+  assert.equal(d.action, 'allow');
 });
 
-await test("pr update-branch (owned) → allow", () => {
-  const d = decide(["pr", "update-branch"], makePolicy({ ownedPrNumber: 42 }));
-  assert.equal(d.action, "allow");
+await test('pr update-branch (owned) → allow', () => {
+  const d = decide(['pr', 'update-branch'], makePolicy({ ownedPrNumber: 42 }));
+  assert.equal(d.action, 'allow');
 });
 
-await test("pr merge 42 → deny", () => {
-  const d = decide(["pr", "merge", "42"]);
-  assert.equal(d.action, "deny");
+await test('pr merge 42 → deny', () => {
+  const d = decide(['pr', 'merge', '42']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("pr close 42 → deny", () => {
-  const d = decide(["pr", "close", "42"]);
-  assert.equal(d.action, "deny");
+await test('pr close 42 → deny', () => {
+  const d = decide(['pr', 'close', '42']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("pr checkout 42 → deny", () => {
-  const d = decide(["pr", "checkout", "42"]);
-  assert.equal(d.action, "deny");
+await test('pr checkout 42 → deny', () => {
+  const d = decide(['pr', 'checkout', '42']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("pr reopen 42 → deny", () => {
-  const d = decide(["pr", "reopen", "42"]);
-  assert.equal(d.action, "deny");
+await test('pr reopen 42 → deny', () => {
+  const d = decide(['pr', 'reopen', '42']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("pr review 42 → deny", () => {
-  const d = decide(["pr", "review", "42"]);
-  assert.equal(d.action, "deny");
+await test('pr review 42 → deny', () => {
+  const d = decide(['pr', 'review', '42']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("pr lock 42 → deny", () => {
-  const d = decide(["pr", "lock", "42"]);
-  assert.equal(d.action, "deny");
+await test('pr lock 42 → deny', () => {
+  const d = decide(['pr', 'lock', '42']);
+  assert.equal(d.action, 'deny');
 });
 
 // ==========================================================
 // Policy Evaluation Tests — Issue
 // ==========================================================
 
-console.log("\nPolicy evaluation — issue:");
+console.log('\nPolicy evaluation — issue:');
 
-await test("issue view 10 → allow", () => {
-  const d = decide(["issue", "view", "10"]);
-  assert.equal(d.action, "allow");
+await test('issue view 10 → allow', () => {
+  const d = decide(['issue', 'view', '10']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("issue list → allow", () => {
-  const d = decide(["issue", "list"]);
-  assert.equal(d.action, "allow");
+await test('issue list → allow', () => {
+  const d = decide(['issue', 'list']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("issue status → allow", () => {
-  const d = decide(["issue", "status"]);
-  assert.equal(d.action, "allow");
+await test('issue status → allow', () => {
+  const d = decide(['issue', 'status']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("issue create → deny", () => {
-  const d = decide(["issue", "create"]);
-  assert.equal(d.action, "deny");
+await test('issue create → deny', () => {
+  const d = decide(['issue', 'create']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("issue edit 10 → deny", () => {
-  const d = decide(["issue", "edit", "10"]);
-  assert.equal(d.action, "deny");
+await test('issue edit 10 → deny', () => {
+  const d = decide(['issue', 'edit', '10']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("issue close 10 → deny", () => {
-  const d = decide(["issue", "close", "10"]);
-  assert.equal(d.action, "deny");
+await test('issue close 10 → deny', () => {
+  const d = decide(['issue', 'close', '10']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("issue comment 10 → deny", () => {
-  const d = decide(["issue", "comment", "10"]);
-  assert.equal(d.action, "deny");
+await test('issue comment 10 → deny', () => {
+  const d = decide(['issue', 'comment', '10']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("issue delete 10 → deny", () => {
-  const d = decide(["issue", "delete", "10"]);
-  assert.equal(d.action, "deny");
+await test('issue delete 10 → deny', () => {
+  const d = decide(['issue', 'delete', '10']);
+  assert.equal(d.action, 'deny');
 });
 
 // ==========================================================
 // Policy Evaluation Tests — Other Commands
 // ==========================================================
 
-console.log("\nPolicy evaluation — other commands:");
+console.log('\nPolicy evaluation — other commands:');
 
-await test("repo (no subcommand) → allow", () => {
-  const d = decide(["repo"]);
-  assert.equal(d.action, "allow");
+await test('repo (no subcommand) → allow', () => {
+  const d = decide(['repo']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("repo view → allow", () => {
-  const d = decide(["repo", "view"]);
-  assert.equal(d.action, "allow");
+await test('repo view → allow', () => {
+  const d = decide(['repo', 'view']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("repo clone → deny", () => {
-  const d = decide(["repo", "clone"]);
-  assert.equal(d.action, "deny");
+await test('repo clone → deny', () => {
+  const d = decide(['repo', 'clone']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("release list → allow", () => {
-  const d = decide(["release", "list"]);
-  assert.equal(d.action, "allow");
+await test('release list → allow', () => {
+  const d = decide(['release', 'list']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("release view → allow", () => {
-  const d = decide(["release", "view"]);
-  assert.equal(d.action, "allow");
+await test('release view → allow', () => {
+  const d = decide(['release', 'view']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("release create → deny", () => {
-  const d = decide(["release", "create"]);
-  assert.equal(d.action, "deny");
+await test('release create → deny', () => {
+  const d = decide(['release', 'create']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("search repos → allow", () => {
-  const d = decide(["search", "repos"]);
-  assert.equal(d.action, "allow");
+await test('search repos → allow', () => {
+  const d = decide(['search', 'repos']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("browse → allow", () => {
-  const d = decide(["browse"]);
-  assert.equal(d.action, "allow");
+await test('browse → allow', () => {
+  const d = decide(['browse']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("status → allow", () => {
-  const d = decide(["status"]);
-  assert.equal(d.action, "allow");
+await test('status → allow', () => {
+  const d = decide(['status']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("run view → allow", () => {
-  const d = decide(["run", "view"]);
-  assert.equal(d.action, "allow");
+await test('run view → allow', () => {
+  const d = decide(['run', 'view']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("run list → allow", () => {
-  const d = decide(["run", "list"]);
-  assert.equal(d.action, "allow");
+await test('run list → allow', () => {
+  const d = decide(['run', 'list']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("run cancel → deny", () => {
-  const d = decide(["run", "cancel"]);
-  assert.equal(d.action, "deny");
+await test('run cancel → deny', () => {
+  const d = decide(['run', 'cancel']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("run rerun → deny", () => {
-  const d = decide(["run", "rerun"]);
-  assert.equal(d.action, "deny");
+await test('run rerun → deny', () => {
+  const d = decide(['run', 'rerun']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("workflow view → allow", () => {
-  const d = decide(["workflow", "view"]);
-  assert.equal(d.action, "allow");
+await test('workflow view → allow', () => {
+  const d = decide(['workflow', 'view']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("workflow list → allow", () => {
-  const d = decide(["workflow", "list"]);
-  assert.equal(d.action, "allow");
+await test('workflow list → allow', () => {
+  const d = decide(['workflow', 'list']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("workflow run → deny", () => {
-  const d = decide(["workflow", "run"]);
-  assert.equal(d.action, "deny");
+await test('workflow run → deny', () => {
+  const d = decide(['workflow', 'run']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("workflow enable → deny", () => {
-  const d = decide(["workflow", "enable"]);
-  assert.equal(d.action, "deny");
+await test('workflow enable → deny', () => {
+  const d = decide(['workflow', 'enable']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("auth login → deny", () => {
-  const d = decide(["auth", "login"]);
-  assert.equal(d.action, "deny");
+await test('auth login → deny', () => {
+  const d = decide(['auth', 'login']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("config set → deny", () => {
-  const d = decide(["config", "set"]);
-  assert.equal(d.action, "deny");
+await test('config set → deny', () => {
+  const d = decide(['config', 'set']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("gist create → deny", () => {
-  const d = decide(["gist", "create"]);
-  assert.equal(d.action, "deny");
+await test('gist create → deny', () => {
+  const d = decide(['gist', 'create']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("codespace create → deny", () => {
-  const d = decide(["codespace", "create"]);
-  assert.equal(d.action, "deny");
+await test('codespace create → deny', () => {
+  const d = decide(['codespace', 'create']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("ssh-key add → deny", () => {
-  const d = decide(["ssh-key", "add"]);
-  assert.equal(d.action, "deny");
+await test('ssh-key add → deny', () => {
+  const d = decide(['ssh-key', 'add']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("secret set → deny", () => {
-  const d = decide(["secret", "set"]);
-  assert.equal(d.action, "deny");
+await test('secret set → deny', () => {
+  const d = decide(['secret', 'set']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("extension install → deny", () => {
-  const d = decide(["extension", "install"]);
-  assert.equal(d.action, "deny");
+await test('extension install → deny', () => {
+  const d = decide(['extension', 'install']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("--help → allow", () => {
-  const d = decide(["--help"]);
-  assert.equal(d.action, "allow");
+await test('--help → allow', () => {
+  const d = decide(['--help']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("--version → allow", () => {
-  const d = decide(["--version"]);
-  assert.equal(d.action, "allow");
+await test('--version → allow', () => {
+  const d = decide(['--version']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("unknown-command → deny", () => {
-  const d = decide(["unknown-command"]);
-  assert.equal(d.action, "deny");
+await test('unknown-command → deny', () => {
+  const d = decide(['unknown-command']);
+  assert.equal(d.action, 'deny');
 });
 
 // ==========================================================
 // Policy Evaluation Tests — Cross-repo
 // ==========================================================
 
-console.log("\nPolicy evaluation — cross-repo:");
+console.log('\nPolicy evaluation — cross-repo:');
 
-await test("-R other/repo pr list → deny", () => {
-  const d = decide(["-R", "other/repo", "pr", "list"]);
-  assert.equal(d.action, "deny");
+await test('-R other/repo pr list → deny', () => {
+  const d = decide(['-R', 'other/repo', 'pr', 'list']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("-R owner/repo pr list → allow (same repo)", () => {
-  const d = decide(["-R", "owner/repo", "pr", "list"]);
-  assert.equal(d.action, "allow");
+await test('-R owner/repo pr list → allow (same repo)', () => {
+  const d = decide(['-R', 'owner/repo', 'pr', 'list']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("--repo=other/repo pr list → deny (= syntax)", () => {
-  const d = decide(["--repo=other/repo", "pr", "list"]);
-  assert.equal(d.action, "deny");
+await test('--repo=other/repo pr list → deny (= syntax)', () => {
+  const d = decide(['--repo=other/repo', 'pr', 'list']);
+  assert.equal(d.action, 'deny');
 });
 
 // ==========================================================
 // Policy Evaluation Tests — API
 // ==========================================================
 
-console.log("\nPolicy evaluation — api:");
+console.log('\nPolicy evaluation — api:');
 
-await test("api /repos/owner/repo/pulls GET → allow", () => {
-  const d = decide(["api", "/repos/owner/repo/pulls", "--method", "GET"]);
-  assert.equal(d.action, "allow");
+await test('api /repos/owner/repo/pulls GET → allow', () => {
+  const d = decide(['api', '/repos/owner/repo/pulls', '--method', 'GET']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("api /repos/owner/repo/pulls POST (canCreatePr) → allow-and-capture-pr", () => {
-  const d = decide(["api", "/repos/owner/repo/pulls", "--method", "POST"]);
-  assert.equal(d.action, "allow-and-capture-pr");
+await test('api /repos/owner/repo/pulls POST (canCreatePr) → allow-and-capture-pr', () => {
+  const d = decide(['api', '/repos/owner/repo/pulls', '--method', 'POST']);
+  assert.equal(d.action, 'allow-and-capture-pr');
 });
 
-await test("api /repos/owner/repo/pulls POST (no canCreatePr) → deny", () => {
-  const d = decide(["api", "/repos/owner/repo/pulls", "--method", "POST"], makePolicy({ canCreatePr: false }));
-  assert.equal(d.action, "deny");
+await test('api /repos/owner/repo/pulls POST (no canCreatePr) → deny', () => {
+  const d = decide(
+    ['api', '/repos/owner/repo/pulls', '--method', 'POST'],
+    makePolicy({ canCreatePr: false }),
+  );
+  assert.equal(d.action, 'deny');
 });
 
-await test("api /repos/owner/repo/pulls/42/merge PUT → deny", () => {
-  const d = decide(["api", "/repos/owner/repo/pulls/42/merge", "--method", "PUT"]);
-  assert.equal(d.action, "deny");
+await test('api /repos/owner/repo/pulls/42/merge PUT → deny', () => {
+  const d = decide(['api', '/repos/owner/repo/pulls/42/merge', '--method', 'PUT']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("api /repos/owner/repo/issues GET → allow", () => {
-  const d = decide(["api", "/repos/owner/repo/issues", "--method", "GET"]);
-  assert.equal(d.action, "allow");
+await test('api /repos/owner/repo/issues GET → allow', () => {
+  const d = decide(['api', '/repos/owner/repo/issues', '--method', 'GET']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("api /repos/owner/repo/issues POST → deny", () => {
-  const d = decide(["api", "/repos/owner/repo/issues", "--method", "POST"]);
-  assert.equal(d.action, "deny");
+await test('api /repos/owner/repo/issues POST → deny', () => {
+  const d = decide(['api', '/repos/owner/repo/issues', '--method', 'POST']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("api graphql → allow", () => {
-  const d = decide(["api", "graphql", "-f", "query=..."]);
-  assert.equal(d.action, "allow");
+await test('api graphql → allow', () => {
+  const d = decide(['api', 'graphql', '-f', 'query=...']);
+  assert.equal(d.action, 'allow');
 });
 
-await test("api DELETE anything → deny", () => {
-  const d = decide(["api", "/repos/owner/repo/pulls/42", "-X", "DELETE"]);
-  assert.equal(d.action, "deny");
+await test('api DELETE anything → deny', () => {
+  const d = decide(['api', '/repos/owner/repo/pulls/42', '-X', 'DELETE']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("api cross-repo → deny", () => {
-  const d = decide(["api", "/repos/other/repo/pulls", "--method", "GET"]);
-  assert.equal(d.action, "deny");
+await test('api cross-repo → deny', () => {
+  const d = decide(['api', '/repos/other/repo/pulls', '--method', 'GET']);
+  assert.equal(d.action, 'deny');
 });
 
-await test("api /repos/{owner}/{repo}/pulls → allow (placeholder)", () => {
-  const d = decide(["api", "/repos/{owner}/{repo}/pulls", "--method", "GET"]);
-  assert.equal(d.action, "allow");
+await test('api /repos/{owner}/{repo}/pulls → allow (placeholder)', () => {
+  const d = decide(['api', '/repos/{owner}/{repo}/pulls', '--method', 'GET']);
+  assert.equal(d.action, 'allow');
 });
 
 // --- Summary ---

--- a/scripts/test-github-policy-engine.ts
+++ b/scripts/test-github-policy-engine.ts
@@ -5,15 +5,15 @@
 //
 // Usage: npx tsx scripts/test-github-policy-engine.ts
 
-import assert from "node:assert/strict";
+import assert from 'node:assert/strict';
 import {
   evaluateGitHubRequest,
   parseGitReceivePack,
   evaluateGitPush,
   type RefUpdate,
   type ReceivePackResult,
-} from "../src/main/github-policy-engine.js";
-import type { GitHubPolicy } from "../src/main/types.js";
+} from '../src/main/github-policy-engine.js';
+import type { GitHubPolicy } from '../src/main/types.js';
 
 let passed = 0;
 let failed = 0;
@@ -33,8 +33,8 @@ function test(name: string, fn: () => void | Promise<void>): Promise<void> {
 
 function makePolicy(overrides: Partial<GitHubPolicy> = {}): GitHubPolicy {
   return {
-    repo: "owner/repo",
-    allowedPushRefs: ["feature-branch"],
+    repo: 'owner/repo',
+    allowedPushRefs: ['feature-branch'],
     ownedPrNumber: null,
     canCreatePr: true,
     ...overrides,
@@ -45,155 +45,174 @@ function makePolicy(overrides: Partial<GitHubPolicy> = {}): GitHubPolicy {
 // evaluateGitHubRequest
 // =========================================================================
 
-console.log("\ngithub-policy-engine tests\n");
-console.log("  evaluateGitHubRequest:");
+console.log('\ngithub-policy-engine tests\n');
+console.log('  evaluateGitHubRequest:');
 
-await test("GET /repos/owner/repo/pulls → allow", () => {
-  const d = evaluateGitHubRequest("GET", "/repos/owner/repo/pulls", makePolicy());
-  assert.equal(d.action, "allow");
+await test('GET /repos/owner/repo/pulls → allow', () => {
+  const d = evaluateGitHubRequest('GET', '/repos/owner/repo/pulls', makePolicy());
+  assert.equal(d.action, 'allow');
 });
 
-await test("POST /repos/owner/repo/pulls (canCreatePr: true) → allow-and-capture-pr", () => {
-  const d = evaluateGitHubRequest("POST", "/repos/owner/repo/pulls", makePolicy());
-  assert.equal(d.action, "allow-and-capture-pr");
+await test('POST /repos/owner/repo/pulls (canCreatePr: true) → allow-and-capture-pr', () => {
+  const d = evaluateGitHubRequest('POST', '/repos/owner/repo/pulls', makePolicy());
+  assert.equal(d.action, 'allow-and-capture-pr');
 });
 
-await test("POST /repos/owner/repo/pulls (canCreatePr: false) → deny", () => {
-  const d = evaluateGitHubRequest("POST", "/repos/owner/repo/pulls", makePolicy({ canCreatePr: false }));
-  assert.equal(d.action, "deny");
+await test('POST /repos/owner/repo/pulls (canCreatePr: false) → deny', () => {
+  const d = evaluateGitHubRequest(
+    'POST',
+    '/repos/owner/repo/pulls',
+    makePolicy({ canCreatePr: false }),
+  );
+  assert.equal(d.action, 'deny');
 });
 
-await test("PUT /repos/owner/repo/pulls/42/merge → deny", () => {
-  const d = evaluateGitHubRequest("PUT", "/repos/owner/repo/pulls/42/merge", makePolicy());
-  assert.equal(d.action, "deny");
+await test('PUT /repos/owner/repo/pulls/42/merge → deny', () => {
+  const d = evaluateGitHubRequest('PUT', '/repos/owner/repo/pulls/42/merge', makePolicy());
+  assert.equal(d.action, 'deny');
 });
 
-await test("POST /graphql → deny", () => {
-  const d = evaluateGitHubRequest("POST", "/graphql", makePolicy());
-  assert.equal(d.action, "deny");
-  assert.ok(d.action === "deny" && d.reason.includes("GraphQL"));
+await test('POST /graphql → deny', () => {
+  const d = evaluateGitHubRequest('POST', '/graphql', makePolicy());
+  assert.equal(d.action, 'deny');
+  assert.ok(d.action === 'deny' && d.reason.includes('GraphQL'));
 });
 
-await test("DELETE /repos/owner/repo/pulls/42 → deny", () => {
-  const d = evaluateGitHubRequest("DELETE", "/repos/owner/repo/pulls/42", makePolicy());
-  assert.equal(d.action, "deny");
+await test('DELETE /repos/owner/repo/pulls/42 → deny', () => {
+  const d = evaluateGitHubRequest('DELETE', '/repos/owner/repo/pulls/42', makePolicy());
+  assert.equal(d.action, 'deny');
 });
 
-await test("GET /repos/other/repo/pulls → deny (cross-repo)", () => {
-  const d = evaluateGitHubRequest("GET", "/repos/other/repo/pulls", makePolicy());
-  assert.equal(d.action, "deny");
-  assert.ok(d.action === "deny" && d.reason.includes("cross-repo"));
+await test('GET /repos/other/repo/pulls → deny (cross-repo)', () => {
+  const d = evaluateGitHubRequest('GET', '/repos/other/repo/pulls', makePolicy());
+  assert.equal(d.action, 'deny');
+  assert.ok(d.action === 'deny' && d.reason.includes('cross-repo'));
 });
 
-await test("GET /some/unknown/endpoint → deny (default-deny)", () => {
-  const d = evaluateGitHubRequest("GET", "/some/unknown/endpoint", makePolicy());
-  assert.equal(d.action, "deny");
-  assert.ok(d.action === "deny" && d.reason.includes("not in allowlist"));
+await test('GET /some/unknown/endpoint → deny (default-deny)', () => {
+  const d = evaluateGitHubRequest('GET', '/some/unknown/endpoint', makePolicy());
+  assert.equal(d.action, 'deny');
+  assert.ok(d.action === 'deny' && d.reason.includes('not in allowlist'));
 });
 
-await test("GET /repos/owner/repo → allow (repo metadata)", () => {
-  const d = evaluateGitHubRequest("GET", "/repos/owner/repo", makePolicy());
-  assert.equal(d.action, "allow");
+await test('GET /repos/owner/repo → allow (repo metadata)', () => {
+  const d = evaluateGitHubRequest('GET', '/repos/owner/repo', makePolicy());
+  assert.equal(d.action, 'allow');
 });
 
-await test("GET /repos/owner/repo/issues → allow", () => {
-  const d = evaluateGitHubRequest("GET", "/repos/owner/repo/issues", makePolicy());
-  assert.equal(d.action, "allow");
+await test('GET /repos/owner/repo/issues → allow', () => {
+  const d = evaluateGitHubRequest('GET', '/repos/owner/repo/issues', makePolicy());
+  assert.equal(d.action, 'allow');
 });
 
-await test("POST /repos/owner/repo/issues → deny", () => {
-  const d = evaluateGitHubRequest("POST", "/repos/owner/repo/issues", makePolicy());
-  assert.equal(d.action, "deny");
+await test('POST /repos/owner/repo/issues → deny', () => {
+  const d = evaluateGitHubRequest('POST', '/repos/owner/repo/issues', makePolicy());
+  assert.equal(d.action, 'deny');
 });
 
-await test("PATCH /repos/owner/repo/pulls/42 (owned) → allow", () => {
-  const d = evaluateGitHubRequest("PATCH", "/repos/owner/repo/pulls/42", makePolicy({ ownedPrNumber: 42 }));
-  assert.equal(d.action, "allow");
+await test('PATCH /repos/owner/repo/pulls/42 (owned) → allow', () => {
+  const d = evaluateGitHubRequest(
+    'PATCH',
+    '/repos/owner/repo/pulls/42',
+    makePolicy({ ownedPrNumber: 42 }),
+  );
+  assert.equal(d.action, 'allow');
 });
 
-await test("PATCH /repos/owner/repo/pulls/99 (not owned) → deny", () => {
-  const d = evaluateGitHubRequest("PATCH", "/repos/owner/repo/pulls/99", makePolicy({ ownedPrNumber: 42 }));
-  assert.equal(d.action, "deny");
+await test('PATCH /repos/owner/repo/pulls/99 (not owned) → deny', () => {
+  const d = evaluateGitHubRequest(
+    'PATCH',
+    '/repos/owner/repo/pulls/99',
+    makePolicy({ ownedPrNumber: 42 }),
+  );
+  assert.equal(d.action, 'deny');
 });
 
-await test("GET /repos/owner/repo/pulls?per_page=100 → allow (query string stripped)", () => {
-  const d = evaluateGitHubRequest("GET", "/repos/owner/repo/pulls?per_page=100", makePolicy());
-  assert.equal(d.action, "allow");
+await test('GET /repos/owner/repo/pulls?per_page=100 → allow (query string stripped)', () => {
+  const d = evaluateGitHubRequest('GET', '/repos/owner/repo/pulls?per_page=100', makePolicy());
+  assert.equal(d.action, 'allow');
 });
 
-await test("GET /repos/owner/repo/pulls/ → allow (trailing slash stripped)", () => {
-  const d = evaluateGitHubRequest("GET", "/repos/owner/repo/pulls/", makePolicy());
-  assert.equal(d.action, "allow");
+await test('GET /repos/owner/repo/pulls/ → allow (trailing slash stripped)', () => {
+  const d = evaluateGitHubRequest('GET', '/repos/owner/repo/pulls/', makePolicy());
+  assert.equal(d.action, 'allow');
 });
 
 // =========================================================================
 // parseGitReceivePack
 // =========================================================================
 
-console.log("\n  parseGitReceivePack:");
+console.log('\n  parseGitReceivePack:');
 
 function makePktLine(line: string): Buffer {
-  const payload = line + "\n";
-  const len = (payload.length + 4).toString(16).padStart(4, "0");
-  return Buffer.from(len + payload, "ascii");
+  const payload = line + '\n';
+  const len = (payload.length + 4).toString(16).padStart(4, '0');
+  return Buffer.from(len + payload, 'ascii');
 }
 
-const FLUSH = Buffer.from("0000", "ascii");
+const FLUSH = Buffer.from('0000', 'ascii');
 
-await test("parse a single ref update", () => {
+await test('parse a single ref update', () => {
   const body = Buffer.concat([
-    makePktLine("0000000000000000000000000000000000000000 abc123abc123abc123abc123abc123abc123abc1 refs/heads/feature-branch"),
+    makePktLine(
+      '0000000000000000000000000000000000000000 abc123abc123abc123abc123abc123abc123abc1 refs/heads/feature-branch',
+    ),
     FLUSH,
   ]);
   const result = parseGitReceivePack(body);
   assert.equal(result.ok, true);
   assert.equal(result.refs.length, 1);
-  assert.equal(result.refs[0].oldSha, "0000000000000000000000000000000000000000");
-  assert.equal(result.refs[0].newSha, "abc123abc123abc123abc123abc123abc123abc1");
-  assert.equal(result.refs[0].refName, "refs/heads/feature-branch");
+  assert.equal(result.refs[0].oldSha, '0000000000000000000000000000000000000000');
+  assert.equal(result.refs[0].newSha, 'abc123abc123abc123abc123abc123abc123abc1');
+  assert.equal(result.refs[0].refName, 'refs/heads/feature-branch');
 });
 
-await test("parse multiple ref updates", () => {
+await test('parse multiple ref updates', () => {
   const body = Buffer.concat([
-    makePktLine("aaaa000000000000000000000000000000000000 bbbb000000000000000000000000000000000000 refs/heads/branch-a"),
-    makePktLine("cccc000000000000000000000000000000000000 dddd000000000000000000000000000000000000 refs/heads/branch-b"),
+    makePktLine(
+      'aaaa000000000000000000000000000000000000 bbbb000000000000000000000000000000000000 refs/heads/branch-a',
+    ),
+    makePktLine(
+      'cccc000000000000000000000000000000000000 dddd000000000000000000000000000000000000 refs/heads/branch-b',
+    ),
     FLUSH,
   ]);
   const result = parseGitReceivePack(body);
   assert.equal(result.ok, true);
   assert.equal(result.refs.length, 2);
-  assert.equal(result.refs[0].refName, "refs/heads/branch-a");
-  assert.equal(result.refs[1].refName, "refs/heads/branch-b");
+  assert.equal(result.refs[0].refName, 'refs/heads/branch-a');
+  assert.equal(result.refs[1].refName, 'refs/heads/branch-b');
 });
 
-await test("handle capabilities appended to first line", () => {
-  const line = "0000000000000000000000000000000000000000 abc123abc123abc123abc123abc123abc123abc1 refs/heads/main\0 report-status side-band-64k";
+await test('handle capabilities appended to first line', () => {
+  const line =
+    '0000000000000000000000000000000000000000 abc123abc123abc123abc123abc123abc123abc1 refs/heads/main\0 report-status side-band-64k';
   const body = Buffer.concat([makePktLine(line), FLUSH]);
   const result = parseGitReceivePack(body);
   assert.equal(result.ok, true);
   assert.equal(result.refs.length, 1);
-  assert.equal(result.refs[0].refName, "refs/heads/main");
+  assert.equal(result.refs[0].refName, 'refs/heads/main');
 });
 
-await test("flush packet with no data → ok with empty refs", () => {
+await test('flush packet with no data → ok with empty refs', () => {
   const result = parseGitReceivePack(FLUSH);
   assert.equal(result.ok, true);
   assert.equal(result.refs.length, 0);
 });
 
-await test("empty buffer → not ok (no flush packet)", () => {
+await test('empty buffer → not ok (no flush packet)', () => {
   const result = parseGitReceivePack(Buffer.alloc(0));
   assert.equal(result.ok, false);
 });
 
-await test("truncated pkt-line → not ok", () => {
-  const body = Buffer.from("00ff", "ascii"); // claims 255 bytes but only 4 present
+await test('truncated pkt-line → not ok', () => {
+  const body = Buffer.from('00ff', 'ascii'); // claims 255 bytes but only 4 present
   const result = parseGitReceivePack(body);
   assert.equal(result.ok, false);
 });
 
-await test("malformed length → not ok", () => {
-  const body = Buffer.from("zzzz", "ascii");
+await test('malformed length → not ok', () => {
+  const body = Buffer.from('zzzz', 'ascii');
   const result = parseGitReceivePack(body);
   assert.equal(result.ok, false);
 });
@@ -202,15 +221,15 @@ await test("malformed length → not ok", () => {
 // evaluateGitPush
 // =========================================================================
 
-console.log("\n  evaluateGitPush:");
+console.log('\n  evaluateGitPush:');
 
 function okRefs(refs: RefUpdate[]): ReceivePackResult {
   return { refs, ok: true };
 }
 
-await test("push to allowed ref → allowed", () => {
+await test('push to allowed ref → allowed', () => {
   const result = evaluateGitPush(
-    okRefs([{ oldSha: "aaa", newSha: "bbb", refName: "refs/heads/feature-branch" }]),
+    okRefs([{ oldSha: 'aaa', newSha: 'bbb', refName: 'refs/heads/feature-branch' }]),
     makePolicy(),
   );
   assert.equal(result.allowed, true);
@@ -218,45 +237,45 @@ await test("push to allowed ref → allowed", () => {
 
 await test("push to refs/heads/main with allowedPushRefs: ['feature-branch'] → denied", () => {
   const result = evaluateGitPush(
-    okRefs([{ oldSha: "aaa", newSha: "bbb", refName: "refs/heads/main" }]),
+    okRefs([{ oldSha: 'aaa', newSha: 'bbb', refName: 'refs/heads/main' }]),
     makePolicy(),
   );
   assert.equal(result.allowed, false);
-  assert.equal(result.deniedRef, "refs/heads/main");
+  assert.equal(result.deniedRef, 'refs/heads/main');
 });
 
-await test("push to multiple refs — one denied → denied", () => {
+await test('push to multiple refs — one denied → denied', () => {
   const result = evaluateGitPush(
     okRefs([
-      { oldSha: "aaa", newSha: "bbb", refName: "refs/heads/feature-branch" },
-      { oldSha: "ccc", newSha: "ddd", refName: "refs/heads/main" },
+      { oldSha: 'aaa', newSha: 'bbb', refName: 'refs/heads/feature-branch' },
+      { oldSha: 'ccc', newSha: 'ddd', refName: 'refs/heads/main' },
     ]),
     makePolicy(),
   );
   assert.equal(result.allowed, false);
-  assert.equal(result.deniedRef, "refs/heads/main");
+  assert.equal(result.deniedRef, 'refs/heads/main');
 });
 
-await test("push to multiple allowed refs → allowed", () => {
+await test('push to multiple allowed refs → allowed', () => {
   const result = evaluateGitPush(
     okRefs([
-      { oldSha: "aaa", newSha: "bbb", refName: "refs/heads/feature-branch" },
-      { oldSha: "ccc", newSha: "ddd", refName: "refs/heads/dev" },
+      { oldSha: 'aaa', newSha: 'bbb', refName: 'refs/heads/feature-branch' },
+      { oldSha: 'ccc', newSha: 'ddd', refName: 'refs/heads/dev' },
     ]),
-    makePolicy({ allowedPushRefs: ["feature-branch", "dev"] }),
+    makePolicy({ allowedPushRefs: ['feature-branch', 'dev'] }),
   );
   assert.equal(result.allowed, true);
 });
 
-await test("empty refs (ok parse) → allowed", () => {
+await test('empty refs (ok parse) → allowed', () => {
   const result = evaluateGitPush(okRefs([]), makePolicy());
   assert.equal(result.allowed, true);
 });
 
-await test("malformed parse result → denied (fail-closed)", () => {
+await test('malformed parse result → denied (fail-closed)', () => {
   const result = evaluateGitPush({ refs: [], ok: false }, makePolicy());
   assert.equal(result.allowed, false);
-  assert.ok(result.reason?.includes("malformed"));
+  assert.ok(result.reason?.includes('malformed'));
 });
 
 // --- Summary ---

--- a/scripts/test-github-policy.ts
+++ b/scripts/test-github-policy.ts
@@ -4,9 +4,9 @@
 //
 // Usage: npx tsx scripts/test-github-policy.ts
 
-import assert from "node:assert/strict";
-import { existsSync } from "node:fs";
-import { POLICY_DIR } from "../src/main/sandbox.js";
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { POLICY_DIR } from '../src/main/sandbox.js';
 import {
   detectGitHubRepo,
   parseGitHubRemoteUrl,
@@ -15,7 +15,7 @@ import {
   writePolicyState,
   readPolicyState,
   cleanupPolicyState,
-} from "../src/main/github-policy.js";
+} from '../src/main/github-policy.js';
 
 let passed = 0;
 let failed = 0;
@@ -33,96 +33,96 @@ function test(name: string, fn: () => void | Promise<void>): Promise<void> {
     });
 }
 
-console.log("=== GitHub Policy Tests ===\n");
+console.log('=== GitHub Policy Tests ===\n');
 
 // --- URL Parsing ---
 
-console.log("URL parsing:");
+console.log('URL parsing:');
 
-await test("HTTPS with .git", () => {
-  assert.equal(parseGitHubRemoteUrl("https://github.com/owner/repo.git"), "owner/repo");
+await test('HTTPS with .git', () => {
+  assert.equal(parseGitHubRemoteUrl('https://github.com/owner/repo.git'), 'owner/repo');
 });
 
-await test("HTTPS without .git", () => {
-  assert.equal(parseGitHubRemoteUrl("https://github.com/owner/repo"), "owner/repo");
+await test('HTTPS without .git', () => {
+  assert.equal(parseGitHubRemoteUrl('https://github.com/owner/repo'), 'owner/repo');
 });
 
-await test("SSH shorthand with .git", () => {
-  assert.equal(parseGitHubRemoteUrl("git@github.com:owner/repo.git"), "owner/repo");
+await test('SSH shorthand with .git', () => {
+  assert.equal(parseGitHubRemoteUrl('git@github.com:owner/repo.git'), 'owner/repo');
 });
 
-await test("SSH shorthand without .git", () => {
-  assert.equal(parseGitHubRemoteUrl("git@github.com:owner/repo"), "owner/repo");
+await test('SSH shorthand without .git', () => {
+  assert.equal(parseGitHubRemoteUrl('git@github.com:owner/repo'), 'owner/repo');
 });
 
-await test("SSH URL with .git", () => {
-  assert.equal(parseGitHubRemoteUrl("ssh://git@github.com/owner/repo.git"), "owner/repo");
+await test('SSH URL with .git', () => {
+  assert.equal(parseGitHubRemoteUrl('ssh://git@github.com/owner/repo.git'), 'owner/repo');
 });
 
-await test("SSH URL without .git", () => {
-  assert.equal(parseGitHubRemoteUrl("ssh://git@github.com/owner/repo"), "owner/repo");
+await test('SSH URL without .git', () => {
+  assert.equal(parseGitHubRemoteUrl('ssh://git@github.com/owner/repo'), 'owner/repo');
 });
 
-await test("Non-GitHub HTTPS returns null", () => {
-  assert.equal(parseGitHubRemoteUrl("https://gitlab.com/owner/repo.git"), null);
+await test('Non-GitHub HTTPS returns null', () => {
+  assert.equal(parseGitHubRemoteUrl('https://gitlab.com/owner/repo.git'), null);
 });
 
-await test("Non-GitHub SSH returns null", () => {
-  assert.equal(parseGitHubRemoteUrl("git@gitlab.com:owner/repo.git"), null);
+await test('Non-GitHub SSH returns null', () => {
+  assert.equal(parseGitHubRemoteUrl('git@gitlab.com:owner/repo.git'), null);
 });
 
-await test("Empty string returns null", () => {
-  assert.equal(parseGitHubRemoteUrl(""), null);
+await test('Empty string returns null', () => {
+  assert.equal(parseGitHubRemoteUrl(''), null);
 });
 
 // --- Live remote detection ---
 
-console.log("\nRemote detection:");
+console.log('\nRemote detection:');
 
-await test("detects GitHub repo from this repo", async () => {
+await test('detects GitHub repo from this repo', async () => {
   const repo = await detectGitHubRepo(process.cwd());
   console.log(`    detected: ${repo}`);
-  assert.ok(repo !== null, "should detect a GitHub remote");
-  assert.ok(repo!.includes("/"), "should be owner/repo format");
+  assert.ok(repo !== null, 'should detect a GitHub remote');
+  assert.ok(repo!.includes('/'), 'should be owner/repo format');
 });
 
-await test("returns null for non-git directory", async () => {
-  const repo = await detectGitHubRepo("/tmp");
+await test('returns null for non-git directory', async () => {
+  const repo = await detectGitHubRepo('/tmp');
   assert.equal(repo, null);
 });
 
 // --- buildSessionPolicy ---
 
-console.log("\nbuildSessionPolicy:");
+console.log('\nbuildSessionPolicy:');
 
-await test("builds policy with correct defaults", () => {
-  const policy = buildSessionPolicy("owner/repo", "feature-branch");
-  assert.equal(policy.repo, "owner/repo");
-  assert.deepEqual(policy.allowedPushRefs, ["feature-branch"]);
+await test('builds policy with correct defaults', () => {
+  const policy = buildSessionPolicy('owner/repo', 'feature-branch');
+  assert.equal(policy.repo, 'owner/repo');
+  assert.deepEqual(policy.allowedPushRefs, ['feature-branch']);
   assert.equal(policy.ownedPrNumber, null);
   assert.equal(policy.canCreatePr, true);
 });
 
 // --- State file round-trip ---
 
-console.log("\nState file I/O:");
+console.log('\nState file I/O:');
 
 const testSessionId = `test-github-policy-${Date.now()}`;
 
-await test("write and read round-trip (also ensures POLICY_DIR exists)", async () => {
-  const policy = buildSessionPolicy("dherman/bouncer", "my-branch");
+await test('write and read round-trip (also ensures POLICY_DIR exists)', async () => {
+  const policy = buildSessionPolicy('dherman/bouncer', 'my-branch');
   await writePolicyState(testSessionId, policy);
 
   const loaded = await readPolicyState(policyStatePath(testSessionId));
   assert.deepEqual(loaded, policy);
 });
 
-await test("cleanup removes the file", async () => {
+await test('cleanup removes the file', async () => {
   await cleanupPolicyState(testSessionId);
-  assert.ok(!existsSync(policyStatePath(testSessionId)), "file should be removed");
+  assert.ok(!existsSync(policyStatePath(testSessionId)), 'file should be removed');
 });
 
-await test("cleanup is idempotent (no error on missing file)", async () => {
+await test('cleanup is idempotent (no error on missing file)', async () => {
   await cleanupPolicyState(testSessionId); // already cleaned up
 });
 

--- a/scripts/test-hooks.ts
+++ b/scripts/test-hooks.ts
@@ -5,20 +5,20 @@
 //
 // Usage: npx tsx scripts/test-hooks.ts
 
-import assert from "node:assert/strict";
-import { existsSync } from "node:fs";
-import { readFile, mkdtemp, rm } from "node:fs/promises";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { readFile, mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import {
   hooksDir,
   allowedRefsPath,
   generatePrePushHook,
   installHooks,
   cleanupHooks,
-} from "../src/main/hooks.js";
+} from '../src/main/hooks.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -48,27 +48,27 @@ interface TestRepo {
 }
 
 async function createTestRepo(): Promise<TestRepo> {
-  const baseDir = await mkdtemp(join(tmpdir(), "bouncer-hooks-test-"));
-  const bareDir = join(baseDir, "bare.git");
-  const mainDir = join(baseDir, "main");
-  const worktreeDir = join(baseDir, "worktree");
-  const worktreeBranch = "bouncer/test-branch";
+  const baseDir = await mkdtemp(join(tmpdir(), 'bouncer-hooks-test-'));
+  const bareDir = join(baseDir, 'bare.git');
+  const mainDir = join(baseDir, 'main');
+  const worktreeDir = join(baseDir, 'worktree');
+  const worktreeBranch = 'bouncer/test-branch';
 
   // Create a bare remote repo with explicit default branch
-  await execFileAsync("git", ["init", "--bare", "--initial-branch=main", bareDir]);
+  await execFileAsync('git', ['init', '--bare', '--initial-branch=main', bareDir]);
 
   // Clone it to create a main working copy
-  await execFileAsync("git", ["clone", bareDir, mainDir]);
-  await execFileAsync("git", ["-C", mainDir, "config", "user.email", "test@test.com"]);
-  await execFileAsync("git", ["-C", mainDir, "config", "user.name", "Test"]);
+  await execFileAsync('git', ['clone', bareDir, mainDir]);
+  await execFileAsync('git', ['-C', mainDir, 'config', 'user.email', 'test@test.com']);
+  await execFileAsync('git', ['-C', mainDir, 'config', 'user.name', 'Test']);
 
   // Create an initial commit and push to establish the main branch
-  await execFileAsync("git", ["-C", mainDir, "checkout", "-b", "main"]);
-  await execFileAsync("git", ["-C", mainDir, "commit", "--allow-empty", "-m", "init"]);
-  await execFileAsync("git", ["-C", mainDir, "push", "-u", "origin", "main"]);
+  await execFileAsync('git', ['-C', mainDir, 'checkout', '-b', 'main']);
+  await execFileAsync('git', ['-C', mainDir, 'commit', '--allow-empty', '-m', 'init']);
+  await execFileAsync('git', ['-C', mainDir, 'push', '-u', 'origin', 'main']);
 
   // Create a worktree on the test branch
-  await execFileAsync("git", ["-C", mainDir, "worktree", "add", "-b", worktreeBranch, worktreeDir]);
+  await execFileAsync('git', ['-C', mainDir, 'worktree', 'add', '-b', worktreeBranch, worktreeDir]);
 
   return { bareDir, mainDir, worktreeDir, worktreeBranch };
 }
@@ -76,129 +76,163 @@ async function createTestRepo(): Promise<TestRepo> {
 async function cleanupTestRepo(repo: TestRepo): Promise<void> {
   // Remove worktree first, then the rest
   try {
-    await execFileAsync("git", ["-C", repo.mainDir, "worktree", "remove", "--force", repo.worktreeDir]);
+    await execFileAsync('git', [
+      '-C',
+      repo.mainDir,
+      'worktree',
+      'remove',
+      '--force',
+      repo.worktreeDir,
+    ]);
   } catch {
     // May already be gone
   }
-  await rm(join(repo.bareDir, ".."), { recursive: true, force: true });
+  await rm(join(repo.bareDir, '..'), { recursive: true, force: true });
 }
 
 // ==========================================================
 // Tests
 // ==========================================================
 
-console.log("=== Git Hooks Tests ===\n");
+console.log('=== Git Hooks Tests ===\n');
 
 // --- Unit tests (no repo needed) ---
 
-console.log("Hook generation:");
+console.log('Hook generation:');
 
-await test("hooksDir returns expected path", () => {
-  const dir = hooksDir("test-session");
-  assert.ok(dir.includes("test-session-hooks"));
+await test('hooksDir returns expected path', () => {
+  const dir = hooksDir('test-session');
+  assert.ok(dir.includes('test-session-hooks'));
 });
 
-await test("allowedRefsPath returns expected path", () => {
-  const p = allowedRefsPath("test-session");
-  assert.ok(p.includes("test-session-allowed-refs.txt"));
+await test('allowedRefsPath returns expected path', () => {
+  const p = allowedRefsPath('test-session');
+  assert.ok(p.includes('test-session-allowed-refs.txt'));
 });
 
-await test("generatePrePushHook contains the refs file path", () => {
-  const script = generatePrePushHook("/tmp/test-refs.txt");
-  assert.ok(script.includes("/tmp/test-refs.txt"));
-  assert.ok(script.startsWith("#!/bin/bash"));
-  assert.ok(script.includes("[bouncer:git]"));
+await test('generatePrePushHook contains the refs file path', () => {
+  const script = generatePrePushHook('/tmp/test-refs.txt');
+  assert.ok(script.includes('/tmp/test-refs.txt'));
+  assert.ok(script.startsWith('#!/bin/bash'));
+  assert.ok(script.includes('[bouncer:git]'));
 });
 
 // --- Integration tests (real git repos) ---
 
-console.log("\nHook installation:");
+console.log('\nHook installation:');
 
 const sessionId = `test-hooks-${Date.now()}`;
 let repo: TestRepo;
 
-await test("create test repo with worktree", async () => {
+await test('create test repo with worktree', async () => {
   repo = await createTestRepo();
   assert.ok(existsSync(repo.worktreeDir));
   // Verify the worktree branch exists
-  const { stdout } = await execFileAsync("git", ["-C", repo.worktreeDir, "branch", "--show-current"]);
+  const { stdout } = await execFileAsync('git', [
+    '-C',
+    repo.worktreeDir,
+    'branch',
+    '--show-current',
+  ]);
   assert.equal(stdout.trim(), repo.worktreeBranch);
 });
 
-await test("installHooks creates hook file and sets core.hooksPath", async () => {
+await test('installHooks creates hook file and sets core.hooksPath', async () => {
   await installHooks(sessionId, repo.worktreeDir, [repo.worktreeBranch]);
 
   // Verify hook file exists and is executable
-  const hookPath = join(hooksDir(sessionId), "pre-push");
-  assert.ok(existsSync(hookPath), "pre-push hook should exist");
+  const hookPath = join(hooksDir(sessionId), 'pre-push');
+  assert.ok(existsSync(hookPath), 'pre-push hook should exist');
 
-  const hookContent = await readFile(hookPath, "utf-8");
-  assert.ok(hookContent.includes("#!/bin/bash"), "hook should be a bash script");
+  const hookContent = await readFile(hookPath, 'utf-8');
+  assert.ok(hookContent.includes('#!/bin/bash'), 'hook should be a bash script');
 
   // Verify allowed-refs file
-  const refsContent = await readFile(allowedRefsPath(sessionId), "utf-8");
-  assert.ok(refsContent.includes(repo.worktreeBranch), "allowed-refs should contain the branch");
+  const refsContent = await readFile(allowedRefsPath(sessionId), 'utf-8');
+  assert.ok(refsContent.includes(repo.worktreeBranch), 'allowed-refs should contain the branch');
 
   // Verify core.hooksPath is set
-  const { stdout } = await execFileAsync("git", ["-C", repo.worktreeDir, "config", "core.hooksPath"]);
+  const { stdout } = await execFileAsync('git', [
+    '-C',
+    repo.worktreeDir,
+    'config',
+    'core.hooksPath',
+  ]);
   assert.equal(stdout.trim(), hooksDir(sessionId));
 });
 
-console.log("\nHook enforcement:");
+console.log('\nHook enforcement:');
 
-await test("push to allowed ref succeeds", async () => {
+await test('push to allowed ref succeeds', async () => {
   // Create a commit in the worktree and push
-  await execFileAsync("git", ["-C", repo.worktreeDir, "commit", "--allow-empty", "-m", "test commit"]);
-  await execFileAsync("git", ["-C", repo.worktreeDir, "push", "origin", repo.worktreeBranch]);
+  await execFileAsync('git', [
+    '-C',
+    repo.worktreeDir,
+    'commit',
+    '--allow-empty',
+    '-m',
+    'test commit',
+  ]);
+  await execFileAsync('git', ['-C', repo.worktreeDir, 'push', 'origin', repo.worktreeBranch]);
   // If we get here without error, the push succeeded through the hook
 });
 
-await test("push to denied ref fails", async () => {
+await test('push to denied ref fails', async () => {
   // Try to push to main (not in allowed refs)
   // First create a commit on a different branch in the worktree
   try {
     // Push current branch to a different remote ref — this should be denied
-    await execFileAsync("git", [
-      "-C", repo.worktreeDir, "push", "origin",
+    await execFileAsync('git', [
+      '-C',
+      repo.worktreeDir,
+      'push',
+      'origin',
       `HEAD:refs/heads/unauthorized-branch`,
     ]);
-    assert.fail("push to unauthorized branch should have been denied");
+    assert.fail('push to unauthorized branch should have been denied');
   } catch (err: unknown) {
-    const stderr = (err as { stderr?: string }).stderr ?? "";
+    const stderr = (err as { stderr?: string }).stderr ?? '';
     assert.ok(
-      stderr.includes("[bouncer:git] DENY"),
+      stderr.includes('[bouncer:git] DENY'),
       `expected bouncer denial message, got: ${stderr}`,
     );
   }
 });
 
-console.log("\nHook cleanup:");
+console.log('\nHook cleanup:');
 
-await test("cleanupHooks removes hooks dir and unsets core.hooksPath", async () => {
+await test('cleanupHooks removes hooks dir and unsets core.hooksPath', async () => {
   await cleanupHooks(sessionId, repo.worktreeDir);
 
   // Hooks directory should be gone
-  assert.ok(!existsSync(hooksDir(sessionId)), "hooks dir should be removed");
+  assert.ok(!existsSync(hooksDir(sessionId)), 'hooks dir should be removed');
 
   // Allowed refs file should be gone
-  assert.ok(!existsSync(allowedRefsPath(sessionId)), "allowed-refs file should be removed");
+  assert.ok(!existsSync(allowedRefsPath(sessionId)), 'allowed-refs file should be removed');
 
   // core.hooksPath should be unset
   try {
-    await execFileAsync("git", ["-C", repo.worktreeDir, "config", "core.hooksPath"]);
-    assert.fail("core.hooksPath should be unset");
+    await execFileAsync('git', ['-C', repo.worktreeDir, 'config', 'core.hooksPath']);
+    assert.fail('core.hooksPath should be unset');
   } catch {
     // Expected — config key not found
   }
 });
 
-await test("cleanupHooks is idempotent", async () => {
+await test('cleanupHooks is idempotent', async () => {
   await cleanupHooks(sessionId, repo.worktreeDir);
 });
 
-await test("push works after hook cleanup", async () => {
-  await execFileAsync("git", ["-C", repo.worktreeDir, "commit", "--allow-empty", "-m", "after cleanup"]);
-  await execFileAsync("git", ["-C", repo.worktreeDir, "push", "origin", repo.worktreeBranch]);
+await test('push works after hook cleanup', async () => {
+  await execFileAsync('git', [
+    '-C',
+    repo.worktreeDir,
+    'commit',
+    '--allow-empty',
+    '-m',
+    'after cleanup',
+  ]);
+  await execFileAsync('git', ['-C', repo.worktreeDir, 'push', 'origin', repo.worktreeBranch]);
 });
 
 // --- Cleanup ---

--- a/scripts/test-policy-container.ts
+++ b/scripts/test-policy-container.ts
@@ -2,9 +2,14 @@
  * Test policyToContainerConfig(), generateGitconfig(), and the credential helper.
  */
 
-import { policyToContainerConfig, generateGitconfig, sanitizeGitconfig, generateCredentialHelperJs } from "../src/main/policy-container.js";
-import { standardPrTemplate, researchOnlyTemplate } from "../src/main/policy-templates.js";
-import type { PolicyTemplate } from "../src/main/types.js";
+import {
+  policyToContainerConfig,
+  generateGitconfig,
+  sanitizeGitconfig,
+  generateCredentialHelperJs,
+} from '../src/main/policy-container.js';
+import { standardPrTemplate, researchOnlyTemplate } from '../src/main/policy-templates.js';
+import type { PolicyTemplate } from '../src/main/types.js';
 
 let passed = 0;
 let failed = 0;
@@ -23,62 +28,70 @@ function assert(condition: boolean, msg: string): void {
   const config = policyToContainerConfig(
     standardPrTemplate,
     {
-      sessionId: "test-123",
-      worktreePath: "/tmp/wt",
-      gitCommonDir: "/tmp/repo/.git",
-      agentBinPath: "/app/agent",
-      nodeModulesPath: "/app/node_modules",
-      shimBundlePath: "/tmp/shim.js",
-      shimScriptPath: "/tmp/gh-wrapper",
-      hooksDir: "/tmp/hooks",
-      allowedRefsPath: "/tmp/allowed-refs.txt",
-      policyStatePath: "/tmp/policy.json",
-      gitconfigPath: "/tmp/gitconfig",
-      credentialHelperPath: "/tmp/cred-helper.js",
+      sessionId: 'test-123',
+      worktreePath: '/tmp/wt',
+      gitCommonDir: '/tmp/repo/.git',
+      agentBinPath: '/app/agent',
+      nodeModulesPath: '/app/node_modules',
+      shimBundlePath: '/tmp/shim.js',
+      shimScriptPath: '/tmp/gh-wrapper',
+      hooksDir: '/tmp/hooks',
+      allowedRefsPath: '/tmp/allowed-refs.txt',
+      policyStatePath: '/tmp/policy.json',
+      gitconfigPath: '/tmp/gitconfig',
+      credentialHelperPath: '/tmp/cred-helper.js',
     },
-    { ANTHROPIC_API_KEY: "test-key", GH_TOKEN: "ghp_test" },
-    "bouncer-agent:abc123",
-    ["node", "/usr/local/lib/agent/index.js"],
+    { ANTHROPIC_API_KEY: 'test-key', GH_TOKEN: 'ghp_test' },
+    'bouncer-agent:abc123',
+    ['node', '/usr/local/lib/agent/index.js'],
   );
 
-  assert(config.sessionId === "test-123", "sessionId");
-  assert(config.image === "bouncer-agent:abc123", "image tag");
-  assert(config.workdir === "/workspace", "workdir");
-  assert(config.networkMode === "bridge", "network mode");
+  assert(config.sessionId === 'test-123', 'sessionId');
+  assert(config.image === 'bouncer-agent:abc123', 'image tag');
+  assert(config.workdir === '/workspace', 'workdir');
+  assert(config.networkMode === 'bridge', 'network mode');
 
   // Check mounts
   const mountPaths = config.mounts.map((m) => m.containerPath);
-  assert(mountPaths.includes("/workspace"), "worktree mount");
-  assert(mountPaths.includes("/tmp/repo/.git"), "git common dir mount (at host path)");
-  assert(mountPaths.includes("/usr/local/lib/agent"), "agent bin mount");
-  assert(mountPaths.includes("/usr/local/lib/agent/node_modules"), "node_modules mount");
-  assert(mountPaths.includes("/etc/bouncer/hooks"), "hooks mount");
-  assert(mountPaths.includes("/etc/bouncer/allowed-refs.txt"), "allowed refs mount");
-  assert(mountPaths.includes("/usr/local/bin/gh"), "shim script mount");
-  assert(mountPaths.includes("/usr/local/lib/bouncer/gh-shim.js"), "shim bundle mount");
-  assert(mountPaths.includes("/etc/bouncer/github-policy.json"), "policy state mount");
-  assert(mountPaths.includes("/etc/gitconfig"), "gitconfig mount");
-  assert(mountPaths.includes("/usr/local/lib/bouncer/gh-credential-helper.js"), "credential helper mount");
+  assert(mountPaths.includes('/workspace'), 'worktree mount');
+  assert(mountPaths.includes('/tmp/repo/.git'), 'git common dir mount (at host path)');
+  assert(mountPaths.includes('/usr/local/lib/agent'), 'agent bin mount');
+  assert(mountPaths.includes('/usr/local/lib/agent/node_modules'), 'node_modules mount');
+  assert(mountPaths.includes('/etc/bouncer/hooks'), 'hooks mount');
+  assert(mountPaths.includes('/etc/bouncer/allowed-refs.txt'), 'allowed refs mount');
+  assert(mountPaths.includes('/usr/local/bin/gh'), 'shim script mount');
+  assert(mountPaths.includes('/usr/local/lib/bouncer/gh-shim.js'), 'shim bundle mount');
+  assert(mountPaths.includes('/etc/bouncer/github-policy.json'), 'policy state mount');
+  assert(mountPaths.includes('/etc/gitconfig'), 'gitconfig mount');
+  assert(
+    mountPaths.includes('/usr/local/lib/bouncer/gh-credential-helper.js'),
+    'credential helper mount',
+  );
 
   // Worktree should be rw for standard PR
-  const wtMount = config.mounts.find((m) => m.containerPath === "/workspace");
-  assert(wtMount?.readOnly === false, "worktree is rw for standard-pr");
+  const wtMount = config.mounts.find((m) => m.containerPath === '/workspace');
+  assert(wtMount?.readOnly === false, 'worktree is rw for standard-pr');
 
   // Policy state should be rw
-  const policyMount = config.mounts.find((m) => m.containerPath === "/etc/bouncer/github-policy.json");
-  assert(policyMount?.readOnly === false, "policy state is rw");
+  const policyMount = config.mounts.find(
+    (m) => m.containerPath === '/etc/bouncer/github-policy.json',
+  );
+  assert(policyMount?.readOnly === false, 'policy state is rw');
 
   // Hooks should be ro
-  const hooksMount = config.mounts.find((m) => m.containerPath === "/etc/bouncer/hooks");
-  assert(hooksMount?.readOnly === true, "hooks is ro");
+  const hooksMount = config.mounts.find((m) => m.containerPath === '/etc/bouncer/hooks');
+  assert(hooksMount?.readOnly === true, 'hooks is ro');
 
   // Env
-  assert(config.env.BOUNCER_GITHUB_POLICY === "/etc/bouncer/github-policy.json", "BOUNCER_GITHUB_POLICY env");
-  assert(config.env.NODE_PATH === "/usr/local/lib/agent/node_modules", "NODE_PATH env");
-  assert(config.env.ANTHROPIC_API_KEY === "test-key", "ANTHROPIC_API_KEY passthrough");
+  assert(
+    config.env.BOUNCER_GITHUB_POLICY === '/etc/bouncer/github-policy.json',
+    'BOUNCER_GITHUB_POLICY env',
+  );
+  assert(config.env.NODE_PATH === '/usr/local/lib/agent/node_modules', 'NODE_PATH env');
+  assert(config.env.ANTHROPIC_API_KEY === 'test-key', 'ANTHROPIC_API_KEY passthrough');
 
   // SSH should NOT be mounted (not provided in ctx)
-  assert(!mountPaths.includes("/home/agent/.ssh"), "no SSH mount when sshDir not provided");
+  assert(!mountPaths.includes('/home/agent/.ssh'), 'no SSH mount when sshDir not provided');
 }
 
 // --- Test policyToContainerConfig: template without github ---
@@ -86,75 +99,81 @@ function assert(condition: boolean, msg: string): void {
   const config = policyToContainerConfig(
     researchOnlyTemplate,
     {
-      sessionId: "test-456",
-      worktreePath: "/tmp/wt2",
-      agentBinPath: "/app/agent",
-      nodeModulesPath: "/app/node_modules",
+      sessionId: 'test-456',
+      worktreePath: '/tmp/wt2',
+      agentBinPath: '/app/agent',
+      nodeModulesPath: '/app/node_modules',
     },
     {},
-    "bouncer-agent:def456",
-    ["node", "/usr/local/lib/agent/index.js"],
+    'bouncer-agent:def456',
+    ['node', '/usr/local/lib/agent/index.js'],
   );
 
   const mountPaths = config.mounts.map((m) => m.containerPath);
-  assert(!mountPaths.includes("/etc/bouncer/hooks"), "no hooks mount without github");
-  assert(!mountPaths.includes("/usr/local/bin/gh"), "no shim mount without github");
-  assert(!mountPaths.includes("/etc/gitconfig"), "no gitconfig mount without github");
-  assert(!mountPaths.includes("/usr/local/lib/bouncer/gh-credential-helper.js"), "no cred helper without github");
-  assert(config.env.BOUNCER_GITHUB_POLICY === undefined, "no BOUNCER_GITHUB_POLICY without github");
+  assert(!mountPaths.includes('/etc/bouncer/hooks'), 'no hooks mount without github');
+  assert(!mountPaths.includes('/usr/local/bin/gh'), 'no shim mount without github');
+  assert(!mountPaths.includes('/etc/gitconfig'), 'no gitconfig mount without github');
+  assert(
+    !mountPaths.includes('/usr/local/lib/bouncer/gh-credential-helper.js'),
+    'no cred helper without github',
+  );
+  assert(config.env.BOUNCER_GITHUB_POLICY === undefined, 'no BOUNCER_GITHUB_POLICY without github');
 }
 
 // --- Test policyToContainerConfig: read-only worktree ---
 {
   const roTemplate: PolicyTemplate = {
     ...researchOnlyTemplate,
-    id: "ro-test",
-    filesystem: { ...researchOnlyTemplate.filesystem, worktreeAccess: "read-only" },
+    id: 'ro-test',
+    filesystem: { ...researchOnlyTemplate.filesystem, worktreeAccess: 'read-only' },
   };
 
   const config = policyToContainerConfig(
     roTemplate,
     {
-      sessionId: "test-789",
-      worktreePath: "/tmp/wt3",
-      gitCommonDir: "/tmp/repo3/.git",
-      agentBinPath: "/app/agent",
-      nodeModulesPath: "/app/node_modules",
+      sessionId: 'test-789',
+      worktreePath: '/tmp/wt3',
+      gitCommonDir: '/tmp/repo3/.git',
+      agentBinPath: '/app/agent',
+      nodeModulesPath: '/app/node_modules',
     },
     {},
-    "bouncer-agent:ghi789",
-    ["node", "/usr/local/lib/agent/index.js"],
+    'bouncer-agent:ghi789',
+    ['node', '/usr/local/lib/agent/index.js'],
   );
 
-  const wtMount = config.mounts.find((m) => m.containerPath === "/workspace");
-  assert(wtMount?.readOnly === true, "worktree is ro for read-only template");
-  const gitMount = config.mounts.find((m) => m.containerPath === "/tmp/repo3/.git");
-  assert(gitMount?.readOnly === true, "git common dir follows worktree access mode");
+  const wtMount = config.mounts.find((m) => m.containerPath === '/workspace');
+  assert(wtMount?.readOnly === true, 'worktree is ro for read-only template');
+  const gitMount = config.mounts.find((m) => m.containerPath === '/tmp/repo3/.git');
+  assert(gitMount?.readOnly === true, 'git common dir follows worktree access mode');
 }
 
 // --- Test generateGitconfig ---
 {
   const content = generateGitconfig({
-    hooksPath: "/etc/bouncer/hooks",
-    credentialHelperPath: "/usr/local/lib/bouncer/gh-credential-helper.js",
-    userName: "Test User",
-    userEmail: "test@example.com",
+    hooksPath: '/etc/bouncer/hooks',
+    credentialHelperPath: '/usr/local/lib/bouncer/gh-credential-helper.js',
+    userName: 'Test User',
+    userEmail: 'test@example.com',
   });
 
-  assert(content.includes("hooksPath = /etc/bouncer/hooks"), "gitconfig has hooksPath");
-  assert(content.includes('helper = !node /usr/local/lib/bouncer/gh-credential-helper.js'), "gitconfig has credential helper");
-  assert(content.includes("name = Test User"), "gitconfig has user name");
-  assert(content.includes("email = test@example.com"), "gitconfig has user email");
+  assert(content.includes('hooksPath = /etc/bouncer/hooks'), 'gitconfig has hooksPath');
+  assert(
+    content.includes('helper = !node /usr/local/lib/bouncer/gh-credential-helper.js'),
+    'gitconfig has credential helper',
+  );
+  assert(content.includes('name = Test User'), 'gitconfig has user name');
+  assert(content.includes('email = test@example.com'), 'gitconfig has user email');
 }
 
 // --- Test generateGitconfig without user ---
 {
   const content = generateGitconfig({
-    hooksPath: "/etc/bouncer/hooks",
-    credentialHelperPath: "/usr/local/lib/bouncer/gh-credential-helper.js",
+    hooksPath: '/etc/bouncer/hooks',
+    credentialHelperPath: '/usr/local/lib/bouncer/gh-credential-helper.js',
   });
 
-  assert(!content.includes("[user]"), "gitconfig omits [user] when not provided");
+  assert(!content.includes('[user]'), 'gitconfig omits [user] when not provided');
 }
 
 // --- Test policyToContainerConfig: Claude config and credentials mounts ---
@@ -162,26 +181,31 @@ function assert(condition: boolean, msg: string): void {
   const config = policyToContainerConfig(
     researchOnlyTemplate,
     {
-      sessionId: "test-claude",
-      worktreePath: "/tmp/wt-claude",
-      agentBinPath: "/app/agent",
-      nodeModulesPath: "/app/node_modules",
-      claudeConfigDir: "/home/testuser/.claude",
-      claudeCredentialsPath: "/tmp/creds.json",
+      sessionId: 'test-claude',
+      worktreePath: '/tmp/wt-claude',
+      agentBinPath: '/app/agent',
+      nodeModulesPath: '/app/node_modules',
+      claudeConfigDir: '/home/testuser/.claude',
+      claudeCredentialsPath: '/tmp/creds.json',
     },
     {},
-    "bouncer-agent:claude",
-    ["node", "/usr/local/lib/agent/dist/index.js"],
+    'bouncer-agent:claude',
+    ['node', '/usr/local/lib/agent/dist/index.js'],
   );
 
   const mountPaths = config.mounts.map((m) => m.containerPath);
-  assert(mountPaths.includes("/home/agent/.claude"), "claude config dir mounted");
-  assert(mountPaths.includes("/home/agent/.claude/.credentials.json"), "claude credentials file mounted");
+  assert(mountPaths.includes('/home/agent/.claude'), 'claude config dir mounted');
+  assert(
+    mountPaths.includes('/home/agent/.claude/.credentials.json'),
+    'claude credentials file mounted',
+  );
 
-  const configMount = config.mounts.find((m) => m.containerPath === "/home/agent/.claude");
-  assert(configMount?.readOnly === false, "claude config dir is rw");
-  const credsMount = config.mounts.find((m) => m.containerPath === "/home/agent/.claude/.credentials.json");
-  assert(credsMount?.readOnly === true, "claude credentials file is ro");
+  const configMount = config.mounts.find((m) => m.containerPath === '/home/agent/.claude');
+  assert(configMount?.readOnly === false, 'claude config dir is rw');
+  const credsMount = config.mounts.find(
+    (m) => m.containerPath === '/home/agent/.claude/.credentials.json',
+  );
+  assert(credsMount?.readOnly === true, 'claude credentials file is ro');
 }
 
 // --- Test policyToContainerConfig: no Claude mounts when not provided ---
@@ -189,19 +213,22 @@ function assert(condition: boolean, msg: string): void {
   const config = policyToContainerConfig(
     researchOnlyTemplate,
     {
-      sessionId: "test-no-claude",
-      worktreePath: "/tmp/wt-no-claude",
-      agentBinPath: "/app/agent",
-      nodeModulesPath: "/app/node_modules",
+      sessionId: 'test-no-claude',
+      worktreePath: '/tmp/wt-no-claude',
+      agentBinPath: '/app/agent',
+      nodeModulesPath: '/app/node_modules',
     },
     {},
-    "bouncer-agent:no-claude",
-    ["node", "/usr/local/lib/agent/dist/index.js"],
+    'bouncer-agent:no-claude',
+    ['node', '/usr/local/lib/agent/dist/index.js'],
   );
 
   const mountPaths = config.mounts.map((m) => m.containerPath);
-  assert(!mountPaths.includes("/home/agent/.claude"), "no claude config mount when not provided");
-  assert(!mountPaths.includes("/home/agent/.claude/.credentials.json"), "no claude creds mount when not provided");
+  assert(!mountPaths.includes('/home/agent/.claude'), 'no claude config mount when not provided');
+  assert(
+    !mountPaths.includes('/home/agent/.claude/.credentials.json'),
+    'no claude creds mount when not provided',
+  );
 }
 
 // --- Test sanitizeGitconfig ---
@@ -216,10 +243,10 @@ function assert(condition: boolean, msg: string): void {
     editor = vim
 `;
   const result = sanitizeGitconfig(input);
-  assert(result.includes("name = Test User"), "sanitize keeps [user] section");
-  assert(result.includes("editor = vim"), "sanitize keeps [core] section");
-  assert(!result.includes("credential"), "sanitize removes credential section");
-  assert(!result.includes("/opt/homebrew"), "sanitize removes host path");
+  assert(result.includes('name = Test User'), 'sanitize keeps [user] section');
+  assert(result.includes('editor = vim'), 'sanitize keeps [core] section');
+  assert(!result.includes('credential'), 'sanitize removes credential section');
+  assert(!result.includes('/opt/homebrew'), 'sanitize removes host path');
 }
 
 {
@@ -235,10 +262,10 @@ function assert(condition: boolean, msg: string): void {
     co = checkout
 `;
   const result = sanitizeGitconfig(input);
-  assert(result.includes("name = Test"), "sanitize keeps user with blank lines in cred");
-  assert(result.includes("co = checkout"), "sanitize keeps alias after cred section");
-  assert(!result.includes("helper"), "sanitize removes helper in cred section");
-  assert(!result.includes("useHttpPath"), "sanitize removes all keys in cred section");
+  assert(result.includes('name = Test'), 'sanitize keeps user with blank lines in cred');
+  assert(result.includes('co = checkout'), 'sanitize keeps alias after cred section');
+  assert(!result.includes('helper'), 'sanitize removes helper in cred section');
+  assert(!result.includes('useHttpPath'), 'sanitize removes all keys in cred section');
 }
 
 {
@@ -250,8 +277,8 @@ credential.helper = store
     editor = vim
 `;
   const result = sanitizeGitconfig(input);
-  assert(!result.includes("credential.helper"), "sanitize removes standalone credential.helper");
-  assert(result.includes("editor = vim"), "sanitize keeps core after standalone cred line");
+  assert(!result.includes('credential.helper'), 'sanitize removes standalone credential.helper');
+  assert(result.includes('editor = vim'), 'sanitize keeps core after standalone cred line');
 }
 
 {
@@ -262,19 +289,19 @@ credential.helper = store
     editor = vim
 `;
   const result = sanitizeGitconfig(input);
-  assert(result.includes("name = Test"), "no-op sanitize keeps user");
-  assert(result.includes("editor = vim"), "no-op sanitize keeps core");
+  assert(result.includes('name = Test'), 'no-op sanitize keeps user');
+  assert(result.includes('editor = vim'), 'no-op sanitize keeps core');
 }
 
 // --- Test generateCredentialHelperJs ---
 {
   const js = generateCredentialHelperJs();
-  assert(js.includes("#!/usr/bin/env node"), "cred helper has shebang");
-  assert(js.includes("GH_TOKEN"), "cred helper reads GH_TOKEN");
-  assert(js.includes("github.com"), "cred helper checks github.com");
-  assert(js.includes("x-access-token"), "cred helper uses x-access-token username");
-  assert(!js.includes(": Promise"), "cred helper has no TypeScript syntax");
-  assert(!js.includes(": string"), "cred helper has no TypeScript type annotations");
+  assert(js.includes('#!/usr/bin/env node'), 'cred helper has shebang');
+  assert(js.includes('GH_TOKEN'), 'cred helper reads GH_TOKEN');
+  assert(js.includes('github.com'), 'cred helper checks github.com');
+  assert(js.includes('x-access-token'), 'cred helper uses x-access-token username');
+  assert(!js.includes(': Promise'), 'cred helper has no TypeScript syntax');
+  assert(!js.includes(': string'), 'cred helper has no TypeScript type annotations');
 }
 
 // --- Results ---

--- a/scripts/test-policy-event-parser.ts
+++ b/scripts/test-policy-event-parser.ts
@@ -4,8 +4,8 @@
 //
 // Usage: npx tsx scripts/test-policy-event-parser.ts
 
-import assert from "node:assert/strict";
-import { parsePolicyEvent } from "../src/main/policy-event-parser.js";
+import assert from 'node:assert/strict';
+import { parsePolicyEvent } from '../src/main/policy-event-parser.js';
 
 let passed = 0;
 let failed = 0;
@@ -22,114 +22,120 @@ function test(name: string, fn: () => void): void {
   }
 }
 
-console.log("=== Policy Event Parser Tests ===\n");
+console.log('=== Policy Event Parser Tests ===\n');
 
 // --- gh shim events ---
 
-console.log("gh shim events:");
+console.log('gh shim events:');
 
-test("ALLOW pr create", () => {
+test('ALLOW pr create', () => {
   const event = parsePolicyEvent('[bouncer:gh] ALLOW pr create --title "foo"');
   assert.ok(event);
-  assert.equal(event.tool, "gh");
-  assert.equal(event.decision, "allow");
+  assert.equal(event.tool, 'gh');
+  assert.equal(event.decision, 'allow');
   assert.equal(event.operation, 'pr create --title "foo"');
   assert.equal(event.reason, undefined);
 });
 
-test("ALLOW pr view 42", () => {
-  const event = parsePolicyEvent("[bouncer:gh] ALLOW pr view 42");
+test('ALLOW pr view 42', () => {
+  const event = parsePolicyEvent('[bouncer:gh] ALLOW pr view 42');
   assert.ok(event);
-  assert.equal(event.tool, "gh");
-  assert.equal(event.decision, "allow");
-  assert.equal(event.operation, "pr view 42");
+  assert.equal(event.tool, 'gh');
+  assert.equal(event.decision, 'allow');
+  assert.equal(event.operation, 'pr view 42');
 });
 
-test("ALLOW api graphql [unaudited]", () => {
-  const event = parsePolicyEvent("[bouncer:gh] ALLOW api graphql [unaudited]");
+test('ALLOW api graphql [unaudited]', () => {
+  const event = parsePolicyEvent('[bouncer:gh] ALLOW api graphql [unaudited]');
   assert.ok(event);
-  assert.equal(event.tool, "gh");
-  assert.equal(event.decision, "allow");
-  assert.equal(event.operation, "api graphql");
+  assert.equal(event.tool, 'gh');
+  assert.equal(event.decision, 'allow');
+  assert.equal(event.operation, 'api graphql');
   assert.equal(event.reason, undefined);
 });
 
-test("DENY pr merge 15", () => {
-  const event = parsePolicyEvent("[bouncer:gh] DENY pr merge 15 — merging pull requests is not allowed");
+test('DENY pr merge 15', () => {
+  const event = parsePolicyEvent(
+    '[bouncer:gh] DENY pr merge 15 — merging pull requests is not allowed',
+  );
   assert.ok(event);
-  assert.equal(event.tool, "gh");
-  assert.equal(event.decision, "deny");
-  assert.equal(event.operation, "pr merge 15");
-  assert.equal(event.reason, "merging pull requests is not allowed");
+  assert.equal(event.tool, 'gh');
+  assert.equal(event.decision, 'deny');
+  assert.equal(event.operation, 'pr merge 15');
+  assert.equal(event.reason, 'merging pull requests is not allowed');
 });
 
-test("DENY auth login", () => {
-  const event = parsePolicyEvent("[bouncer:gh] DENY auth login — auth commands are not allowed");
+test('DENY auth login', () => {
+  const event = parsePolicyEvent('[bouncer:gh] DENY auth login — auth commands are not allowed');
   assert.ok(event);
-  assert.equal(event.decision, "deny");
-  assert.equal(event.operation, "auth login");
-  assert.equal(event.reason, "auth commands are not allowed");
+  assert.equal(event.decision, 'deny');
+  assert.equal(event.operation, 'auth login');
+  assert.equal(event.reason, 'auth commands are not allowed');
 });
 
-test("DENY cross-repo", () => {
-  const event = parsePolicyEvent("[bouncer:gh] DENY pr list — cross-repo access denied: 'other/repo' (session repo: 'owner/repo')");
+test('DENY cross-repo', () => {
+  const event = parsePolicyEvent(
+    "[bouncer:gh] DENY pr list — cross-repo access denied: 'other/repo' (session repo: 'owner/repo')",
+  );
   assert.ok(event);
-  assert.equal(event.decision, "deny");
-  assert.equal(event.operation, "pr list");
-  assert.ok(event.reason?.includes("cross-repo"));
+  assert.equal(event.decision, 'deny');
+  assert.equal(event.operation, 'pr list');
+  assert.ok(event.reason?.includes('cross-repo'));
 });
 
-test("ALLOW with no subcommand args", () => {
-  const event = parsePolicyEvent("[bouncer:gh] ALLOW pr list");
+test('ALLOW with no subcommand args', () => {
+  const event = parsePolicyEvent('[bouncer:gh] ALLOW pr list');
   assert.ok(event);
-  assert.equal(event.operation, "pr list");
-  assert.equal(event.decision, "allow");
+  assert.equal(event.operation, 'pr list');
+  assert.equal(event.decision, 'allow');
 });
 
 // --- git hook events ---
 
-console.log("\ngit hook events:");
+console.log('\ngit hook events:');
 
-test("ALLOW push to branch", () => {
-  const event = parsePolicyEvent("[bouncer:git] ALLOW push to bouncer/abc123");
+test('ALLOW push to branch', () => {
+  const event = parsePolicyEvent('[bouncer:git] ALLOW push to bouncer/abc123');
   assert.ok(event);
-  assert.equal(event.tool, "git");
-  assert.equal(event.decision, "allow");
-  assert.equal(event.operation, "push to bouncer/abc123");
+  assert.equal(event.tool, 'git');
+  assert.equal(event.decision, 'allow');
+  assert.equal(event.operation, 'push to bouncer/abc123');
 });
 
-test("DENY push to unauthorized branch", () => {
-  const event = parsePolicyEvent("[bouncer:git] DENY push to main — ref not in allowed list (bouncer/abc123)");
+test('DENY push to unauthorized branch', () => {
+  const event = parsePolicyEvent(
+    '[bouncer:git] DENY push to main — ref not in allowed list (bouncer/abc123)',
+  );
   assert.ok(event);
-  assert.equal(event.tool, "git");
-  assert.equal(event.decision, "deny");
-  assert.equal(event.operation, "push to main");
-  assert.equal(event.reason, "ref not in allowed list (bouncer/abc123)");
+  assert.equal(event.tool, 'git');
+  assert.equal(event.decision, 'deny');
+  assert.equal(event.operation, 'push to main');
+  assert.equal(event.reason, 'ref not in allowed list (bouncer/abc123)');
 });
 
 // --- Non-matching lines ---
 
-console.log("\nNon-matching lines:");
+console.log('\nNon-matching lines:');
 
-test("random stderr line returns null", () => {
-  assert.equal(parsePolicyEvent("some random stderr output"), null);
+test('random stderr line returns null', () => {
+  assert.equal(parsePolicyEvent('some random stderr output'), null);
 });
 
-test("empty line returns null", () => {
-  assert.equal(parsePolicyEvent(""), null);
+test('empty line returns null', () => {
+  assert.equal(parsePolicyEvent(''), null);
 });
 
-test("[bouncer:gh] error line returns null (not ALLOW/DENY)", () => {
-  assert.equal(parsePolicyEvent("[bouncer:gh] error: BOUNCER_GITHUB_POLICY not set"), null);
+test('[bouncer:gh] error line returns null (not ALLOW/DENY)', () => {
+  assert.equal(parsePolicyEvent('[bouncer:gh] error: BOUNCER_GITHUB_POLICY not set'), null);
 });
 
-test("[bouncer:gh] captured PR returns null", () => {
-  assert.equal(parsePolicyEvent("[bouncer:gh] captured PR #42"), null);
+test('[bouncer:gh] captured PR returns null', () => {
+  assert.equal(parsePolicyEvent('[bouncer:gh] captured PR #42'), null);
 });
 
-test("timestamp field is set", () => {
+test('timestamp field is set', () => {
   const before = Date.now();
-  const event = parsePolicyEvent("[bouncer:gh] ALLOW pr list");
+  const event = parsePolicyEvent('[bouncer:gh] ALLOW pr list');
   const after = Date.now();
   assert.ok(event);
   assert.ok(event.timestamp >= before && event.timestamp <= after);

--- a/scripts/test-policy-sandbox.ts
+++ b/scripts/test-policy-sandbox.ts
@@ -5,59 +5,67 @@
 //
 // Usage: npx tsx scripts/test-policy-sandbox.ts
 
-import assert from "node:assert/strict";
-import { PolicyTemplateRegistry } from "../src/main/policy-registry.js";
-import { policyToSandboxConfig } from "../src/main/policy-sandbox.js";
-import { buildSafehouseArgs } from "../src/main/sandbox.js";
+import assert from 'node:assert/strict';
+import { PolicyTemplateRegistry } from '../src/main/policy-registry.js';
+import { policyToSandboxConfig } from '../src/main/policy-sandbox.js';
+import { buildSafehouseArgs } from '../src/main/sandbox.js';
 
 const registry = new PolicyTemplateRegistry();
 const ctx = {
-  sessionId: "test-session-id",
-  worktreePath: "/tmp/test-worktree",
-  gitCommonDir: "/Users/test/project/.git",
-  readOnlyDirs: ["/path/to/agent-pkg"],
+  sessionId: 'test-session-id',
+  worktreePath: '/tmp/test-worktree',
+  gitCommonDir: '/Users/test/project/.git',
+  readOnlyDirs: ['/path/to/agent-pkg'],
 };
 
-console.log("=== Policy Template → Sandbox Config Tests ===\n");
+console.log('=== Policy Template → Sandbox Config Tests ===\n');
 
 for (const summary of registry.list()) {
   const template = registry.get(summary.id);
   const config = policyToSandboxConfig(template, ctx);
-  const args = buildSafehouseArgs(config, ["node", "/path/to/agent.js"]);
+  const args = buildSafehouseArgs(config, ['node', '/path/to/agent.js']);
 
   console.log(`--- ${summary.id} (${summary.name}) ---`);
   console.log(`  Description: ${summary.description}`);
-  console.log(`  Writable dirs: ${config.writableDirs.join(", ") || "(none)"}`);
-  console.log(`  Read-only dirs: ${config.readOnlyDirs.join(", ") || "(none)"}`);
-  console.log(`  Env passthrough: ${config.envPassthrough.join(", ")}`);
-  console.log(`  Append profile: ${config.appendProfileContent ? "yes" : "no"}`);
+  console.log(`  Writable dirs: ${config.writableDirs.join(', ') || '(none)'}`);
+  console.log(`  Read-only dirs: ${config.readOnlyDirs.join(', ') || '(none)'}`);
+  console.log(`  Env passthrough: ${config.envPassthrough.join(', ')}`);
+  console.log(`  Append profile: ${config.appendProfileContent ? 'yes' : 'no'}`);
   if (config.appendProfileContent) {
-    console.log(`  Append profile content:\n${config.appendProfileContent.split("\n").map(l => "    " + l).join("\n")}`);
+    console.log(
+      `  Append profile content:\n${config.appendProfileContent
+        .split('\n')
+        .map((l) => '    ' + l)
+        .join('\n')}`,
+    );
   }
-  console.log(`  Safehouse args: safehouse ${args.join(" ")}`);
+  console.log(`  Safehouse args: safehouse ${args.join(' ')}`);
 
   // Assertions
-  const hasAppendProfile = args.some((a) => a.startsWith("--append-profile="));
+  const hasAppendProfile = args.some((a) => a.startsWith('--append-profile='));
   const hasWorktreeWritable = config.writableDirs.includes(ctx.worktreePath);
   const hasWorktreeReadOnly = config.readOnlyDirs.includes(ctx.worktreePath);
 
-  if (summary.id === "standard-pr") {
-    assert(hasWorktreeWritable, "standard-pr: worktree should be writable");
-    assert(!hasWorktreeReadOnly, "standard-pr: worktree should not be read-only");
+  if (summary.id === 'standard-pr') {
+    assert(hasWorktreeWritable, 'standard-pr: worktree should be writable');
+    assert(!hasWorktreeReadOnly, 'standard-pr: worktree should not be read-only');
     // Network deny is intentionally skipped — SBPL deny blocks agent API traffic.
     // See docs/milestones/policy-templates/findings.md
-    assert(!hasAppendProfile, "standard-pr: should not have append profile (network deny deferred to M6)");
-  } else if (summary.id === "research-only") {
-    assert(hasWorktreeWritable, "research-only: worktree should be writable (scoped to worktree)");
-    assert(!hasWorktreeReadOnly, "research-only: worktree should not be read-only");
-    assert(!hasAppendProfile, "research-only: should not have append profile");
-  } else if (summary.id === "permissive") {
-    assert(hasWorktreeWritable, "permissive: worktree should be writable");
-    assert(!hasWorktreeReadOnly, "permissive: worktree should not be read-only");
-    assert(!hasAppendProfile, "permissive: should not have append profile");
+    assert(
+      !hasAppendProfile,
+      'standard-pr: should not have append profile (network deny deferred to M6)',
+    );
+  } else if (summary.id === 'research-only') {
+    assert(hasWorktreeWritable, 'research-only: worktree should be writable (scoped to worktree)');
+    assert(!hasWorktreeReadOnly, 'research-only: worktree should not be read-only');
+    assert(!hasAppendProfile, 'research-only: should not have append profile');
+  } else if (summary.id === 'permissive') {
+    assert(hasWorktreeWritable, 'permissive: worktree should be writable');
+    assert(!hasWorktreeReadOnly, 'permissive: worktree should not be read-only');
+    assert(!hasAppendProfile, 'permissive: should not have append profile');
   }
 
   console.log(`  ✓ Assertions passed\n`);
 }
 
-console.log("=== All tests passed ===");
+console.log('=== All tests passed ===');

--- a/scripts/test-proxy-e2e.ts
+++ b/scripts/test-proxy-e2e.ts
@@ -13,18 +13,18 @@
 //
 // Usage: npx tsx scripts/test-proxy-e2e.ts
 
-import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-import { mkdtempSync, rmSync, readFileSync } from "node:fs";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
-import { createHash } from "node:crypto";
-import { ensureCA, type BouncerCA } from "../src/main/proxy-tls.js";
-import { startProxy, type ProxyConfig, type ProxyHandle } from "../src/main/proxy.js";
-import { createGitHubMitmHandler } from "../src/main/proxy-github.js";
-import { createSessionNetwork, type SessionNetwork } from "../src/main/proxy-network.js";
-import type { GitHubPolicy, PolicyEvent } from "../src/main/types.js";
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createHash } from 'node:crypto';
+import { ensureCA, type BouncerCA } from '../src/main/proxy-tls.js';
+import { startProxy, type ProxyConfig, type ProxyHandle } from '../src/main/proxy.js';
+import { createGitHubMitmHandler } from '../src/main/proxy-github.js';
+import { createSessionNetwork, type SessionNetwork } from '../src/main/proxy-network.js';
+import type { GitHubPolicy, PolicyEvent } from '../src/main/types.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -48,7 +48,7 @@ function test(name: string, fn: () => void | Promise<void>): Promise<void> {
 
 async function isDockerAvailable(): Promise<boolean> {
   try {
-    await execFileAsync("docker", ["info"], { timeout: 10_000 });
+    await execFileAsync('docker', ['info'], { timeout: 10_000 });
     return true;
   } catch {
     return false;
@@ -58,24 +58,24 @@ async function isDockerAvailable(): Promise<boolean> {
 // --- Resolve agent image (same logic as container.ts but without Electron) ---
 
 async function resolveAgentImage(): Promise<string> {
-  const dockerDir = join(process.cwd(), "docker");
-  const dockerfilePath = join(dockerDir, "agent.Dockerfile");
+  const dockerDir = join(process.cwd(), 'docker');
+  const dockerfilePath = join(dockerDir, 'agent.Dockerfile');
   // Hash all build-context files so image is rebuilt when any input changes
-  const hasher = createHash("sha256");
-  hasher.update(readFileSync(dockerfilePath, "utf-8"));
-  hasher.update(readFileSync(join(dockerDir, "entrypoint.sh"), "utf-8"));
-  const hash = hasher.digest("hex").slice(0, 12);
+  const hasher = createHash('sha256');
+  hasher.update(readFileSync(dockerfilePath, 'utf-8'));
+  hasher.update(readFileSync(join(dockerDir, 'entrypoint.sh'), 'utf-8'));
+  const hash = hasher.digest('hex').slice(0, 12);
   const imageTag = `bouncer-agent:${hash}`;
 
   try {
-    await execFileAsync("docker", ["image", "inspect", imageTag], { timeout: 10_000 });
+    await execFileAsync('docker', ['image', 'inspect', imageTag], { timeout: 10_000 });
     return imageTag;
   } catch {
     // Build the image
     console.log(`  [setup] Building agent image ${imageTag}...`);
     await execFileAsync(
-      "docker",
-      ["build", "-t", imageTag, "-f", dockerfilePath, join(process.cwd(), "docker")],
+      'docker',
+      ['build', '-t', imageTag, '-f', dockerfilePath, join(process.cwd(), 'docker')],
       { timeout: 600_000 },
     );
     return imageTag;
@@ -84,15 +84,15 @@ async function resolveAgentImage(): Promise<string> {
 
 // =========================================================================
 
-console.log("\nM7 proxy end-to-end test\n");
+console.log('\nM7 proxy end-to-end test\n');
 
 const dockerAvailable = await isDockerAvailable();
 if (!dockerAvailable) {
-  console.log("  ⚠ Docker not available — skipping end-to-end test\n");
+  console.log('  ⚠ Docker not available — skipping end-to-end test\n');
   process.exit(0);
 }
 
-const tempDir = mkdtempSync(join(tmpdir(), "bouncer-e2e-"));
+const tempDir = mkdtempSync(join(tmpdir(), 'bouncer-e2e-'));
 let ca: BouncerCA;
 let proxy: ProxyHandle | undefined;
 let network: SessionNetwork | undefined;
@@ -107,8 +107,8 @@ try {
   imageTag = await resolveAgentImage();
 
   const policy: GitHubPolicy = {
-    repo: "owner/repo",
-    allowedPushRefs: ["feature-branch"],
+    repo: 'owner/repo',
+    allowedPushRefs: ['feature-branch'],
     ownedPrNumber: null,
     canCreatePr: true,
   };
@@ -116,14 +116,9 @@ try {
   const proxyConfig: ProxyConfig = {
     sessionId,
     port: 0,
-    listenHost: "0.0.0.0",
-    allowedDomains: [
-      "api.github.com",
-      "*.github.com",
-      "github.com",
-      "registry.npmjs.org",
-    ],
-    inspectedDomains: ["api.github.com", "github.com"],
+    listenHost: '0.0.0.0',
+    allowedDomains: ['api.github.com', '*.github.com', 'github.com', 'registry.npmjs.org'],
+    inspectedDomains: ['api.github.com', 'github.com'],
     githubPolicy: policy,
     ca,
     onPolicyEvent: (e) => events.push(e),
@@ -138,113 +133,144 @@ try {
 
   // Common docker run args: session network, proxy env vars, CA cert mount, host-gateway
   const dockerRunBase = [
-    "run", "--rm",
-    "--network", network.networkName,
-    "--add-host=host.docker.internal:host-gateway",
-    "-e", `HTTP_PROXY=${proxyUrl}`,
-    "-e", `HTTPS_PROXY=${proxyUrl}`,
-    "-e", `http_proxy=${proxyUrl}`,
-    "-e", `https_proxy=${proxyUrl}`,
-    "-e", "NO_PROXY=localhost,127.0.0.1,::1",
-    "-e", "no_proxy=localhost,127.0.0.1,::1",
-    "-v", `${ca.certPath}:/usr/local/share/ca-certificates/bouncer/bouncer-ca.crt:ro`,
+    'run',
+    '--rm',
+    '--network',
+    network.networkName,
+    '--add-host=host.docker.internal:host-gateway',
+    '-e',
+    `HTTP_PROXY=${proxyUrl}`,
+    '-e',
+    `HTTPS_PROXY=${proxyUrl}`,
+    '-e',
+    `http_proxy=${proxyUrl}`,
+    '-e',
+    `https_proxy=${proxyUrl}`,
+    '-e',
+    'NO_PROXY=localhost,127.0.0.1,::1',
+    '-e',
+    'no_proxy=localhost,127.0.0.1,::1',
+    '-v',
+    `${ca.certPath}:/usr/local/share/ca-certificates/bouncer/bouncer-ca.crt:ro`,
   ];
 
   console.log(`  [setup] Proxy on port ${proxy.port}, network ${network.networkName}`);
 
   // --- Tests ---
 
-  await test("allowed non-inspected domain: curl registry.npmjs.org tunnels through", async () => {
+  await test('allowed non-inspected domain: curl registry.npmjs.org tunnels through', async () => {
     // registry.npmjs.org is in allowedDomains but not inspectedDomains,
     // so it tunnels directly through the proxy (no MITM).
     const { stdout } = await execFileAsync(
-      "docker",
+      'docker',
       [
         ...dockerRunBase,
         imageTag,
-        "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
-        "--connect-timeout", "10",
-        "https://registry.npmjs.org/",
+        'curl',
+        '-s',
+        '-o',
+        '/dev/null',
+        '-w',
+        '%{http_code}',
+        '--connect-timeout',
+        '10',
+        'https://registry.npmjs.org/',
       ],
       { timeout: 30_000 },
     );
-    assert.equal(stdout.trim(), "200", `expected 200, got ${stdout.trim()}`);
+    assert.equal(stdout.trim(), '200', `expected 200, got ${stdout.trim()}`);
   });
 
-  await test("denied domain: curl evil.example.com → blocked by proxy", async () => {
+  await test('denied domain: curl evil.example.com → blocked by proxy', async () => {
     try {
       await execFileAsync(
-        "docker",
+        'docker',
         [
           ...dockerRunBase,
           imageTag,
-          "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
-          "--connect-timeout", "10",
-          "https://evil.example.com/",
+          'curl',
+          '-s',
+          '-o',
+          '/dev/null',
+          '-w',
+          '%{http_code}',
+          '--connect-timeout',
+          '10',
+          'https://evil.example.com/',
         ],
         { timeout: 30_000 },
       );
-      assert.fail("curl to denied domain should have failed");
+      assert.fail('curl to denied domain should have failed');
     } catch {
       // Expected: curl returns non-zero on proxy 403
     }
     assert.ok(
-      events.some((e) => e.decision === "deny" && e.operation.includes("evil.example.com")),
-      "should have logged a deny event for evil.example.com",
+      events.some((e) => e.decision === 'deny' && e.operation.includes('evil.example.com')),
+      'should have logged a deny event for evil.example.com',
     );
   });
 
-  await test("GitHub REST enforcement: allowed endpoint is forwarded and logged", async () => {
+  await test('GitHub REST enforcement: allowed endpoint is forwarded and logged', async () => {
     const prevLen = events.length;
     // GET /repos/owner/repo/pulls is allowed by policy. GitHub returns 404
     // for the non-existent repo, but the proxy forwards the request (allow).
     const { stdout } = await execFileAsync(
-      "docker",
+      'docker',
       [
         ...dockerRunBase,
         imageTag,
-        "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
-        "--connect-timeout", "10",
-        "--proxy-insecure",
-        "https://api.github.com/repos/owner/repo/pulls",
+        'curl',
+        '-s',
+        '-o',
+        '/dev/null',
+        '-w',
+        '%{http_code}',
+        '--connect-timeout',
+        '10',
+        '--proxy-insecure',
+        'https://api.github.com/repos/owner/repo/pulls',
       ],
       { timeout: 30_000 },
     );
     // Proxy forwarded (allow) → GitHub responds (status varies: 200, 404, 403 rate limit)
-    assert.ok(
-      /^[0-9]{3}$/.test(stdout.trim()),
-      `expected HTTP status code, got: ${stdout.trim()}`,
-    );
+    assert.ok(/^[0-9]{3}$/.test(stdout.trim()), `expected HTTP status code, got: ${stdout.trim()}`);
     // The definitive check: proxy logged an allow event (not a deny)
     assert.ok(
-      events.slice(prevLen).some((e) => e.decision === "allow" && e.operation.includes("GET")),
-      "should have logged an allow event",
+      events.slice(prevLen).some((e) => e.decision === 'allow' && e.operation.includes('GET')),
+      'should have logged an allow event',
     );
   });
 
-  await test("GitHub REST enforcement: POST /graphql → 403 (denied by policy)", async () => {
+  await test('GitHub REST enforcement: POST /graphql → 403 (denied by policy)', async () => {
     try {
       const { stdout } = await execFileAsync(
-        "docker",
+        'docker',
         [
           ...dockerRunBase,
           imageTag,
-          "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
-          "--connect-timeout", "10",
-          "--proxy-insecure",
-          "-X", "POST",
-          "https://api.github.com/graphql",
+          'curl',
+          '-s',
+          '-o',
+          '/dev/null',
+          '-w',
+          '%{http_code}',
+          '--connect-timeout',
+          '10',
+          '--proxy-insecure',
+          '-X',
+          'POST',
+          'https://api.github.com/graphql',
         ],
         { timeout: 30_000 },
       );
       // curl may still succeed with a 403 status
-      assert.equal(stdout.trim(), "403");
+      assert.equal(stdout.trim(), '403');
     } catch {
       // curl may exit non-zero — that's also fine
     }
     assert.ok(
-      events.some((e) => e.decision === "deny" && e.operation.includes("graphql")),
-      "should have logged a deny for graphql",
+      events.some((e) => e.decision === 'deny' && e.operation.includes('graphql')),
+      'should have logged a deny for graphql',
     );
   });
 
@@ -254,14 +280,20 @@ try {
     // We use the agent image (which has the entrypoint) without --proxy-insecure.
     // GET /repos/owner/repo/pulls is allowed by policy → forwarded to GitHub.
     const { stdout } = await execFileAsync(
-      "docker",
+      'docker',
       [
         ...dockerRunBase,
         imageTag,
-        "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
-        "--connect-timeout", "10",
+        'curl',
+        '-s',
+        '-o',
+        '/dev/null',
+        '-w',
+        '%{http_code}',
+        '--connect-timeout',
+        '10',
         // No --proxy-insecure: relies on CA trust from entrypoint
-        "https://api.github.com/repos/owner/repo/pulls",
+        'https://api.github.com/repos/owner/repo/pulls',
       ],
       { timeout: 30_000 },
     );
@@ -273,18 +305,21 @@ try {
     );
   });
 
-  await test("policy events accumulated during session", () => {
-    assert.ok(events.length > 0, "should have accumulated policy events");
-    const allows = events.filter((e) => e.decision === "allow");
-    const denies = events.filter((e) => e.decision === "deny");
-    assert.ok(allows.length > 0, "should have allow events");
-    assert.ok(denies.length > 0, "should have deny events");
-    assert.ok(events.every((e) => e.tool === "proxy"), "all events should be from proxy tool");
+  await test('policy events accumulated during session', () => {
+    assert.ok(events.length > 0, 'should have accumulated policy events');
+    const allows = events.filter((e) => e.decision === 'allow');
+    const denies = events.filter((e) => e.decision === 'deny');
+    assert.ok(allows.length > 0, 'should have allow events');
+    assert.ok(denies.length > 0, 'should have deny events');
+    assert.ok(
+      events.every((e) => e.tool === 'proxy'),
+      'all events should be from proxy tool',
+    );
   });
 
-  await test("teardown: proxy stops and network is removed cleanly", async () => {
-    assert.ok(proxy, "proxy should have been started");
-    assert.ok(network, "network should have been created");
+  await test('teardown: proxy stops and network is removed cleanly', async () => {
+    assert.ok(proxy, 'proxy should have been started');
+    assert.ok(network, 'network should have been created');
     const networkName = network.networkName;
     await proxy.stop();
     await network.cleanup();
@@ -293,20 +328,24 @@ try {
 
     // Verify network is gone
     try {
-      await execFileAsync("docker", ["network", "inspect", networkName]);
-      assert.fail("network should have been removed");
+      await execFileAsync('docker', ['network', 'inspect', networkName]);
+      assert.fail('network should have been removed');
     } catch (err: any) {
-      const msg = (err.message ?? "") + (err.stderr ?? "");
+      const msg = (err.message ?? '') + (err.stderr ?? '');
       assert.ok(
-        msg.includes("not found") || msg.includes("No such network"),
+        msg.includes('not found') || msg.includes('No such network'),
         `expected network-not-found, got: ${msg}`,
       );
     }
   });
 } finally {
   // Best-effort cleanup in case tests failed before teardown test
-  try { await proxy?.stop(); } catch {}
-  try { await network?.cleanup(); } catch {}
+  try {
+    await proxy?.stop();
+  } catch {}
+  try {
+    await network?.cleanup();
+  } catch {}
   rmSync(tempDir, { recursive: true, force: true });
 }
 

--- a/scripts/test-proxy-github.ts
+++ b/scripts/test-proxy-github.ts
@@ -6,18 +6,18 @@
 //
 // Usage: npx tsx scripts/test-proxy-github.ts
 
-import assert from "node:assert/strict";
-import http from "node:http";
-import https from "node:https";
-import tls from "node:tls";
-import net from "node:net";
-import { mkdtempSync, rmSync } from "node:fs";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
-import { ensureCA, generateHostCert, type BouncerCA } from "../src/main/proxy-tls.js";
-import { startProxy, type ProxyConfig } from "../src/main/proxy.js";
-import { createGitHubMitmHandler } from "../src/main/proxy-github.js";
-import type { GitHubPolicy, PolicyEvent } from "../src/main/types.js";
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import https from 'node:https';
+import tls from 'node:tls';
+import net from 'node:net';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ensureCA, generateHostCert, type BouncerCA } from '../src/main/proxy-tls.js';
+import { startProxy, type ProxyConfig } from '../src/main/proxy.js';
+import { createGitHubMitmHandler } from '../src/main/proxy-github.js';
+import type { GitHubPolicy, PolicyEvent } from '../src/main/types.js';
 
 let passed = 0;
 let failed = 0;
@@ -37,47 +37,47 @@ function test(name: string, fn: () => void | Promise<void>): Promise<void> {
 
 // --- Setup ---
 
-const tempDir = mkdtempSync(join(tmpdir(), "bouncer-proxy-gh-test-"));
+const tempDir = mkdtempSync(join(tmpdir(), 'bouncer-proxy-gh-test-'));
 const ca = await ensureCA(tempDir);
 
 // Mock HTTPS upstream server. Tests use "localhost" as the hostname
 // (instead of api.github.com) so DNS resolves to 127.0.0.1 where the
 // mock is listening. createGitHubMitmHandler accepts a custom hostname.
-const TEST_API_HOST = "api.localhost";
+const TEST_API_HOST = 'api.localhost';
 const upstreamCert = generateHostCert(TEST_API_HOST, ca);
 const mockUpstream = https.createServer(
   { cert: upstreamCert.cert, key: upstreamCert.key },
   (req, res) => {
-    const url = req.url ?? "/";
-    const method = req.method ?? "GET";
+    const url = req.url ?? '/';
+    const method = req.method ?? 'GET';
 
     // POST /repos/owner/repo/pulls → return a PR creation response
-    if (method === "POST" && url === "/repos/owner/repo/pulls") {
-      let body = "";
-      req.on("data", (chunk: Buffer) => (body += chunk.toString()));
-      req.on("end", () => {
-        res.writeHead(201, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ number: 42, html_url: "https://github.com/owner/repo/pull/42" }));
+    if (method === 'POST' && url === '/repos/owner/repo/pulls') {
+      let body = '';
+      req.on('data', (chunk: Buffer) => (body += chunk.toString()));
+      req.on('end', () => {
+        res.writeHead(201, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ number: 42, html_url: 'https://github.com/owner/repo/pull/42' }));
       });
       return;
     }
 
     // GET /repos/owner/repo/pulls → return a list
-    if (method === "GET" && url === "/repos/owner/repo/pulls") {
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify([{ number: 1, title: "Test PR" }]));
+    if (method === 'GET' && url === '/repos/owner/repo/pulls') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify([{ number: 1, title: 'Test PR' }]));
       return;
     }
 
     // GET /repos/owner/repo → repo metadata
-    if (method === "GET" && url === "/repos/owner/repo") {
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ full_name: "owner/repo" }));
+    if (method === 'GET' && url === '/repos/owner/repo') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ full_name: 'owner/repo' }));
       return;
     }
 
     // Fallback
-    res.writeHead(200, { "Content-Type": "application/json" });
+    res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ path: url, method }));
   },
 );
@@ -89,8 +89,8 @@ const upstreamPort = (mockUpstream.address() as net.AddressInfo).port;
 
 function makePolicy(overrides: Partial<GitHubPolicy> = {}): GitHubPolicy {
   return {
-    repo: "owner/repo",
-    allowedPushRefs: ["feature-branch"],
+    repo: 'owner/repo',
+    allowedPushRefs: ['feature-branch'],
     ownedPrNumber: null,
     canCreatePr: true,
     ...overrides,
@@ -98,7 +98,7 @@ function makePolicy(overrides: Partial<GitHubPolicy> = {}): GitHubPolicy {
 }
 
 interface TestContext {
-  proxy: { port: number; stop: () => Promise<void>; };
+  proxy: { port: number; stop: () => Promise<void> };
   events: PolicyEvent[];
   policy: GitHubPolicy;
 }
@@ -107,9 +107,9 @@ async function setupProxy(policyOverrides: Partial<GitHubPolicy> = {}): Promise<
   const events: PolicyEvent[] = [];
   const policy = makePolicy(policyOverrides);
   const config: ProxyConfig = {
-    sessionId: "test",
+    sessionId: 'test',
     port: 0,
-    listenHost: "127.0.0.1",
+    listenHost: '127.0.0.1',
     allowedDomains: [TEST_API_HOST],
     inspectedDomains: [TEST_API_HOST],
     githubPolicy: policy,
@@ -129,19 +129,19 @@ async function requestViaProxy(
   method: string,
   path: string,
   body?: string,
-): Promise<{ status: number; body: string; }> {
+): Promise<{ status: number; body: string }> {
   // 1. CONNECT to the proxy
   const { socket } = await new Promise<{ socket: net.Socket }>((resolve, reject) => {
     const req = http.request({
-      host: "127.0.0.1",
+      host: '127.0.0.1',
       port: proxyPort,
-      method: "CONNECT",
+      method: 'CONNECT',
       // Use the upstream port instead of 443 so the MITM forwardToUpstream
       // hits our mock server
       path: `${TEST_API_HOST}:${upstreamPort}`,
     });
-    req.on("connect", (_res, socket) => resolve({ socket }));
-    req.on("error", reject);
+    req.on('connect', (_res, socket) => resolve({ socket }));
+    req.on('error', reject);
     req.end();
   });
 
@@ -153,8 +153,8 @@ async function requestViaProxy(
   });
 
   await new Promise<void>((resolve, reject) => {
-    tlsSocket.on("secureConnect", resolve);
-    tlsSocket.on("error", reject);
+    tlsSocket.on('secureConnect', resolve);
+    tlsSocket.on('error', reject);
   });
 
   // 3. Make HTTP request over the MITM'd connection
@@ -167,16 +167,16 @@ async function requestViaProxy(
         method,
         headers: {
           host: TEST_API_HOST,
-          ...(body ? { "content-type": "application/json" } : {}),
+          ...(body ? { 'content-type': 'application/json' } : {}),
         },
       },
       (res) => {
-        let data = "";
-        res.on("data", (chunk: Buffer) => (data += chunk.toString()));
-        res.on("end", () => resolve({ status: res.statusCode ?? 0, body: data }));
+        let data = '';
+        res.on('data', (chunk: Buffer) => (data += chunk.toString()));
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, body: data }));
       },
     );
-    req.on("error", reject);
+    req.on('error', reject);
     if (body) req.write(body);
     req.end();
   });
@@ -186,87 +186,87 @@ async function requestViaProxy(
 // Tests
 // =========================================================================
 
-console.log("\nproxy-github tests\n");
+console.log('\nproxy-github tests\n');
 
-await test("GET /repos/owner/repo/pulls → 200 (allowed, forwarded)", async () => {
+await test('GET /repos/owner/repo/pulls → 200 (allowed, forwarded)', async () => {
   const ctx = await setupProxy();
   try {
-    const res = await requestViaProxy(ctx.proxy.port, "GET", "/repos/owner/repo/pulls");
+    const res = await requestViaProxy(ctx.proxy.port, 'GET', '/repos/owner/repo/pulls');
     assert.equal(res.status, 200);
     const data = JSON.parse(res.body);
-    assert.ok(Array.isArray(data), "should return array from mock upstream");
+    assert.ok(Array.isArray(data), 'should return array from mock upstream');
     // Check allow event was logged
-    assert.ok(ctx.events.some((e) => e.decision === "allow" && e.operation.includes("GET")));
+    assert.ok(ctx.events.some((e) => e.decision === 'allow' && e.operation.includes('GET')));
   } finally {
     await ctx.proxy.stop();
   }
 });
 
-await test("PUT /repos/owner/repo/pulls/1/merge → 403 (denied)", async () => {
+await test('PUT /repos/owner/repo/pulls/1/merge → 403 (denied)', async () => {
   const ctx = await setupProxy();
   try {
-    const res = await requestViaProxy(ctx.proxy.port, "PUT", "/repos/owner/repo/pulls/1/merge");
+    const res = await requestViaProxy(ctx.proxy.port, 'PUT', '/repos/owner/repo/pulls/1/merge');
     assert.equal(res.status, 403);
-    assert.ok(res.body.includes("[bouncer:proxy]"), "deny message should have bouncer prefix");
-    assert.ok(res.body.includes("merging"), "should mention merge denial");
-    assert.ok(ctx.events.some((e) => e.decision === "deny"));
+    assert.ok(res.body.includes('[bouncer:proxy]'), 'deny message should have bouncer prefix');
+    assert.ok(res.body.includes('merging'), 'should mention merge denial');
+    assert.ok(ctx.events.some((e) => e.decision === 'deny'));
   } finally {
     await ctx.proxy.stop();
   }
 });
 
-await test("POST /graphql → 403 (not in allowlist)", async () => {
+await test('POST /graphql → 403 (not in allowlist)', async () => {
   const ctx = await setupProxy();
   try {
-    const res = await requestViaProxy(ctx.proxy.port, "POST", "/graphql");
+    const res = await requestViaProxy(ctx.proxy.port, 'POST', '/graphql');
     assert.equal(res.status, 403);
-    assert.ok(res.body.includes("GraphQL"));
+    assert.ok(res.body.includes('GraphQL'));
   } finally {
     await ctx.proxy.stop();
   }
 });
 
-await test("GET /repos/other/repo/pulls → 403 (cross-repo)", async () => {
+await test('GET /repos/other/repo/pulls → 403 (cross-repo)', async () => {
   const ctx = await setupProxy();
   try {
-    const res = await requestViaProxy(ctx.proxy.port, "GET", "/repos/other/repo/pulls");
+    const res = await requestViaProxy(ctx.proxy.port, 'GET', '/repos/other/repo/pulls');
     assert.equal(res.status, 403);
-    assert.ok(res.body.includes("cross-repo"));
+    assert.ok(res.body.includes('cross-repo'));
   } finally {
     await ctx.proxy.stop();
   }
 });
 
-await test("DELETE /repos/owner/repo/anything → 403 (DELETE denied)", async () => {
+await test('DELETE /repos/owner/repo/anything → 403 (DELETE denied)', async () => {
   const ctx = await setupProxy();
   try {
-    const res = await requestViaProxy(ctx.proxy.port, "DELETE", "/repos/owner/repo/pulls/1");
+    const res = await requestViaProxy(ctx.proxy.port, 'DELETE', '/repos/owner/repo/pulls/1');
     assert.equal(res.status, 403);
-    assert.ok(res.body.includes("DELETE"));
+    assert.ok(res.body.includes('DELETE'));
   } finally {
     await ctx.proxy.stop();
   }
 });
 
-await test("GET /unknown/endpoint → 403 (default-deny)", async () => {
+await test('GET /unknown/endpoint → 403 (default-deny)', async () => {
   const ctx = await setupProxy();
   try {
-    const res = await requestViaProxy(ctx.proxy.port, "GET", "/unknown/endpoint");
+    const res = await requestViaProxy(ctx.proxy.port, 'GET', '/unknown/endpoint');
     assert.equal(res.status, 403);
-    assert.ok(res.body.includes("not in allowlist"));
+    assert.ok(res.body.includes('not in allowlist'));
   } finally {
     await ctx.proxy.stop();
   }
 });
 
-await test("POST /repos/owner/repo/pulls → 201 + PR capture", async () => {
+await test('POST /repos/owner/repo/pulls → 201 + PR capture', async () => {
   const ctx = await setupProxy({ canCreatePr: true });
   try {
     const res = await requestViaProxy(
       ctx.proxy.port,
-      "POST",
-      "/repos/owner/repo/pulls",
-      JSON.stringify({ title: "Test PR", head: "feature", base: "main" }),
+      'POST',
+      '/repos/owner/repo/pulls',
+      JSON.stringify({ title: 'Test PR', head: 'feature', base: 'main' }),
     );
     assert.equal(res.status, 201);
     const data = JSON.parse(res.body);
@@ -277,7 +277,7 @@ await test("POST /repos/owner/repo/pulls → 201 + PR capture", async () => {
     assert.equal(ctx.policy.canCreatePr, false);
 
     // Verify capture event was logged
-    assert.ok(ctx.events.some((e) => e.operation.includes("captured PR #42")));
+    assert.ok(ctx.events.some((e) => e.operation.includes('captured PR #42')));
   } finally {
     await ctx.proxy.stop();
   }
@@ -288,21 +288,21 @@ await test("POST /repos/owner/repo/pulls after capture → 403 (can't create sec
   try {
     const res = await requestViaProxy(
       ctx.proxy.port,
-      "POST",
-      "/repos/owner/repo/pulls",
-      JSON.stringify({ title: "Second PR" }),
+      'POST',
+      '/repos/owner/repo/pulls',
+      JSON.stringify({ title: 'Second PR' }),
     );
     assert.equal(res.status, 403);
-    assert.ok(res.body.includes("already created"));
+    assert.ok(res.body.includes('already created'));
   } finally {
     await ctx.proxy.stop();
   }
 });
 
-await test("GET /repos/owner/repo → 200 (repo metadata allowed)", async () => {
+await test('GET /repos/owner/repo → 200 (repo metadata allowed)', async () => {
   const ctx = await setupProxy();
   try {
-    const res = await requestViaProxy(ctx.proxy.port, "GET", "/repos/owner/repo");
+    const res = await requestViaProxy(ctx.proxy.port, 'GET', '/repos/owner/repo');
     assert.equal(res.status, 200);
   } finally {
     await ctx.proxy.stop();
@@ -313,10 +313,10 @@ await test("GET /repos/owner/repo → 200 (repo metadata allowed)", async () => 
 // Phase 6: Git smart HTTP enforcement tests
 // =========================================================================
 
-console.log("\n  git push enforcement:");
+console.log('\n  git push enforcement:');
 
 // Mock HTTPS upstream for git transport (github.com)
-const TEST_GIT_HOST = "localhost";
+const TEST_GIT_HOST = 'localhost';
 const gitUpstreamCert = generateHostCert(TEST_GIT_HOST, ca);
 let lastGitPushBody: Buffer | null = null;
 
@@ -325,11 +325,11 @@ const mockGitUpstream = https.createServer(
   (req, res) => {
     // Capture the body for verification
     const chunks: Buffer[] = [];
-    req.on("data", (chunk: Buffer) => chunks.push(chunk));
-    req.on("end", () => {
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
       lastGitPushBody = Buffer.concat(chunks);
-      res.writeHead(200, { "Content-Type": "application/x-git-receive-pack-result" });
-      res.end("0000"); // minimal valid response
+      res.writeHead(200, { 'Content-Type': 'application/x-git-receive-pack-result' });
+      res.end('0000'); // minimal valid response
     });
   },
 );
@@ -338,19 +338,19 @@ const gitUpstreamPort = (mockGitUpstream.address() as net.AddressInfo).port;
 
 // Helper to build pkt-line data for git push simulation
 function makePktLine(line: string): Buffer {
-  const payload = line + "\n";
-  const len = (payload.length + 4).toString(16).padStart(4, "0");
-  return Buffer.from(len + payload, "ascii");
+  const payload = line + '\n';
+  const len = (payload.length + 4).toString(16).padStart(4, '0');
+  return Buffer.from(len + payload, 'ascii');
 }
-const FLUSH = Buffer.from("0000", "ascii");
+const FLUSH = Buffer.from('0000', 'ascii');
 
 async function setupGitProxy(policyOverrides: Partial<GitHubPolicy> = {}): Promise<TestContext> {
   const events: PolicyEvent[] = [];
   const policy = makePolicy(policyOverrides);
   const config: ProxyConfig = {
-    sessionId: "test",
+    sessionId: 'test',
     port: 0,
-    listenHost: "127.0.0.1",
+    listenHost: '127.0.0.1',
     allowedDomains: [TEST_API_HOST, TEST_GIT_HOST],
     inspectedDomains: [TEST_API_HOST, TEST_GIT_HOST],
     githubPolicy: policy,
@@ -372,13 +372,13 @@ async function gitPushViaProxy(
 ): Promise<{ status: number; body: string }> {
   const { socket } = await new Promise<{ socket: net.Socket }>((resolve, reject) => {
     const req = http.request({
-      host: "127.0.0.1",
+      host: '127.0.0.1',
       port: proxyPort,
-      method: "CONNECT",
+      method: 'CONNECT',
       path: `${TEST_GIT_HOST}:${gitUpstreamPort}`,
     });
-    req.on("connect", (_res, socket) => resolve({ socket }));
-    req.on("error", reject);
+    req.on('connect', (_res, socket) => resolve({ socket }));
+    req.on('error', reject);
     req.end();
   });
 
@@ -389,8 +389,8 @@ async function gitPushViaProxy(
   });
 
   await new Promise<void>((resolve, reject) => {
-    tlsSocket.on("secureConnect", resolve);
-    tlsSocket.on("error", reject);
+    tlsSocket.on('secureConnect', resolve);
+    tlsSocket.on('error', reject);
   });
 
   return new Promise((resolve, reject) => {
@@ -399,52 +399,56 @@ async function gitPushViaProxy(
         createConnection: () => tlsSocket as unknown as net.Socket,
         hostname: TEST_GIT_HOST,
         path: `/${repoPath}.git/git-receive-pack`,
-        method: "POST",
+        method: 'POST',
         headers: {
           host: TEST_GIT_HOST,
-          "content-type": "application/x-git-receive-pack-request",
+          'content-type': 'application/x-git-receive-pack-request',
         },
       },
       (res) => {
-        let data = "";
-        res.on("data", (chunk: Buffer) => (data += chunk.toString()));
-        res.on("end", () => resolve({ status: res.statusCode ?? 0, body: data }));
+        let data = '';
+        res.on('data', (chunk: Buffer) => (data += chunk.toString()));
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, body: data }));
       },
     );
-    req.on("error", reject);
+    req.on('error', reject);
     req.write(pktLineBody);
     req.end();
   });
 }
 
-await test("git push to allowed branch → 200 (forwarded)", async () => {
-  const ctx = await setupGitProxy({ allowedPushRefs: ["feature-branch"] });
+await test('git push to allowed branch → 200 (forwarded)', async () => {
+  const ctx = await setupGitProxy({ allowedPushRefs: ['feature-branch'] });
   try {
     const body = Buffer.concat([
-      makePktLine("0000000000000000000000000000000000000000 abc123abc123abc123abc123abc123abc123abc1 refs/heads/feature-branch"),
+      makePktLine(
+        '0000000000000000000000000000000000000000 abc123abc123abc123abc123abc123abc123abc1 refs/heads/feature-branch',
+      ),
       FLUSH,
     ]);
     lastGitPushBody = null;
-    const res = await gitPushViaProxy(ctx.proxy.port, "owner/repo", body);
+    const res = await gitPushViaProxy(ctx.proxy.port, 'owner/repo', body);
     assert.equal(res.status, 200, `expected 200, got ${res.status}: ${res.body}`);
-    assert.ok(lastGitPushBody !== null, "push body should have been forwarded");
-    assert.ok(ctx.events.some((e) => e.decision === "allow" && e.operation.includes("git push")));
+    assert.ok(lastGitPushBody !== null, 'push body should have been forwarded');
+    assert.ok(ctx.events.some((e) => e.decision === 'allow' && e.operation.includes('git push')));
   } finally {
     await ctx.proxy.stop();
   }
 });
 
-await test("git push to main → 403 (denied)", async () => {
-  const ctx = await setupGitProxy({ allowedPushRefs: ["feature-branch"] });
+await test('git push to main → 403 (denied)', async () => {
+  const ctx = await setupGitProxy({ allowedPushRefs: ['feature-branch'] });
   try {
     const body = Buffer.concat([
-      makePktLine("0000000000000000000000000000000000000000 abc123abc123abc123abc123abc123abc123abc1 refs/heads/main"),
+      makePktLine(
+        '0000000000000000000000000000000000000000 abc123abc123abc123abc123abc123abc123abc1 refs/heads/main',
+      ),
       FLUSH,
     ]);
-    const res = await gitPushViaProxy(ctx.proxy.port, "owner/repo", body);
+    const res = await gitPushViaProxy(ctx.proxy.port, 'owner/repo', body);
     assert.equal(res.status, 403);
-    assert.ok(res.body.includes("refs/heads/main"));
-    assert.ok(ctx.events.some((e) => e.decision === "deny" && e.operation.includes("main")));
+    assert.ok(res.body.includes('refs/heads/main'));
+    assert.ok(ctx.events.some((e) => e.decision === 'deny' && e.operation.includes('main')));
   } finally {
     await ctx.proxy.stop();
   }
@@ -452,49 +456,53 @@ await test("git push to main → 403 (denied)", async () => {
 
 await test("git push --no-verify to main → still 403 (proxy doesn't care about hooks)", async () => {
   // --no-verify only skips local hooks; the proxy enforces at the network level
-  const ctx = await setupGitProxy({ allowedPushRefs: ["feature-branch"] });
+  const ctx = await setupGitProxy({ allowedPushRefs: ['feature-branch'] });
   try {
     const body = Buffer.concat([
-      makePktLine("0000000000000000000000000000000000000000 abc123abc123abc123abc123abc123abc123abc1 refs/heads/main\0 report-status"),
+      makePktLine(
+        '0000000000000000000000000000000000000000 abc123abc123abc123abc123abc123abc123abc1 refs/heads/main\0 report-status',
+      ),
       FLUSH,
     ]);
-    const res = await gitPushViaProxy(ctx.proxy.port, "owner/repo", body);
+    const res = await gitPushViaProxy(ctx.proxy.port, 'owner/repo', body);
     assert.equal(res.status, 403);
-    assert.ok(res.body.includes("refs/heads/main"));
+    assert.ok(res.body.includes('refs/heads/main'));
   } finally {
     await ctx.proxy.stop();
   }
 });
 
-await test("git push to different repo → 403 (cross-repo)", async () => {
+await test('git push to different repo → 403 (cross-repo)', async () => {
   const ctx = await setupGitProxy();
   try {
     const body = Buffer.concat([
-      makePktLine("0000000000000000000000000000000000000000 abc123abc123abc123abc123abc123abc123abc1 refs/heads/feature-branch"),
+      makePktLine(
+        '0000000000000000000000000000000000000000 abc123abc123abc123abc123abc123abc123abc1 refs/heads/feature-branch',
+      ),
       FLUSH,
     ]);
-    const res = await gitPushViaProxy(ctx.proxy.port, "other/repo", body);
+    const res = await gitPushViaProxy(ctx.proxy.port, 'other/repo', body);
     assert.equal(res.status, 403);
-    assert.ok(res.body.includes("cross-repo"));
+    assert.ok(res.body.includes('cross-repo'));
   } finally {
     await ctx.proxy.stop();
   }
 });
 
-await test("git fetch (non-push) → forwarded without policy check", async () => {
+await test('git fetch (non-push) → forwarded without policy check', async () => {
   // GET requests to github.com should pass through (ref advertisement, clone)
   const ctx = await setupGitProxy();
   try {
     // Use the normal requestViaProxy but target the git host
     const { socket } = await new Promise<{ socket: net.Socket }>((resolve, reject) => {
       const req = http.request({
-        host: "127.0.0.1",
+        host: '127.0.0.1',
         port: ctx.proxy.port,
-        method: "CONNECT",
+        method: 'CONNECT',
         path: `${TEST_GIT_HOST}:${gitUpstreamPort}`,
       });
-      req.on("connect", (_res, socket) => resolve({ socket }));
-      req.on("error", reject);
+      req.on('connect', (_res, socket) => resolve({ socket }));
+      req.on('error', reject);
       req.end();
     });
 
@@ -505,8 +513,8 @@ await test("git fetch (non-push) → forwarded without policy check", async () =
     });
 
     await new Promise<void>((resolve, reject) => {
-      tlsSocket.on("secureConnect", resolve);
-      tlsSocket.on("error", reject);
+      tlsSocket.on('secureConnect', resolve);
+      tlsSocket.on('error', reject);
     });
 
     const res = await new Promise<{ status: number }>((resolve, reject) => {
@@ -514,19 +522,19 @@ await test("git fetch (non-push) → forwarded without policy check", async () =
         {
           createConnection: () => tlsSocket as unknown as net.Socket,
           hostname: TEST_GIT_HOST,
-          path: "/owner/repo.git/info/refs?service=git-upload-pack",
-          method: "GET",
+          path: '/owner/repo.git/info/refs?service=git-upload-pack',
+          method: 'GET',
           headers: { host: TEST_GIT_HOST },
         },
         (res) => {
           res.resume(); // drain
-          res.on("end", () => resolve({ status: res.statusCode ?? 0 }));
+          res.on('end', () => resolve({ status: res.statusCode ?? 0 }));
         },
       );
-      req.on("error", reject);
+      req.on('error', reject);
       req.end();
     });
-    assert.equal(res.status, 200, "GET should be forwarded");
+    assert.equal(res.status, 200, 'GET should be forwarded');
   } finally {
     await ctx.proxy.stop();
   }

--- a/scripts/test-proxy-network.ts
+++ b/scripts/test-proxy-network.ts
@@ -6,20 +6,17 @@
 //
 // Usage: npx tsx scripts/test-proxy-network.ts
 
-import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-import { mkdtempSync, rmSync } from "node:fs";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
-import { buildDockerRunArgs, type ContainerConfig } from "../src/main/container.js";
-import { ensureCA, type BouncerCA } from "../src/main/proxy-tls.js";
-import { startProxy, type ProxyConfig } from "../src/main/proxy.js";
-import {
-  createSessionNetwork,
-  cleanupOrphanNetworks,
-} from "../src/main/proxy-network.js";
-import type { PolicyEvent } from "../src/main/types.js";
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { buildDockerRunArgs, type ContainerConfig } from '../src/main/container.js';
+import { ensureCA, type BouncerCA } from '../src/main/proxy-tls.js';
+import { startProxy, type ProxyConfig } from '../src/main/proxy.js';
+import { createSessionNetwork, cleanupOrphanNetworks } from '../src/main/proxy-network.js';
+import type { PolicyEvent } from '../src/main/types.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -43,7 +40,7 @@ function test(name: string, fn: () => void | Promise<void>): Promise<void> {
 
 async function isDockerAvailable(): Promise<boolean> {
   try {
-    await execFileAsync("docker", ["info"], { timeout: 10_000 });
+    await execFileAsync('docker', ['info'], { timeout: 10_000 });
     return true;
   } catch {
     return false;
@@ -54,20 +51,18 @@ async function isDockerAvailable(): Promise<boolean> {
 // Unit tests: buildDockerRunArgs with proxy networkMode
 // =========================================================================
 
-console.log("\nproxy-network tests\n");
-console.log("  buildDockerRunArgs:");
+console.log('\nproxy-network tests\n');
+console.log('  buildDockerRunArgs:');
 
-function makeContainerConfig(
-  overrides: Partial<ContainerConfig> = {},
-): ContainerConfig {
+function makeContainerConfig(overrides: Partial<ContainerConfig> = {}): ContainerConfig {
   return {
-    sessionId: "test-123",
-    image: "test-image:latest",
-    command: ["echo", "hello"],
-    workdir: "/workspace",
+    sessionId: 'test-123',
+    image: 'test-image:latest',
+    command: ['echo', 'hello'],
+    workdir: '/workspace',
     mounts: [],
     env: {},
-    networkMode: "bridge",
+    networkMode: 'bridge',
     ...overrides,
   };
 }
@@ -75,36 +70,32 @@ function makeContainerConfig(
 await test("networkMode 'proxy' with networkName uses the named network", () => {
   const args = buildDockerRunArgs(
     makeContainerConfig({
-      networkMode: "proxy",
-      networkName: "bouncer-net-test-123",
+      networkMode: 'proxy',
+      networkName: 'bouncer-net-test-123',
     }),
   );
-  const netIdx = args.indexOf("--network");
-  assert.ok(netIdx >= 0, "--network flag should be present");
-  assert.equal(args[netIdx + 1], "bouncer-net-test-123");
+  const netIdx = args.indexOf('--network');
+  assert.ok(netIdx >= 0, '--network flag should be present');
+  assert.equal(args[netIdx + 1], 'bouncer-net-test-123');
 });
 
 await test("networkMode 'proxy' without networkName throws", () => {
   assert.throws(
-    () => buildDockerRunArgs(makeContainerConfig({ networkMode: "proxy" })),
+    () => buildDockerRunArgs(makeContainerConfig({ networkMode: 'proxy' })),
     /networkName is required/,
   );
 });
 
 await test("networkMode 'none' still works", () => {
-  const args = buildDockerRunArgs(
-    makeContainerConfig({ networkMode: "none" }),
-  );
-  const netIdx = args.indexOf("--network");
-  assert.equal(args[netIdx + 1], "none");
+  const args = buildDockerRunArgs(makeContainerConfig({ networkMode: 'none' }));
+  const netIdx = args.indexOf('--network');
+  assert.equal(args[netIdx + 1], 'none');
 });
 
 await test("networkMode 'bridge' still works", () => {
-  const args = buildDockerRunArgs(
-    makeContainerConfig({ networkMode: "bridge" }),
-  );
-  const netIdx = args.indexOf("--network");
-  assert.equal(args[netIdx + 1], "bridge");
+  const args = buildDockerRunArgs(makeContainerConfig({ networkMode: 'bridge' }));
+  const netIdx = args.indexOf('--network');
+  assert.equal(args[netIdx + 1], 'bridge');
 });
 
 // =========================================================================
@@ -114,84 +105,80 @@ await test("networkMode 'bridge' still works", () => {
 const dockerAvailable = await isDockerAvailable();
 
 if (!dockerAvailable) {
-  console.log("\n  ⚠ Docker not available — skipping integration tests\n");
+  console.log('\n  ⚠ Docker not available — skipping integration tests\n');
 } else {
-  console.log("\n  Docker integration:");
+  console.log('\n  Docker integration:');
 
-  const tempDir = mkdtempSync(join(tmpdir(), "bouncer-net-test-"));
+  const tempDir = mkdtempSync(join(tmpdir(), 'bouncer-net-test-'));
   let ca: BouncerCA;
 
   try {
     ca = await ensureCA(tempDir);
 
-    await test("createSessionNetwork creates a Docker bridge network", async () => {
-      const net = await createSessionNetwork("integ-test-1");
+    await test('createSessionNetwork creates a Docker bridge network', async () => {
+      const net = await createSessionNetwork('integ-test-1');
       try {
         // Verify the network exists
-        const { stdout: driver } = await execFileAsync("docker", [
-          "network",
-          "inspect",
+        const { stdout: driver } = await execFileAsync('docker', [
+          'network',
+          'inspect',
           net.networkName,
-          "--format",
-          "{{.Driver}}",
+          '--format',
+          '{{.Driver}}',
         ]);
-        assert.equal(driver.trim(), "bridge", "network should use bridge driver");
+        assert.equal(driver.trim(), 'bridge', 'network should use bridge driver');
 
         // Verify labels
-        const { stdout: labels } = await execFileAsync("docker", [
-          "network",
-          "inspect",
+        const { stdout: labels } = await execFileAsync('docker', [
+          'network',
+          'inspect',
           net.networkName,
-          "--format",
+          '--format',
           '{{index .Labels "bouncer.managed"}}',
         ]);
-        assert.equal(labels.trim(), "true", "should have managed label");
+        assert.equal(labels.trim(), 'true', 'should have managed label');
       } finally {
         await net.cleanup();
       }
     });
 
-    await test("createSessionNetwork cleanup is idempotent", async () => {
-      const net = await createSessionNetwork("integ-test-2");
+    await test('createSessionNetwork cleanup is idempotent', async () => {
+      const net = await createSessionNetwork('integ-test-2');
       await net.cleanup();
       // Second cleanup should not throw
       await net.cleanup();
     });
 
-    await test("cleanupOrphanNetworks removes untracked networks", async () => {
-      const net = await createSessionNetwork("orphan-test");
+    await test('cleanupOrphanNetworks removes untracked networks', async () => {
+      const net = await createSessionNetwork('orphan-test');
       // Don't include this session in active set
-      await cleanupOrphanNetworks(new Set(["other-session"]));
+      await cleanupOrphanNetworks(new Set(['other-session']));
 
       // Network should be gone
       try {
-        await execFileAsync("docker", [
-          "network",
-          "inspect",
-          net.networkName,
-        ]);
-        assert.fail("network should have been removed");
+        await execFileAsync('docker', ['network', 'inspect', net.networkName]);
+        assert.fail('network should have been removed');
       } catch (err: any) {
-        const msg = (err.message ?? "") + (err.stderr ?? "");
+        const msg = (err.message ?? '') + (err.stderr ?? '');
         assert.ok(
-          msg.includes("No such network") || msg.includes("not found"),
+          msg.includes('No such network') || msg.includes('not found'),
           `expected network-not-found error, got: ${msg}`,
         );
       }
     });
 
-    await test("cleanupOrphanNetworks preserves active session networks", async () => {
-      const net = await createSessionNetwork("active-test");
+    await test('cleanupOrphanNetworks preserves active session networks', async () => {
+      const net = await createSessionNetwork('active-test');
       try {
-        await cleanupOrphanNetworks(new Set(["active-test"]));
+        await cleanupOrphanNetworks(new Set(['active-test']));
 
         // Network should still exist
-        const { stdout } = await execFileAsync("docker", [
-          "network",
-          "inspect",
+        const { stdout } = await execFileAsync('docker', [
+          'network',
+          'inspect',
           net.networkName,
-          "--format",
-          "{{.Name}}",
+          '--format',
+          '{{.Name}}',
         ]);
         assert.equal(stdout.trim(), net.networkName);
       } finally {
@@ -199,16 +186,16 @@ if (!dockerAvailable) {
       }
     });
 
-    await test("container on session network routes traffic through proxy", async () => {
-      const sessionId = "isolation-test";
+    await test('container on session network routes traffic through proxy', async () => {
+      const sessionId = 'isolation-test';
       const events: PolicyEvent[] = [];
 
       // 1. Start proxy
       const proxy = await startProxy({
         sessionId,
         port: 0,
-        listenHost: "0.0.0.0", // Must be reachable from container
-        allowedDomains: ["api.github.com", "*.github.com"],
+        listenHost: '0.0.0.0', // Must be reachable from container
+        allowedDomains: ['api.github.com', '*.github.com'],
         inspectedDomains: [],
         githubPolicy: null,
         ca,
@@ -225,43 +212,43 @@ if (!dockerAvailable) {
         // Common docker run args for proxy-configured containers.
         // --add-host ensures host.docker.internal resolves on Linux Docker engines.
         const dockerRunBase = [
-          "run",
-          "--rm",
-          "--network",
+          'run',
+          '--rm',
+          '--network',
           net.networkName,
-          "--add-host=host.docker.internal:host-gateway",
-          "-e",
+          '--add-host=host.docker.internal:host-gateway',
+          '-e',
           `HTTP_PROXY=${proxyUrl}`,
-          "-e",
+          '-e',
           `HTTPS_PROXY=${proxyUrl}`,
-          "-e",
+          '-e',
           `http_proxy=${proxyUrl}`,
-          "-e",
+          '-e',
           `https_proxy=${proxyUrl}`,
         ];
 
         // Test: proxy egress works for allowed domain
         const { stdout: allowedResult } = await execFileAsync(
-          "docker",
+          'docker',
           [
             ...dockerRunBase,
-            "alpine/curl",
-            "curl",
-            "-s",
-            "-o",
-            "/dev/null",
-            "-w",
-            "%{http_code}",
-            "--connect-timeout",
-            "10",
-            "--proxy-insecure",
-            "https://api.github.com/",
+            'alpine/curl',
+            'curl',
+            '-s',
+            '-o',
+            '/dev/null',
+            '-w',
+            '%{http_code}',
+            '--connect-timeout',
+            '10',
+            '--proxy-insecure',
+            'https://api.github.com/',
           ],
           { timeout: 30_000 },
         );
         assert.equal(
           allowedResult.trim(),
-          "200",
+          '200',
           `allowed domain should return 200, got ${allowedResult.trim()}`,
         );
 
@@ -270,32 +257,32 @@ if (!dockerAvailable) {
         // and verify from the deny event instead
         try {
           await execFileAsync(
-            "docker",
+            'docker',
             [
               ...dockerRunBase,
-              "alpine/curl",
-              "curl",
-              "-s",
-              "-o",
-              "/dev/null",
-              "-w",
-              "%{http_code}",
-              "--connect-timeout",
-              "10",
-              "https://evil.example.com/",
+              'alpine/curl',
+              'curl',
+              '-s',
+              '-o',
+              '/dev/null',
+              '-w',
+              '%{http_code}',
+              '--connect-timeout',
+              '10',
+              'https://evil.example.com/',
             ],
             { timeout: 30_000 },
           );
           // If curl somehow succeeded, that's a failure
-          assert.fail("curl to denied domain should have failed");
+          assert.fail('curl to denied domain should have failed');
         } catch {
           // Expected — curl returns non-zero on proxy 403
         }
 
         // Verify deny event was logged
         assert.ok(
-          events.some((e) => e.decision === "deny"),
-          "should have logged a deny event for evil.example.com",
+          events.some((e) => e.decision === 'deny'),
+          'should have logged a deny event for evil.example.com',
         );
       } finally {
         await proxy.stop();

--- a/scripts/test-proxy-tls.ts
+++ b/scripts/test-proxy-tls.ts
@@ -5,19 +5,19 @@
 //
 // Usage: npx tsx scripts/test-proxy-tls.ts
 
-import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
-import tls from "node:tls";
-import https from "node:https";
-import { X509Certificate } from "node:crypto";
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import tls from 'node:tls';
+import https from 'node:https';
+import { X509Certificate } from 'node:crypto';
 import {
   ensureCA,
   generateHostCert,
   clearHostCertCache,
   type BouncerCA,
-} from "../src/main/proxy-tls.js";
+} from '../src/main/proxy-tls.js';
 
 let passed = 0;
 let failed = 0;
@@ -40,127 +40,127 @@ function test(name: string, fn: () => void | Promise<void>): Promise<void> {
 let tempDir: string;
 
 function freshTempDir(): string {
-  return mkdtempSync(join(tmpdir(), "bouncer-tls-test-"));
+  return mkdtempSync(join(tmpdir(), 'bouncer-tls-test-'));
 }
 
 // --- Tests ---
 
-console.log("\nproxy-tls tests\n");
+console.log('\nproxy-tls tests\n');
 
 // Generate a CA once for reuse across tests
 tempDir = freshTempDir();
 let ca: BouncerCA;
 
-await test("ensureCA() generates a valid CA certificate", async () => {
+await test('ensureCA() generates a valid CA certificate', async () => {
   ca = await ensureCA(tempDir);
 
-  assert.ok(ca.cert.includes("BEGIN CERTIFICATE"), "cert is PEM-encoded");
-  assert.ok(ca.key.includes("BEGIN RSA PRIVATE KEY"), "key is PEM-encoded");
-  assert.equal(ca.certPath, join(tempDir, "bouncer-ca.crt"));
+  assert.ok(ca.cert.includes('BEGIN CERTIFICATE'), 'cert is PEM-encoded');
+  assert.ok(ca.key.includes('BEGIN RSA PRIVATE KEY'), 'key is PEM-encoded');
+  assert.equal(ca.certPath, join(tempDir, 'bouncer-ca.crt'));
 
   // Parse and verify it's a CA
   const x509 = new X509Certificate(ca.cert);
-  assert.ok(x509.ca, "certificate should have CA flag set");
-  assert.ok(x509.subject.includes("CN=Bouncer Proxy CA"), "subject has correct CN");
-  assert.ok(x509.issuer.includes("CN=Bouncer Proxy CA"), "self-signed: issuer matches subject");
+  assert.ok(x509.ca, 'certificate should have CA flag set');
+  assert.ok(x509.subject.includes('CN=Bouncer Proxy CA'), 'subject has correct CN');
+  assert.ok(x509.issuer.includes('CN=Bouncer Proxy CA'), 'self-signed: issuer matches subject');
 });
 
-await test("ensureCA() persists files to disk", async () => {
-  assert.ok(existsSync(join(tempDir, "bouncer-ca.crt")), "cert file exists");
-  assert.ok(existsSync(join(tempDir, "bouncer-ca.key")), "key file exists");
+await test('ensureCA() persists files to disk', async () => {
+  assert.ok(existsSync(join(tempDir, 'bouncer-ca.crt')), 'cert file exists');
+  assert.ok(existsSync(join(tempDir, 'bouncer-ca.key')), 'key file exists');
 });
 
-await test("ensureCA() is idempotent — loads from disk on second call", async () => {
+await test('ensureCA() is idempotent — loads from disk on second call', async () => {
   const ca2 = await ensureCA(tempDir);
-  assert.equal(ca2.cert, ca.cert, "same cert on second call");
-  assert.equal(ca2.key, ca.key, "same key on second call");
+  assert.equal(ca2.cert, ca.cert, 'same cert on second call');
+  assert.equal(ca2.key, ca.key, 'same key on second call');
 });
 
-await test("generateHostCert() returns a cert signed by the CA", () => {
+await test('generateHostCert() returns a cert signed by the CA', () => {
   clearHostCertCache();
-  const host = generateHostCert("api.github.com", ca);
+  const host = generateHostCert('api.github.com', ca);
 
-  assert.ok(host.cert.includes("BEGIN CERTIFICATE"), "host cert is PEM-encoded");
-  assert.ok(host.key.includes("BEGIN RSA PRIVATE KEY"), "host key is PEM-encoded");
+  assert.ok(host.cert.includes('BEGIN CERTIFICATE'), 'host cert is PEM-encoded');
+  assert.ok(host.key.includes('BEGIN RSA PRIVATE KEY'), 'host key is PEM-encoded');
 
   const x509 = new X509Certificate(host.cert);
-  assert.ok(x509.subject.includes("CN=api.github.com"), "correct subject CN");
-  assert.ok(x509.issuer.includes("CN=Bouncer Proxy CA"), "issuer is our CA");
-  assert.ok(!x509.ca, "host cert is not a CA");
+  assert.ok(x509.subject.includes('CN=api.github.com'), 'correct subject CN');
+  assert.ok(x509.issuer.includes('CN=Bouncer Proxy CA'), 'issuer is our CA');
+  assert.ok(!x509.ca, 'host cert is not a CA');
 
   // Verify SAN
   const san = x509.subjectAltName;
-  assert.ok(san?.includes("DNS:api.github.com"), `SAN should include DNS:api.github.com, got: ${san}`);
+  assert.ok(
+    san?.includes('DNS:api.github.com'),
+    `SAN should include DNS:api.github.com, got: ${san}`,
+  );
 });
 
-await test("generateHostCert() caches — same hostname returns cached cert", () => {
+await test('generateHostCert() caches — same hostname returns cached cert', () => {
   clearHostCertCache();
-  const first = generateHostCert("example.com", ca);
-  const second = generateHostCert("example.com", ca);
-  assert.equal(first.cert, second.cert, "cached cert returned");
-  assert.equal(first.key, second.key, "cached key returned");
+  const first = generateHostCert('example.com', ca);
+  const second = generateHostCert('example.com', ca);
+  assert.equal(first.cert, second.cert, 'cached cert returned');
+  assert.equal(first.key, second.key, 'cached key returned');
 });
 
-await test("generateHostCert() — different hostnames produce different certs", () => {
+await test('generateHostCert() — different hostnames produce different certs', () => {
   clearHostCertCache();
-  const a = generateHostCert("a.example.com", ca);
-  const b = generateHostCert("b.example.com", ca);
-  assert.notEqual(a.cert, b.cert, "different hostnames get different certs");
+  const a = generateHostCert('a.example.com', ca);
+  const b = generateHostCert('b.example.com', ca);
+  assert.notEqual(a.cert, b.cert, 'different hostnames get different certs');
 });
 
-await test("TLS chain verification: tls.connect trusts host cert when CA is provided", async () => {
+await test('TLS chain verification: tls.connect trusts host cert when CA is provided', async () => {
   clearHostCertCache();
-  const hostname = "test.bouncer.local";
+  const hostname = 'test.bouncer.local';
   const hostCert = generateHostCert(hostname, ca);
 
   // Start a minimal HTTPS server using the host cert
-  const server = https.createServer(
-    { cert: hostCert.cert, key: hostCert.key },
-    (_req, res) => {
-      res.writeHead(200);
-      res.end("ok");
-    },
-  );
+  const server = https.createServer({ cert: hostCert.cert, key: hostCert.key }, (_req, res) => {
+    res.writeHead(200);
+    res.end('ok');
+  });
 
-  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
   const port = (server.address() as { port: number }).port;
 
   try {
     // Connect with our CA as trusted — should succeed
     await new Promise<void>((resolve, reject) => {
       const socket = tls.connect(
-        { host: "127.0.0.1", port, ca: ca.cert, servername: hostname },
+        { host: '127.0.0.1', port, ca: ca.cert, servername: hostname },
         () => {
-          assert.ok(socket.authorized, "connection should be authorized");
+          assert.ok(socket.authorized, 'connection should be authorized');
           socket.end();
           resolve();
         },
       );
-      socket.on("error", reject);
+      socket.on('error', reject);
     });
 
     // Connect WITHOUT our CA — should fail verification
     await new Promise<void>((resolve, reject) => {
       const socket = tls.connect(
-        { host: "127.0.0.1", port, servername: hostname, rejectUnauthorized: true },
+        { host: '127.0.0.1', port, servername: hostname, rejectUnauthorized: true },
         () => {
           // If we get here, it unexpectedly succeeded
           socket.end();
-          reject(new Error("Expected TLS verification to fail without CA"));
+          reject(new Error('Expected TLS verification to fail without CA'));
         },
       );
-      socket.on("error", (err: NodeJS.ErrnoException) => {
+      socket.on('error', (err: NodeJS.ErrnoException) => {
         const expectedCodes = [
-          "SELF_SIGNED_CERT_IN_CHAIN",
-          "DEPTH_ZERO_SELF_SIGNED_CERT",
-          "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
-          "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+          'SELF_SIGNED_CERT_IN_CHAIN',
+          'DEPTH_ZERO_SELF_SIGNED_CERT',
+          'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+          'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
         ];
         assert.ok(
           (err.code && expectedCodes.includes(err.code)) ||
             /self[- ]signed/i.test(err.message) ||
             /unable to verify/i.test(err.message),
-          `expected cert verification error, got code=${err.code ?? "N/A"} message=${err.message}`,
+          `expected cert verification error, got code=${err.code ?? 'N/A'} message=${err.message}`,
         );
         resolve();
       });
@@ -170,11 +170,11 @@ await test("TLS chain verification: tls.connect trusts host cert when CA is prov
   }
 });
 
-await test("ensureCA() in a fresh directory generates a new CA", async () => {
+await test('ensureCA() in a fresh directory generates a new CA', async () => {
   const dir2 = freshTempDir();
   try {
     const ca2 = await ensureCA(dir2);
-    assert.notEqual(ca2.cert, ca.cert, "different directory = different CA");
+    assert.notEqual(ca2.cert, ca.cert, 'different directory = different CA');
   } finally {
     rmSync(dir2, { recursive: true, force: true });
   }

--- a/scripts/test-proxy.ts
+++ b/scripts/test-proxy.ts
@@ -5,23 +5,23 @@
 //
 // Usage: npx tsx scripts/test-proxy.ts
 
-import assert from "node:assert/strict";
-import http from "node:http";
-import https from "node:https";
-import tls from "node:tls";
-import net from "node:net";
-import { mkdtempSync, rmSync } from "node:fs";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
-import { X509Certificate } from "node:crypto";
-import { ensureCA, type BouncerCA } from "../src/main/proxy-tls.js";
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import https from 'node:https';
+import tls from 'node:tls';
+import net from 'node:net';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { X509Certificate } from 'node:crypto';
+import { ensureCA, type BouncerCA } from '../src/main/proxy-tls.js';
 import {
   domainMatches,
   startProxy,
   type ProxyConfig,
   type ProxyHandle,
-} from "../src/main/proxy.js";
-import type { PolicyEvent } from "../src/main/types.js";
+} from '../src/main/proxy.js';
+import type { PolicyEvent } from '../src/main/types.js';
 
 let passed = 0;
 let failed = 0;
@@ -41,16 +41,16 @@ function test(name: string, fn: () => void | Promise<void>): Promise<void> {
 
 // --- Helpers ---
 
-const tempDir = mkdtempSync(join(tmpdir(), "bouncer-proxy-test-"));
+const tempDir = mkdtempSync(join(tmpdir(), 'bouncer-proxy-test-'));
 let ca: BouncerCA;
 
 function makeConfig(overrides: Partial<ProxyConfig> = {}): ProxyConfig {
   const events: PolicyEvent[] = [];
   return {
-    sessionId: "test-session",
+    sessionId: 'test-session',
     port: 0,
-    listenHost: "127.0.0.1",
-    allowedDomains: ["*"],
+    listenHost: '127.0.0.1',
+    allowedDomains: ['*'],
     inspectedDomains: [],
     githubPolicy: null,
     ca,
@@ -70,21 +70,19 @@ function httpViaProxy(
     const url = new URL(targetUrl);
     const req = http.request(
       {
-        host: "127.0.0.1",
+        host: '127.0.0.1',
         port: proxyPort,
         path: targetUrl,
-        method: "GET",
+        method: 'GET',
         headers: { host: url.host },
       },
       (res) => {
-        let body = "";
-        res.on("data", (chunk: Buffer) => (body += chunk.toString()));
-        res.on("end", () =>
-          resolve({ status: res.statusCode ?? 0, body }),
-        );
+        let body = '';
+        res.on('data', (chunk: Buffer) => (body += chunk.toString()));
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, body }));
       },
     );
-    req.on("error", reject);
+    req.on('error', reject);
     req.end();
   });
 }
@@ -97,15 +95,15 @@ function connectViaProxy(
 ): Promise<{ status: number; socket: net.Socket }> {
   return new Promise((resolve, reject) => {
     const req = http.request({
-      host: "127.0.0.1",
+      host: '127.0.0.1',
       port: proxyPort,
-      method: "CONNECT",
+      method: 'CONNECT',
       path: `${host}:${port}`,
     });
-    req.on("connect", (res, socket) => {
+    req.on('connect', (res, socket) => {
       resolve({ status: res.statusCode ?? 0, socket });
     });
-    req.on("error", reject);
+    req.on('error', reject);
     req.end();
   });
 }
@@ -114,100 +112,94 @@ function connectViaProxy(
 // Tests
 // =========================================================================
 
-console.log("\nproxy tests\n");
+console.log('\nproxy tests\n');
 
 // --- Setup ---
 ca = await ensureCA(tempDir);
 
 // --- domainMatches unit tests ---
 
-console.log("  domainMatches:");
+console.log('  domainMatches:');
 
-await test("* matches any hostname", () => {
-  assert.ok(domainMatches("anything.example.com", "*"));
-  assert.ok(domainMatches("localhost", "*"));
+await test('* matches any hostname', () => {
+  assert.ok(domainMatches('anything.example.com', '*'));
+  assert.ok(domainMatches('localhost', '*'));
 });
 
-await test("exact match", () => {
-  assert.ok(domainMatches("example.com", "example.com"));
-  assert.ok(!domainMatches("other.com", "example.com"));
+await test('exact match', () => {
+  assert.ok(domainMatches('example.com', 'example.com'));
+  assert.ok(!domainMatches('other.com', 'example.com'));
 });
 
-await test("wildcard *.example.com matches subdomains", () => {
-  assert.ok(domainMatches("foo.example.com", "*.example.com"));
-  assert.ok(domainMatches("bar.baz.example.com", "*.example.com"));
+await test('wildcard *.example.com matches subdomains', () => {
+  assert.ok(domainMatches('foo.example.com', '*.example.com'));
+  assert.ok(domainMatches('bar.baz.example.com', '*.example.com'));
 });
 
-await test("wildcard *.example.com does NOT match bare domain", () => {
-  assert.ok(!domainMatches("example.com", "*.example.com"));
+await test('wildcard *.example.com does NOT match bare domain', () => {
+  assert.ok(!domainMatches('example.com', '*.example.com'));
 });
 
-await test("no match returns false", () => {
-  assert.ok(!domainMatches("evil.com", "example.com"));
-  assert.ok(!domainMatches("evil.com", "*.example.com"));
+await test('no match returns false', () => {
+  assert.ok(!domainMatches('evil.com', 'example.com'));
+  assert.ok(!domainMatches('evil.com', '*.example.com'));
 });
 
-await test("matching is case-insensitive", () => {
-  assert.ok(domainMatches("Example.COM", "example.com"));
-  assert.ok(domainMatches("FOO.example.com", "*.Example.COM"));
+await test('matching is case-insensitive', () => {
+  assert.ok(domainMatches('Example.COM', 'example.com'));
+  assert.ok(domainMatches('FOO.example.com', '*.Example.COM'));
 });
 
-await test("trailing dots are ignored", () => {
-  assert.ok(domainMatches("example.com.", "example.com"));
-  assert.ok(domainMatches("example.com", "example.com."));
+await test('trailing dots are ignored', () => {
+  assert.ok(domainMatches('example.com.', 'example.com'));
+  assert.ok(domainMatches('example.com', 'example.com.'));
 });
 
 // --- Proxy: plain HTTP domain filtering ---
 
-console.log("\n  plain HTTP filtering:");
+console.log('\n  plain HTTP filtering:');
 
 // Start a simple upstream HTTP server for testing
 const upstream = http.createServer((_req, res) => {
   res.writeHead(200);
-  res.end("upstream ok");
+  res.end('upstream ok');
 });
-await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", resolve));
+await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
 const upstreamPort = (upstream.address() as net.AddressInfo).port;
 
-await test("allowed domain: plain HTTP request is forwarded", async () => {
+await test('allowed domain: plain HTTP request is forwarded', async () => {
   const events: PolicyEvent[] = [];
   const proxy = await startProxy(
     makeConfig({
-      allowedDomains: ["127.0.0.1"],
+      allowedDomains: ['127.0.0.1'],
       onPolicyEvent: (e) => events.push(e),
     }),
   );
   try {
-    const res = await httpViaProxy(
-      proxy.port,
-      `http://127.0.0.1:${upstreamPort}/test`,
-    );
+    const res = await httpViaProxy(proxy.port, `http://127.0.0.1:${upstreamPort}/test`);
     assert.equal(res.status, 200);
-    assert.equal(res.body, "upstream ok");
-    assert.equal(events.length, 0, "no deny events for allowed domain");
+    assert.equal(res.body, 'upstream ok');
+    assert.equal(events.length, 0, 'no deny events for allowed domain');
   } finally {
     await proxy.stop();
   }
 });
 
-await test("denied domain: plain HTTP request gets 403", async () => {
+await test('denied domain: plain HTTP request gets 403', async () => {
   const events: PolicyEvent[] = [];
   const proxy = await startProxy(
     makeConfig({
-      allowedDomains: ["other.com"],
+      allowedDomains: ['other.com'],
       onPolicyEvent: (e) => events.push(e),
     }),
   );
   try {
-    const res = await httpViaProxy(
-      proxy.port,
-      `http://127.0.0.1:${upstreamPort}/test`,
-    );
+    const res = await httpViaProxy(proxy.port, `http://127.0.0.1:${upstreamPort}/test`);
     assert.equal(res.status, 403);
-    assert.ok(res.body.includes("not in the allowed domain list"));
+    assert.ok(res.body.includes('not in the allowed domain list'));
     assert.equal(events.length, 1);
-    assert.equal(events[0].decision, "deny");
-    assert.equal(events[0].tool, "proxy");
+    assert.equal(events[0].decision, 'deny');
+    assert.equal(events[0].tool, 'proxy');
   } finally {
     await proxy.stop();
   }
@@ -215,64 +207,54 @@ await test("denied domain: plain HTTP request gets 403", async () => {
 
 // --- Proxy: CONNECT domain filtering ---
 
-console.log("\n  CONNECT filtering:");
+console.log('\n  CONNECT filtering:');
 
-await test("CONNECT to allowed non-inspected domain: tunnel established", async () => {
+await test('CONNECT to allowed non-inspected domain: tunnel established', async () => {
   // Start a TCP server that echoes back what it receives.
   // Using echo (wait for data) instead of immediate write avoids a race
   // where the server sends before the proxy tunnel is fully piped.
   const echo = net.createServer((socket) => {
-    socket.on("data", (chunk) => {
+    socket.on('data', (chunk) => {
       socket.write(`echo: ${chunk.toString()}`);
       socket.end();
     });
   });
-  await new Promise<void>((resolve) => echo.listen(0, "127.0.0.1", resolve));
+  await new Promise<void>((resolve) => echo.listen(0, '127.0.0.1', resolve));
   const echoPort = (echo.address() as net.AddressInfo).port;
 
-  const proxy = await startProxy(
-    makeConfig({ allowedDomains: ["127.0.0.1"] }),
-  );
+  const proxy = await startProxy(makeConfig({ allowedDomains: ['127.0.0.1'] }));
   try {
-    const { status, socket } = await connectViaProxy(
-      proxy.port,
-      "127.0.0.1",
-      echoPort,
-    );
+    const { status, socket } = await connectViaProxy(proxy.port, '127.0.0.1', echoPort);
     assert.equal(status, 200);
 
     // Send data through the tunnel and wait for the echo
-    socket.write("ping");
+    socket.write('ping');
     const data = await new Promise<string>((resolve) => {
-      let buf = "";
-      socket.on("data", (chunk: Buffer) => (buf += chunk.toString()));
-      socket.on("end", () => resolve(buf));
+      let buf = '';
+      socket.on('data', (chunk: Buffer) => (buf += chunk.toString()));
+      socket.on('end', () => resolve(buf));
     });
-    assert.equal(data, "echo: ping");
+    assert.equal(data, 'echo: ping');
   } finally {
     await proxy.stop();
     echo.close();
   }
 });
 
-await test("CONNECT to denied domain: gets 403", async () => {
+await test('CONNECT to denied domain: gets 403', async () => {
   const events: PolicyEvent[] = [];
   const proxy = await startProxy(
     makeConfig({
-      allowedDomains: ["allowed.com"],
+      allowedDomains: ['allowed.com'],
       onPolicyEvent: (e) => events.push(e),
     }),
   );
   try {
-    const { status, socket } = await connectViaProxy(
-      proxy.port,
-      "denied.example.com",
-      443,
-    );
+    const { status, socket } = await connectViaProxy(proxy.port, 'denied.example.com', 443);
     assert.equal(status, 403);
     socket.destroy();
     assert.equal(events.length, 1);
-    assert.equal(events[0].decision, "deny");
+    assert.equal(events[0].decision, 'deny');
   } finally {
     await proxy.stop();
   }
@@ -280,83 +262,69 @@ await test("CONNECT to denied domain: gets 403", async () => {
 
 // --- Proxy: TLS MITM ---
 
-console.log("\n  TLS MITM:");
+console.log('\n  TLS MITM:');
 
 await test("MITM'd domain: client sees cert signed by Bouncer CA", async () => {
   // Start a real HTTPS upstream server
-  const upstreamCert = (await import("../src/main/proxy-tls.js")).generateHostCert(
-    "localhost",
-    ca,
-  );
+  const upstreamCert = (await import('../src/main/proxy-tls.js')).generateHostCert('localhost', ca);
   const httpsUpstream = https.createServer(
     { cert: upstreamCert.cert, key: upstreamCert.key },
     (_req, res) => {
       res.writeHead(200);
-      res.end("mitm upstream ok");
+      res.end('mitm upstream ok');
     },
   );
-  await new Promise<void>((resolve) =>
-    httpsUpstream.listen(0, "127.0.0.1", resolve),
-  );
+  await new Promise<void>((resolve) => httpsUpstream.listen(0, '127.0.0.1', resolve));
   const httpsPort = (httpsUpstream.address() as net.AddressInfo).port;
 
   const proxy = await startProxy(
     makeConfig({
-      allowedDomains: ["localhost"],
-      inspectedDomains: ["localhost"],
+      allowedDomains: ['localhost'],
+      inspectedDomains: ['localhost'],
     }),
   );
 
   try {
     // CONNECT through the proxy
-    const { status, socket } = await connectViaProxy(
-      proxy.port,
-      "localhost",
-      httpsPort,
-    );
+    const { status, socket } = await connectViaProxy(proxy.port, 'localhost', httpsPort);
     assert.equal(status, 200);
 
     // Upgrade to TLS and verify the cert chain
-    const tlsSocket = tls.connect(
-      {
-        socket,
-        ca: ca.cert,
-        servername: "localhost",
-      },
-    );
+    const tlsSocket = tls.connect({
+      socket,
+      ca: ca.cert,
+      servername: 'localhost',
+    });
 
     await new Promise<void>((resolve, reject) => {
-      tlsSocket.on("secureConnect", () => {
-        assert.ok(tlsSocket.authorized, "TLS connection should be authorized");
+      tlsSocket.on('secureConnect', () => {
+        assert.ok(tlsSocket.authorized, 'TLS connection should be authorized');
 
         // Verify cert is signed by our CA
         const peerCert = tlsSocket.getPeerX509Certificate();
-        assert.ok(peerCert, "should have peer certificate");
+        assert.ok(peerCert, 'should have peer certificate');
         assert.ok(
-          peerCert.issuer.includes("Bouncer Proxy CA"),
-          "cert should be issued by Bouncer CA",
+          peerCert.issuer.includes('Bouncer Proxy CA'),
+          'cert should be issued by Bouncer CA',
         );
-        assert.ok(
-          peerCert.subject.includes("CN=localhost"),
-          "cert CN should match hostname",
-        );
+        assert.ok(peerCert.subject.includes('CN=localhost'), 'cert CN should match hostname');
 
         // Make an HTTP request through the MITM'd connection
         const req = http.request(
           {
             createConnection: () => tlsSocket as unknown as net.Socket,
-            hostname: "localhost",
-            path: "/test",
-            method: "GET",
-            headers: { host: "localhost" },
+            hostname: 'localhost',
+            path: '/test',
+            method: 'GET',
+            headers: { host: 'localhost' },
           },
           (res) => {
-            let body = "";
-            res.on("data", (chunk: Buffer) => (body += chunk.toString()));
-            res.on("end", () => {
+            let body = '';
+            res.on('data', (chunk: Buffer) => (body += chunk.toString()));
+            res.on('end', () => {
               try {
                 assert.equal(res.statusCode, 200);
-                assert.equal(body, "mitm upstream ok");
+                assert.equal(body, 'mitm upstream ok');
                 resolve();
               } catch (e) {
                 reject(e);
@@ -364,10 +332,10 @@ await test("MITM'd domain: client sees cert signed by Bouncer CA", async () => {
             });
           },
         );
-        req.on("error", reject);
+        req.on('error', reject);
         req.end();
       });
-      tlsSocket.on("error", reject);
+      tlsSocket.on('error', reject);
     });
   } finally {
     await proxy.stop();
@@ -377,68 +345,62 @@ await test("MITM'd domain: client sees cert signed by Bouncer CA", async () => {
 
 await test("MITM'd domain with onMitmRequest handler: handler is called", async () => {
   // Simple upstream HTTPS server
-  const upstreamCert = (await import("../src/main/proxy-tls.js")).generateHostCert(
-    "handler-test.local",
+  const upstreamCert = (await import('../src/main/proxy-tls.js')).generateHostCert(
+    'handler-test.local',
     ca,
   );
   const httpsUpstream = https.createServer(
     { cert: upstreamCert.cert, key: upstreamCert.key },
     (_req, res) => {
       res.writeHead(200);
-      res.end("should not see this");
+      res.end('should not see this');
     },
   );
-  await new Promise<void>((resolve) =>
-    httpsUpstream.listen(0, "127.0.0.1", resolve),
-  );
+  await new Promise<void>((resolve) => httpsUpstream.listen(0, '127.0.0.1', resolve));
   const httpsPort = (httpsUpstream.address() as net.AddressInfo).port;
 
   let handlerCalled = false;
   const proxy = await startProxy(
     makeConfig({
-      allowedDomains: ["handler-test.local"],
-      inspectedDomains: ["handler-test.local"],
+      allowedDomains: ['handler-test.local'],
+      inspectedDomains: ['handler-test.local'],
       onMitmRequest: (req, res, hostname, _upstream) => {
         handlerCalled = true;
-        assert.equal(hostname, "handler-test.local");
+        assert.equal(hostname, 'handler-test.local');
         // Return a custom response instead of forwarding
         res.writeHead(403);
-        res.end("blocked by handler");
+        res.end('blocked by handler');
       },
     }),
   );
 
   try {
-    const { socket } = await connectViaProxy(
-      proxy.port,
-      "handler-test.local",
-      httpsPort,
-    );
+    const { socket } = await connectViaProxy(proxy.port, 'handler-test.local', httpsPort);
 
     const tlsSocket = tls.connect({
       socket,
       ca: ca.cert,
-      servername: "handler-test.local",
+      servername: 'handler-test.local',
     });
 
     await new Promise<void>((resolve, reject) => {
-      tlsSocket.on("secureConnect", () => {
+      tlsSocket.on('secureConnect', () => {
         const req = http.request(
           {
             createConnection: () => tlsSocket as unknown as net.Socket,
-            hostname: "handler-test.local",
-            path: "/test",
-            method: "GET",
-            headers: { host: "handler-test.local" },
+            hostname: 'handler-test.local',
+            path: '/test',
+            method: 'GET',
+            headers: { host: 'handler-test.local' },
           },
           (res) => {
-            let body = "";
-            res.on("data", (chunk: Buffer) => (body += chunk.toString()));
-            res.on("end", () => {
+            let body = '';
+            res.on('data', (chunk: Buffer) => (body += chunk.toString()));
+            res.on('end', () => {
               try {
                 assert.equal(res.statusCode, 403);
-                assert.equal(body, "blocked by handler");
-                assert.ok(handlerCalled, "handler should have been called");
+                assert.equal(body, 'blocked by handler');
+                assert.ok(handlerCalled, 'handler should have been called');
                 resolve();
               } catch (e) {
                 reject(e);
@@ -446,10 +408,10 @@ await test("MITM'd domain with onMitmRequest handler: handler is called", async 
             });
           },
         );
-        req.on("error", reject);
+        req.on('error', reject);
         req.end();
       });
-      tlsSocket.on("error", reject);
+      tlsSocket.on('error', reject);
     });
   } finally {
     await proxy.stop();
@@ -457,14 +419,12 @@ await test("MITM'd domain with onMitmRequest handler: handler is called", async 
   }
 });
 
-await test("updatePolicy() updates the config", async () => {
-  const proxy = await startProxy(
-    makeConfig({ githubPolicy: null }),
-  );
+await test('updatePolicy() updates the config', async () => {
+  const proxy = await startProxy(makeConfig({ githubPolicy: null }));
   try {
     const newPolicy = {
-      repo: "owner/repo",
-      allowedPushRefs: ["feature"],
+      repo: 'owner/repo',
+      allowedPushRefs: ['feature'],
       ownedPrNumber: 42,
       canCreatePr: false,
     };
@@ -476,35 +436,33 @@ await test("updatePolicy() updates the config", async () => {
   }
 });
 
-await test("stop() cleans up all connections", async () => {
+await test('stop() cleans up all connections', async () => {
   // Start a TCP server that holds connections open
   const holder = net.createServer((socket) => {
     // Just hold the connection open
-    socket.on("error", () => {});
+    socket.on('error', () => {});
   });
-  await new Promise<void>((resolve) => holder.listen(0, "127.0.0.1", resolve));
+  await new Promise<void>((resolve) => holder.listen(0, '127.0.0.1', resolve));
   const holderPort = (holder.address() as net.AddressInfo).port;
 
-  const proxy = await startProxy(
-    makeConfig({ allowedDomains: ["127.0.0.1"] }),
-  );
+  const proxy = await startProxy(makeConfig({ allowedDomains: ['127.0.0.1'] }));
 
   // Open a CONNECT tunnel to the holder
-  const { socket } = await connectViaProxy(proxy.port, "127.0.0.1", holderPort);
+  const { socket } = await connectViaProxy(proxy.port, '127.0.0.1', holderPort);
 
   await proxy.stop();
 
   // Wait for socket close to propagate
   if (!socket.destroyed) {
     await new Promise<void>((resolve) => {
-      socket.on("close", resolve);
+      socket.on('close', resolve);
       // Timeout safety — if it doesn't close in 500ms, proceed
       setTimeout(resolve, 500);
     });
   }
   assert.ok(
     socket.destroyed || socket.readableEnded || !socket.writable,
-    "socket should be closed after stop()",
+    'socket should be closed after stop()',
   );
   holder.close();
 });

--- a/scripts/test-replay-agent.ts
+++ b/scripts/test-replay-agent.ts
@@ -7,25 +7,25 @@
  *
  * Usage: npx tsx scripts/test-replay-agent.ts
  */
-import { spawn } from "node:child_process";
-import { createRequire } from "node:module";
-import { writeFileSync, mkdtempSync } from "node:fs";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
-import { Writable, Readable } from "node:stream";
-import * as acp from "@agentclientprotocol/sdk";
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { writeFileSync, mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { Writable, Readable } from 'node:stream';
+import * as acp from '@agentclientprotocol/sdk';
 
 const require = createRequire(import.meta.url);
-const tsxBin = require.resolve("tsx/cli");
+const tsxBin = require.resolve('tsx/cli');
 
 const cwd = process.cwd();
 
 // Create a unique temp directory for test files
-const testDir = mkdtempSync(join(tmpdir(), "replay-test-"));
-writeFileSync(join(testDir, "test.txt"), "hello world\n");
+const testDir = mkdtempSync(join(tmpdir(), 'replay-test-'));
+writeFileSync(join(testDir, 'test.txt'), 'hello world\n');
 
-const agent = spawn(process.execPath, [tsxBin, "src/agents/replay-agent.ts"], {
-  stdio: ["pipe", "pipe", "inherit"],
+const agent = spawn(process.execPath, [tsxBin, 'src/agents/replay-agent.ts'], {
+  stdio: ['pipe', 'pipe', 'inherit'],
   env: { ...process.env, REPLAY_WORKTREE_PATH: testDir },
 });
 
@@ -41,72 +41,108 @@ interface ToolCallResult {
   replayOutcome?: string;
 }
 const toolCallUpdates: ToolCallResult[] = [];
-let summaryText = "";
+let summaryText = '';
 
 const connection = new acp.ClientSideConnection(
   (_agent) => ({
     async sessionUpdate(params) {
       const update = params.update;
-      if (update.sessionUpdate === "tool_call") {
+      if (update.sessionUpdate === 'tool_call') {
         const meta = update._meta as { replay?: { replay_outcome?: string } } | undefined;
-        const status = update.status ?? "unknown";
+        const status = update.status ?? 'unknown';
         toolCallUpdates.push({
           toolCallId: update.toolCallId,
           title: update.title,
           status,
           replayOutcome: meta?.replay?.replay_outcome,
         });
-        console.log(`  tool_call: ${update.toolCallId} — ${update.title} [${status}] → ${meta?.replay?.replay_outcome ?? "?"}`);
-      } else if (
-        update.sessionUpdate === "agent_message_chunk" &&
-        update.content.type === "text"
-      ) {
+        console.log(
+          `  tool_call: ${update.toolCallId} — ${update.title} [${status}] → ${meta?.replay?.replay_outcome ?? '?'}`,
+        );
+      } else if (update.sessionUpdate === 'agent_message_chunk' && update.content.type === 'text') {
         summaryText += update.content.text;
       }
     },
     async requestPermission(_params) {
-      return { outcome: { outcome: "cancelled" as const } };
+      return { outcome: { outcome: 'cancelled' as const } };
     },
   }),
-  stream
+  stream,
 );
 
 // Mixed tool calls covering all executor paths + de-anonymization
 const toolCalls = [
   // Direct paths (Phase 3 regression)
-  { id: 1, tool: "Read",      input: { file_path: join(testDir, "test.txt") },          original_outcome: "approved" },
-  { id: 2, tool: "Write",     input: { file_path: join(testDir, "new.txt"), content: "hello" }, original_outcome: "approved" },
-  { id: 3, tool: "Edit",      input: { file_path: join(testDir, "test.txt"), old_string: "hello", new_string: "goodbye" }, original_outcome: "approved" },
-  { id: 4, tool: "Bash",      input: { command: `ls ${testDir}` },                      original_outcome: "approved" },
-  { id: 5, tool: "Grep",      input: { path: testDir, pattern: "hello" },               original_outcome: "approved" },
-  { id: 6, tool: "Glob",      input: { path: testDir, pattern: "*.txt" },               original_outcome: "approved" },
-  { id: 7, tool: "TodoWrite", input: { todos: [] },                                     original_outcome: "approved" },
-  { id: 8, tool: "Read",      input: { file_path: "/nonexistent/path/file.txt" },       original_outcome: "approved" },
+  {
+    id: 1,
+    tool: 'Read',
+    input: { file_path: join(testDir, 'test.txt') },
+    original_outcome: 'approved',
+  },
+  {
+    id: 2,
+    tool: 'Write',
+    input: { file_path: join(testDir, 'new.txt'), content: 'hello' },
+    original_outcome: 'approved',
+  },
+  {
+    id: 3,
+    tool: 'Edit',
+    input: { file_path: join(testDir, 'test.txt'), old_string: 'hello', new_string: 'goodbye' },
+    original_outcome: 'approved',
+  },
+  { id: 4, tool: 'Bash', input: { command: `ls ${testDir}` }, original_outcome: 'approved' },
+  { id: 5, tool: 'Grep', input: { path: testDir, pattern: 'hello' }, original_outcome: 'approved' },
+  { id: 6, tool: 'Glob', input: { path: testDir, pattern: '*.txt' }, original_outcome: 'approved' },
+  { id: 7, tool: 'TodoWrite', input: { todos: [] }, original_outcome: 'approved' },
+  {
+    id: 8,
+    tool: 'Read',
+    input: { file_path: '/nonexistent/path/file.txt' },
+    original_outcome: 'approved',
+  },
   // De-anonymization: {project} placeholder → testDir
-  { id: 9,  tool: "Read",     input: { file_path: "{project}/test.txt" },               original_outcome: "approved" },
-  { id: 10, tool: "Bash",     input: { command: "ls {project}" },                       original_outcome: "approved" },
+  { id: 9, tool: 'Read', input: { file_path: '{project}/test.txt' }, original_outcome: 'approved' },
+  { id: 10, tool: 'Bash', input: { command: 'ls {project}' }, original_outcome: 'approved' },
   // Non-replayable internal paths → skipped
-  { id: 11, tool: "Read",     input: { file_path: "{project}/.claude/projects/-Users-{user}-Code-{project-name}/session.jsonl" }, original_outcome: "approved" },
-  { id: 12, tool: "Read",     input: { file_path: "{home}/.claude/settings.json" },     original_outcome: "approved" },
+  {
+    id: 11,
+    tool: 'Read',
+    input: {
+      file_path: '{project}/.claude/projects/-Users-{user}-Code-{project-name}/session.jsonl',
+    },
+    original_outcome: 'approved',
+  },
+  {
+    id: 12,
+    tool: 'Read',
+    input: { file_path: '{home}/.claude/settings.json' },
+    original_outcome: 'approved',
+  },
   // {host} in Bash → skipped
-  { id: 13, tool: "Bash",     input: { command: "curl https://{host}/api" },             original_outcome: "approved" },
+  {
+    id: 13,
+    tool: 'Bash',
+    input: { command: 'curl https://{host}/api' },
+    original_outcome: 'approved',
+  },
 ];
 
 // Expected outcomes (unsandboxed)
 const expectedOutcomes: Record<number, string> = {
-  1: "allowed",   // Read existing file (direct path)
-  2: "allowed",   // Write new file
-  3: "allowed",   // Edit existing file
-  4: "allowed",   // Bash ls
-  5: "allowed",   // Grep — read access check
-  6: "allowed",   // Glob — readdir
-  7: "skipped",   // TodoWrite — non-replayable
-  8: "error",     // Read nonexistent file
-  9: "allowed",   // Read via {project} de-anonymization
-  10: "allowed",  // Bash via {project} de-anonymization
-  11: "skipped",  // Non-replayable: {project-name} placeholder
-  12: "skipped",  // Non-replayable: .claude/ internal state
-  13: "skipped",  // {host} in Bash
+  1: 'allowed', // Read existing file (direct path)
+  2: 'allowed', // Write new file
+  3: 'allowed', // Edit existing file
+  4: 'allowed', // Bash ls
+  5: 'allowed', // Grep — read access check
+  6: 'allowed', // Glob — readdir
+  7: 'skipped', // TodoWrite — non-replayable
+  8: 'error', // Read nonexistent file
+  9: 'allowed', // Read via {project} de-anonymization
+  10: 'allowed', // Bash via {project} de-anonymization
+  11: 'skipped', // Non-replayable: {project-name} placeholder
+  12: 'skipped', // Non-replayable: .claude/ internal state
+  13: 'skipped', // {host} in Bash
 };
 
 let exitCode = 0;
@@ -126,7 +162,7 @@ try {
     protocolVersion: acp.PROTOCOL_VERSION,
     clientCapabilities: {},
   });
-  console.log("✓ Initialized:", JSON.stringify(initResp));
+  console.log('✓ Initialized:', JSON.stringify(initResp));
 
   // Create session
   const sessionResp = await connection.newSession({
@@ -139,15 +175,18 @@ try {
   console.log(`\nSending ${toolCalls.length} tool calls...`);
   const promptResp = await connection.prompt({
     sessionId: sessionResp.sessionId,
-    prompt: [{ type: "text", text: JSON.stringify(toolCalls) }],
+    prompt: [{ type: 'text', text: JSON.stringify(toolCalls) }],
   });
   console.log(`\n✓ Prompt done: stopReason=${promptResp.stopReason}`);
   console.log(`  Summary: ${summaryText}`);
 
   // Verify results
-  console.log("\n--- Verification ---");
+  console.log('\n--- Verification ---');
 
-  check(`Received ${toolCalls.length} tool_call updates`, toolCallUpdates.length === toolCalls.length);
+  check(
+    `Received ${toolCalls.length} tool_call updates`,
+    toolCallUpdates.length === toolCalls.length,
+  );
 
   for (let i = 0; i < toolCalls.length; i++) {
     const expected = toolCalls[i];
@@ -157,16 +196,16 @@ try {
     const expectedOutcome = expectedOutcomes[expected.id];
     check(
       `Tool ${expected.id} (${expected.tool}): replay_outcome=${actual.replayOutcome} (expected ${expectedOutcome})`,
-      actual.replayOutcome === expectedOutcome
+      actual.replayOutcome === expectedOutcome,
     );
   }
 } catch (err) {
-  console.error("Error:", err);
+  console.error('Error:', err);
   exitCode = 1;
 } finally {
   agent.kill();
   // Cleanup test files
-  const { rmSync } = await import("node:fs");
+  const { rmSync } = await import('node:fs');
   rmSync(testDir, { recursive: true, force: true });
   process.exitCode = exitCode;
 }

--- a/scripts/test-sandbox-monitor.ts
+++ b/scripts/test-sandbox-monitor.ts
@@ -9,28 +9,26 @@
  * Prerequisites:
  *   - safehouse on PATH (brew install eugene1g/safehouse/agent-safehouse)
  */
-import { spawn } from "node:child_process";
-import { randomUUID } from "node:crypto";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
-import { mkdir, rm } from "node:fs/promises";
-import { SandboxMonitor, type SandboxViolation } from "../src/main/sandbox-monitor.js";
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { mkdir, rm } from 'node:fs/promises';
+import { SandboxMonitor, type SandboxViolation } from '../src/main/sandbox-monitor.js';
 import {
   defaultSandboxConfig,
   buildSafehouseArgs,
   isSafehouseAvailable,
   ensurePolicyDir,
   cleanupPolicy,
-} from "../src/main/sandbox.js";
+} from '../src/main/sandbox.js';
 
 const sessionId = randomUUID();
 
-console.log("=== Sandbox Monitor Test ===\n");
+console.log('=== Sandbox Monitor Test ===\n');
 
 if (!(await isSafehouseAvailable())) {
-  console.log(
-    "safehouse not found. Install: brew install eugene1g/safehouse/agent-safehouse"
-  );
+  console.log('safehouse not found. Install: brew install eugene1g/safehouse/agent-safehouse');
   process.exit(1);
 }
 
@@ -45,16 +43,14 @@ const config = defaultSandboxConfig({ sessionId, worktreePath });
 // Start monitor
 const monitor = new SandboxMonitor();
 const violations: SandboxViolation[] = [];
-monitor.on("violation", (v) => {
+monitor.on('violation', (v) => {
   violations.push(v);
-  console.log(
-    `  [VIOLATION] ${v.processName}(${v.pid}) ${v.operation} ${v.path ?? ""}`
-  );
+  console.log(`  [VIOLATION] ${v.processName}(${v.pid}) ${v.operation} ${v.path ?? ''}`);
 });
 
 // Spawn a longer-lived process via safehouse that triggers violations
 // repeatedly so the monitor has time to start and discover the PID tree.
-const homedir = (await import("node:os")).homedir();
+const homedir = (await import('node:os')).homedir();
 const badFile = join(homedir, `.sandbox-monitor-test-${sessionId}`);
 // Use $1 to avoid shell injection if homedir has special characters
 const shellCmd = [
@@ -63,13 +59,13 @@ const shellCmd = [
   `  sleep 1;`,
   `done;`,
   `echo done`,
-].join(" ");
+].join(' ');
 
-const args = buildSafehouseArgs(config, ["/bin/sh", "-c", shellCmd, "--", badFile]);
+const args = buildSafehouseArgs(config, ['/bin/sh', '-c', shellCmd, '--', badFile]);
 
-console.log("Spawning sandboxed process that will trigger violations...\n");
-const proc = spawn("safehouse", args, {
-  stdio: ["ignore", "pipe", "pipe"],
+console.log('Spawning sandboxed process that will trigger violations...\n');
+const proc = spawn('safehouse', args, {
+  stdio: ['ignore', 'pipe', 'pipe'],
   cwd: worktreePath,
 });
 
@@ -77,35 +73,35 @@ const proc = spawn("safehouse", args, {
 // shell and its children are descendants that the monitor discovers.
 monitor.start(proc.pid!);
 
-proc.stdout?.on("data", (d: Buffer) => {
+proc.stdout?.on('data', (d: Buffer) => {
   const text = d.toString().trim();
   if (text) console.log(`  [stdout] ${text}`);
 });
-proc.stderr?.on("data", (d: Buffer) => {
+proc.stderr?.on('data', (d: Buffer) => {
   // Suppress shell-init noise from sandboxed shell
   const text = d.toString().trim();
-  if (text && !text.includes("shell-init")) console.log(`  [stderr] ${text}`);
+  if (text && !text.includes('shell-init')) console.log(`  [stderr] ${text}`);
 });
 
 // Wait for process to exit, then wait for log events to arrive
-await new Promise<void>((resolve) => proc.on("exit", () => resolve()));
-console.log("\nProcess exited. Waiting for log events (3s)...");
+await new Promise<void>((resolve) => proc.on('exit', () => resolve()));
+console.log('\nProcess exited. Waiting for log events (3s)...');
 await new Promise((resolve) => setTimeout(resolve, 3000));
 
 monitor.stop();
 
 console.log(`\nTotal violations captured: ${violations.length}`);
 if (violations.length > 0) {
-  console.log("✓ Monitor detected violations");
+  console.log('✓ Monitor detected violations');
   for (const v of violations) {
-    console.log(`  - ${v.processName}(${v.pid}) ${v.operation} ${v.path ?? ""}`);
+    console.log(`  - ${v.processName}(${v.pid}) ${v.operation} ${v.path ?? ''}`);
   }
 } else {
-  console.log("✗ No violations detected");
-  console.log("  This can happen if:");
+  console.log('✗ No violations detected');
+  console.log('  This can happen if:');
   console.log("  - log stream hasn't started fast enough");
-  console.log("  - PID filtering missed the short-lived process");
-  console.log("  - Full Disk Access may be needed for log stream");
+  console.log('  - PID filtering missed the short-lived process');
+  console.log('  - Full Disk Access may be needed for log stream');
   process.exitCode = 1;
 }
 
@@ -114,4 +110,4 @@ await cleanupPolicy(config.policyOutputPath);
 await rm(worktreePath, { recursive: true, force: true });
 await rm(badFile, { force: true });
 
-console.log("\n=== Done ===");
+console.log('\n=== Done ===');

--- a/scripts/test-sandbox-profile.ts
+++ b/scripts/test-sandbox-profile.ts
@@ -9,18 +9,18 @@
 //
 // Defaults to the current directory as the "worktree" path.
 
-import { homedir } from "node:os";
-import { randomUUID } from "node:crypto";
-import { execFile, spawn } from "node:child_process";
-import { promisify } from "node:util";
-import { readFile, rm } from "node:fs/promises";
+import { homedir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { execFile, spawn } from 'node:child_process';
+import { promisify } from 'node:util';
+import { readFile, rm } from 'node:fs/promises';
 import {
   defaultSandboxConfig,
   buildSafehouseArgs,
   isSafehouseAvailable,
   ensurePolicyDir,
   cleanupPolicy,
-} from "../src/main/sandbox.js";
+} from '../src/main/sandbox.js';
 
 const execFileAsync = promisify(execFile);
 const worktreePath = process.argv[2] || process.cwd();
@@ -38,16 +38,16 @@ function fail(msg: string) {
   failed++;
 }
 
-console.log("=== Sandbox Integration Test (agent-safehouse) ===\n");
+console.log('=== Sandbox Integration Test (agent-safehouse) ===\n');
 
 // Check safehouse availability
 const available = await isSafehouseAvailable();
 if (!available) {
-  console.log("safehouse CLI not found on PATH.");
-  console.log("Install: brew install eugene1g/safehouse/agent-safehouse");
+  console.log('safehouse CLI not found on PATH.');
+  console.log('Install: brew install eugene1g/safehouse/agent-safehouse');
   process.exit(1);
 }
-pass("safehouse CLI available");
+pass('safehouse CLI available');
 
 // Build config
 const config = defaultSandboxConfig({
@@ -56,21 +56,21 @@ const config = defaultSandboxConfig({
 });
 console.log(`\nWorktree: ${worktreePath}`);
 console.log(`Policy output: ${config.policyOutputPath}`);
-console.log(`Writable dirs: ${config.writableDirs.join(", ")}`);
-console.log(`Env passthrough: ${config.envPassthrough.join(", ")}`);
+console.log(`Writable dirs: ${config.writableDirs.join(', ')}`);
+console.log(`Env passthrough: ${config.envPassthrough.join(', ')}`);
 
 // Build args for a simple ls command
-const args = buildSafehouseArgs(config, ["/bin/ls", worktreePath]);
-console.log(`\nSafehouse args: safehouse ${args.join(" ")}`);
+const args = buildSafehouseArgs(config, ['/bin/ls', worktreePath]);
+console.log(`\nSafehouse args: safehouse ${args.join(' ')}`);
 
 // Ensure policy dir exists
 await ensurePolicyDir();
 
 // Test 1: Generate policy and run ls in worktree (should succeed)
-console.log("\n--- Validation Tests ---\n");
+console.log('\n--- Validation Tests ---\n');
 try {
-  const { stdout } = await execFileAsync("safehouse", args);
-  const lines = stdout.trim().split("\n").filter(Boolean);
+  const { stdout } = await execFileAsync('safehouse', args);
+  const lines = stdout.trim().split('\n').filter(Boolean);
   pass(`ls worktree via safehouse: ${lines.length} entries`);
 } catch (err: any) {
   fail(`ls worktree FAILED: ${err.stderr || err.message}`);
@@ -78,20 +78,22 @@ try {
 
 // Test 2: Inspect the generated policy file
 try {
-  const policy = await readFile(config.policyOutputPath, "utf-8");
+  const policy = await readFile(config.policyOutputPath, 'utf-8');
   const ruleCount = (policy.match(/^\(allow /gm) || []).length;
   const denyCount = (policy.match(/^\(deny /gm) || []).length;
-  pass(`policy file generated: ${policy.length} chars, ${ruleCount} allow rules, ${denyCount} deny rules`);
+  pass(
+    `policy file generated: ${policy.length} chars, ${ruleCount} allow rules, ${denyCount} deny rules`,
+  );
 } catch (err: any) {
   fail(`policy file not found: ${err.message}`);
 }
 
 // Test 3: Write to worktree (should succeed)
 const testFile = `${worktreePath}/.sandbox-test-${sessionId}`;
-const writeArgs = buildSafehouseArgs(config, ["/usr/bin/touch", testFile]);
+const writeArgs = buildSafehouseArgs(config, ['/usr/bin/touch', testFile]);
 try {
-  await execFileAsync("safehouse", writeArgs);
-  pass("touch in worktree succeeded");
+  await execFileAsync('safehouse', writeArgs);
+  pass('touch in worktree succeeded');
   await rm(testFile, { force: true });
 } catch (err: any) {
   fail(`touch in worktree FAILED: ${err.stderr || err.message}`);
@@ -99,20 +101,20 @@ try {
 
 // Test 4: Write to home directory (should fail)
 const badFile = `${homedir()}/.sandbox-test-bad-${sessionId}`;
-const badArgs = buildSafehouseArgs(config, ["/usr/bin/touch", badFile]);
+const badArgs = buildSafehouseArgs(config, ['/usr/bin/touch', badFile]);
 try {
-  await execFileAsync("safehouse", badArgs);
-  fail("touch in ~ succeeded (should have been blocked)");
+  await execFileAsync('safehouse', badArgs);
+  fail('touch in ~ succeeded (should have been blocked)');
   await rm(badFile, { force: true });
 } catch {
-  pass("touch in ~ blocked (expected)");
+  pass('touch in ~ blocked (expected)');
 }
 
 // Test 5: System binary access (should succeed)
-const whichArgs = buildSafehouseArgs(config, ["/usr/bin/which", "git"]);
+const whichArgs = buildSafehouseArgs(config, ['/usr/bin/which', 'git']);
 try {
-  await execFileAsync("safehouse", whichArgs);
-  pass("which git succeeded");
+  await execFileAsync('safehouse', whichArgs);
+  pass('which git succeeded');
 } catch (err: any) {
   fail(`which git FAILED: ${err.stderr || err.message}`);
 }
@@ -120,20 +122,22 @@ try {
 // Test 6: Stdio piping works (critical for ACP)
 try {
   const result = await new Promise<string>((resolve, reject) => {
-    const echoArgs = buildSafehouseArgs(config, ["/bin/echo", "hello-acp"]);
-    const proc = spawn("safehouse", echoArgs, {
-      stdio: ["pipe", "pipe", "pipe"],
+    const echoArgs = buildSafehouseArgs(config, ['/bin/echo', 'hello-acp']);
+    const proc = spawn('safehouse', echoArgs, {
+      stdio: ['pipe', 'pipe', 'pipe'],
     });
-    let stdout = "";
-    proc.stdout.on("data", (d: Buffer) => { stdout += d.toString(); });
-    proc.on("close", (code) => {
+    let stdout = '';
+    proc.stdout.on('data', (d: Buffer) => {
+      stdout += d.toString();
+    });
+    proc.on('close', (code) => {
       if (code === 0) resolve(stdout.trim());
       else reject(new Error(`exit ${code}`));
     });
-    proc.on("error", reject);
+    proc.on('error', reject);
   });
-  if (result === "hello-acp") {
-    pass("stdio piping works (critical for ACP JSON-RPC)");
+  if (result === 'hello-acp') {
+    pass('stdio piping works (critical for ACP JSON-RPC)');
   } else {
     fail(`stdio piping returned unexpected output: "${result}"`);
   }
@@ -148,4 +152,4 @@ console.log(`\n--- Results: ${passed} passed, ${failed} failed ---`);
 if (failed > 0) {
   process.exitCode = 1;
 }
-console.log("\n=== Done ===");
+console.log('\n=== Done ===');

--- a/scripts/test-sandboxed-agent.ts
+++ b/scripts/test-sandboxed-agent.ts
@@ -12,30 +12,28 @@
  *   - @zed-industries/claude-agent-acp installed
  *   - ANTHROPIC_API_KEY set or Claude Code OAuth active (~/.claude.json)
  */
-import { spawn } from "node:child_process";
-import { createRequire } from "node:module";
-import { randomUUID } from "node:crypto";
-import { join } from "node:path";
-import { Writable, Readable } from "node:stream";
-import * as acp from "@agentclientprotocol/sdk";
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
+import { Writable, Readable } from 'node:stream';
+import * as acp from '@agentclientprotocol/sdk';
 import {
   defaultSandboxConfig,
   buildSafehouseArgs,
   isSafehouseAvailable,
   ensurePolicyDir,
   cleanupPolicy,
-} from "../src/main/sandbox.js";
+} from '../src/main/sandbox.js';
 
 const require = createRequire(import.meta.url);
 const worktreePath = process.argv[2] || process.cwd();
 const sessionId = randomUUID();
 
-console.log("=== Sandboxed Agent Test ===\n");
+console.log('=== Sandboxed Agent Test ===\n');
 
 if (!(await isSafehouseAvailable())) {
-  console.log(
-    "safehouse not found. Install: brew install eugene1g/safehouse/agent-safehouse"
-  );
+  console.log('safehouse not found. Install: brew install eugene1g/safehouse/agent-safehouse');
   process.exit(1);
 }
 
@@ -46,22 +44,20 @@ console.log(`Worktree: ${worktreePath}`);
 console.log(`Policy: ${config.policyOutputPath}`);
 
 // Resolve agent binary
-const agentBin = require.resolve(
-  "@zed-industries/claude-agent-acp/dist/index.js"
-);
+const agentBin = require.resolve('@zed-industries/claude-agent-acp/dist/index.js');
 
 // Spawn via safehouse
-const args = buildSafehouseArgs(config, ["node", agentBin]);
-console.log(`\nSpawning: safehouse ${args.slice(0, 4).join(" ")} ... -- node <agent>\n`);
+const args = buildSafehouseArgs(config, ['node', agentBin]);
+console.log(`\nSpawning: safehouse ${args.slice(0, 4).join(' ')} ... -- node <agent>\n`);
 
-const agent = spawn("safehouse", args, {
-  stdio: ["pipe", "pipe", "pipe"],
+const agent = spawn('safehouse', args, {
+  stdio: ['pipe', 'pipe', 'pipe'],
   cwd: worktreePath,
 });
 
-agent.stderr?.on("data", (d: Buffer) => process.stderr.write(d));
-agent.on("error", (err) => console.error("Spawn error:", err));
-agent.on("exit", (code) => console.log(`\nAgent exited: code ${code}`));
+agent.stderr?.on('data', (d: Buffer) => process.stderr.write(d));
+agent.on('error', (err) => console.error('Spawn error:', err));
+agent.on('exit', (code) => console.log(`\nAgent exited: code ${code}`));
 
 // ACP setup
 const output = Writable.toWeb(agent.stdin!) as WritableStream<Uint8Array>;
@@ -72,39 +68,33 @@ const connection = new acp.ClientSideConnection(
   (_agentInfo) => ({
     async sessionUpdate(params) {
       const update = params.update;
-      if (
-        update.sessionUpdate === "agent_message_chunk" &&
-        update.content.type === "text"
-      ) {
+      if (update.sessionUpdate === 'agent_message_chunk' && update.content.type === 'text') {
         process.stdout.write(update.content.text);
       } else if (
-        update.sessionUpdate === "tool_call" ||
-        update.sessionUpdate === "tool_call_update"
+        update.sessionUpdate === 'tool_call' ||
+        update.sessionUpdate === 'tool_call_update'
       ) {
-        const meta = update._meta as
-          | { claudeCode?: { toolName?: string } }
-          | undefined;
-        const toolName = meta?.claudeCode?.toolName ?? "Tool";
-        const status =
-          "status" in update ? (update.status as string) : "in_progress";
+        const meta = update._meta as { claudeCode?: { toolName?: string } } | undefined;
+        const toolName = meta?.claudeCode?.toolName ?? 'Tool';
+        const status = 'status' in update ? (update.status as string) : 'in_progress';
         console.log(`\n  [${toolName}: ${status}]`);
       }
     },
     async requestPermission(params) {
-      const opt = params.options.find((o) => o.kind === "allow_once");
+      const opt = params.options.find((o) => o.kind === 'allow_once');
       return {
         outcome: {
-          outcome: "selected" as const,
+          outcome: 'selected' as const,
           optionId: (opt ?? params.options[0]).optionId,
         },
       };
     },
   }),
-  stream
+  stream,
 );
 
 try {
-  console.log("Initializing ACP...");
+  console.log('Initializing ACP...');
   await connection.initialize({
     protocolVersion: acp.PROTOCOL_VERSION,
     clientCapabilities: {
@@ -112,7 +102,7 @@ try {
       fs: { readTextFile: true, writeTextFile: true },
     },
   });
-  console.log("✓ Initialize succeeded");
+  console.log('✓ Initialize succeeded');
 
   const sessionResp = await connection.newSession({
     cwd: worktreePath,
@@ -121,14 +111,14 @@ try {
   console.log(`✓ New session: ${sessionResp.sessionId}`);
 
   // Test 1: Read (list files)
-  const readPrompt = "List the files in the current directory. Be brief.";
+  const readPrompt = 'List the files in the current directory. Be brief.';
   console.log(`\nPrompt 1 (read): "${readPrompt}"\n--- Response ---`);
   const readResp = await connection.prompt({
     sessionId: sessionResp.sessionId,
-    prompt: [{ type: "text", text: readPrompt }],
+    prompt: [{ type: 'text', text: readPrompt }],
   });
   console.log(`\n--- End (stop: ${readResp.stopReason}) ---`);
-  console.log("✓ Read test passed");
+  console.log('✓ Read test passed');
 
   // Test 2: Write (create a file in the worktree)
   const testFileName = `.sandbox-write-test-${sessionId}`;
@@ -136,32 +126,32 @@ try {
   console.log(`\nPrompt 2 (write): "${writePrompt}"\n--- Response ---`);
   const writeResp = await connection.prompt({
     sessionId: sessionResp.sessionId,
-    prompt: [{ type: "text", text: writePrompt }],
+    prompt: [{ type: 'text', text: writePrompt }],
   });
   console.log(`\n--- End (stop: ${writeResp.stopReason}) ---`);
 
   // Verify the file was created
-  const { readFile: readFileAsync, rm: rmAsync } = await import("node:fs/promises");
+  const { readFile: readFileAsync, rm: rmAsync } = await import('node:fs/promises');
   const testFilePath = join(worktreePath, testFileName);
   try {
-    const content = await readFileAsync(testFilePath, "utf-8");
-    if (content.includes("hello from sandbox")) {
-      console.log("✓ Write test passed — file created with expected content");
+    const content = await readFileAsync(testFilePath, 'utf-8');
+    if (content.includes('hello from sandbox')) {
+      console.log('✓ Write test passed — file created with expected content');
     } else {
       console.log(`✗ Write test: file exists but content unexpected: "${content.trim()}"`);
       process.exitCode = 1;
     }
     await rmAsync(testFilePath, { force: true });
   } catch {
-    console.log("✗ Write test failed — file was not created");
+    console.log('✗ Write test failed — file was not created');
     process.exitCode = 1;
   }
 } catch (err) {
-  console.error("\n✗ Error:", err);
+  console.error('\n✗ Error:', err);
   process.exitCode = 1;
 } finally {
   agent.kill();
   await cleanupPolicy(config.policyOutputPath);
 }
 
-console.log("\n=== Done ===");
+console.log('\n=== Done ===');

--- a/scripts/test-scaffold.ts
+++ b/scripts/test-scaffold.ts
@@ -6,17 +6,17 @@
  *
  * Usage: npx tsx scripts/test-scaffold.ts [session-id]
  */
-import { mkdtempSync, readFileSync, rmSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
-import { buildScaffoldPlan, applyScaffold } from "../src/main/replay-scaffold.js";
-import type { ReplayToolCall } from "../src/main/types.js";
+import { mkdtempSync, readFileSync, rmSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { buildScaffoldPlan, applyScaffold } from '../src/main/replay-scaffold.js';
+import type { ReplayToolCall } from '../src/main/types.js';
 
-const sessionId = process.argv[2] ?? "session-308";
-const datasetPath = join(process.cwd(), "data", "tool-use-dataset.jsonl");
+const sessionId = process.argv[2] ?? 'session-308';
+const datasetPath = join(process.cwd(), 'data', 'tool-use-dataset.jsonl');
 
 // Load dataset and filter to target session
-const lines = readFileSync(datasetPath, "utf-8").split("\n").filter(Boolean);
+const lines = readFileSync(datasetPath, 'utf-8').split('\n').filter(Boolean);
 interface DatasetRecord {
   id: number;
   tool: string;
@@ -39,7 +39,7 @@ if (sessionRecords.length === 0) {
 }
 
 console.log(`Session ${sessionId}: ${sessionRecords.length} records`);
-console.log(`Tools used: ${[...new Set(sessionRecords.map((r) => r.tool))].sort().join(", ")}`);
+console.log(`Tools used: ${[...new Set(sessionRecords.map((r) => r.tool))].sort().join(', ')}`);
 
 // Convert to ReplayToolCall format
 const toolCalls: ReplayToolCall[] = sessionRecords.map((r) => ({
@@ -50,7 +50,7 @@ const toolCalls: ReplayToolCall[] = sessionRecords.map((r) => ({
 }));
 
 // Create temp worktree directory
-const worktreeDir = mkdtempSync(join(tmpdir(), "scaffold-test-"));
+const worktreeDir = mkdtempSync(join(tmpdir(), 'scaffold-test-'));
 console.log(`Worktree: ${worktreeDir}\n`);
 
 // Simple deanonymize function for testing
@@ -58,7 +58,7 @@ function deanonymize(path: string): string {
   return path
     .replace(/\{project\}/g, worktreeDir)
     .replace(/\{home\}/g, tmpdir())
-    .replace(/\{user\}/g, "testuser");
+    .replace(/\{user\}/g, 'testuser');
 }
 
 let exitCode = 0;
@@ -79,14 +79,14 @@ try {
 
   // Print plan details
   if (plan.files.size > 0) {
-    console.log("\nFiles to create:");
+    console.log('\nFiles to create:');
     for (const [relPath, content] of plan.files) {
-      const preview = content.length > 60 ? content.slice(0, 60) + "..." : content;
-      console.log(`  ${relPath} (${content.length} bytes): ${preview.replace(/\n/g, "\\n")}`);
+      const preview = content.length > 60 ? content.slice(0, 60) + '...' : content;
+      console.log(`  ${relPath} (${content.length} bytes): ${preview.replace(/\n/g, '\\n')}`);
     }
   }
   if (plan.directories.size > 0) {
-    console.log("\nDirectories to create:");
+    console.log('\nDirectories to create:');
     for (const dir of plan.directories) {
       console.log(`  ${dir}/`);
     }
@@ -97,7 +97,7 @@ try {
   console.log(`\nApplied scaffold: ${filesCreated} files created`);
 
   // Walk the resulting tree
-  function walkDir(dir: string, prefix = ""): string[] {
+  function walkDir(dir: string, prefix = ''): string[] {
     const entries: string[] = [];
     for (const entry of readdirSync(dir)) {
       const fullPath = join(dir, entry);
@@ -120,33 +120,41 @@ try {
   }
 
   // Verification
-  console.log("\n--- Verification ---");
-  check("Plan has at least one file", plan.files.size > 0);
-  check("Files created matches plan", filesCreated === plan.files.size);
-  check("No .claude/ paths in plan", ![...plan.files.keys()].some((p) => p.includes(".claude/")));
-  check("No {project-name} in plan", ![...plan.files.keys()].some((p) => p.includes("{project-name}")));
-  check("No {home} paths in plan", ![...plan.files.keys()].some((p) => p.includes("{home}")));
-  check("All plan files exist on disk", [...plan.files.keys()].every((relPath) => {
-    try {
-      statSync(join(worktreeDir, relPath));
-      return true;
-    } catch {
-      return false;
-    }
-  }));
+  console.log('\n--- Verification ---');
+  check('Plan has at least one file', plan.files.size > 0);
+  check('Files created matches plan', filesCreated === plan.files.size);
+  check('No .claude/ paths in plan', ![...plan.files.keys()].some((p) => p.includes('.claude/')));
+  check(
+    'No {project-name} in plan',
+    ![...plan.files.keys()].some((p) => p.includes('{project-name}')),
+  );
+  check('No {home} paths in plan', ![...plan.files.keys()].some((p) => p.includes('{home}')));
+  check(
+    'All plan files exist on disk',
+    [...plan.files.keys()].every((relPath) => {
+      try {
+        statSync(join(worktreeDir, relPath));
+        return true;
+      } catch {
+        return false;
+      }
+    }),
+  );
 
   // Spot-check: Edit files should contain old_string content
-  const editCalls = toolCalls.filter((c) => c.tool === "Edit" && typeof c.input.old_string === "string");
+  const editCalls = toolCalls.filter(
+    (c) => c.tool === 'Edit' && typeof c.input.old_string === 'string',
+  );
   if (editCalls.length > 0) {
     const firstEdit = editCalls[0];
     const raw = firstEdit.input.file_path as string;
-    if (raw && !raw.includes("{project-name}") && !raw.includes(".claude/")) {
+    if (raw && !raw.includes('{project-name}') && !raw.includes('.claude/')) {
       const abs = deanonymize(raw);
       try {
-        const content = readFileSync(abs, "utf-8");
+        const content = readFileSync(abs, 'utf-8');
         check(
           `Edit file contains old_string seed`,
-          content.includes(firstEdit.input.old_string as string)
+          content.includes(firstEdit.input.old_string as string),
         );
       } catch {
         // File might be outside worktree
@@ -154,7 +162,7 @@ try {
     }
   }
 } catch (err) {
-  console.error("Error:", err);
+  console.error('Error:', err);
   exitCode = 1;
 } finally {
   rmSync(worktreeDir, { recursive: true, force: true });

--- a/scripts/test-worktree.ts
+++ b/scripts/test-worktree.ts
@@ -6,12 +6,12 @@
  *
  * Usage: npx tsx scripts/test-worktree.ts
  */
-import { WorktreeManager } from "../src/main/worktree-manager.js";
-import { randomUUID } from "node:crypto";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-import { access } from "node:fs/promises";
-import { join } from "node:path";
+import { WorktreeManager } from '../src/main/worktree-manager.js';
+import { randomUUID } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { access } from 'node:fs/promises';
+import { join } from 'node:path';
 
 const execFileAsync = promisify(execFile);
 const manager = new WorktreeManager();
@@ -42,23 +42,19 @@ async function pathExists(p: string): Promise<boolean> {
 }
 
 async function branchExists(branch: string, cwd: string): Promise<boolean> {
-  const { stdout } = await execFileAsync(
-    "git",
-    ["branch", "--list", branch],
-    { cwd }
-  );
+  const { stdout } = await execFileAsync('git', ['branch', '--list', branch], { cwd });
   return stdout.trim().length > 0;
 }
 
-console.log("=== WorktreeManager Test ===\n");
+console.log('=== WorktreeManager Test ===\n');
 
 // --- validateGitRepo ---
-console.log("1. validateGitRepo()");
+console.log('1. validateGitRepo()');
 const isGitRepo = await manager.validateGitRepo(projectDir);
-assert(isGitRepo, "bouncer root is a git repo");
+assert(isGitRepo, 'bouncer root is a git repo');
 
-const notGitRepo = await manager.validateGitRepo("/tmp");
-assert(!notGitRepo, "/tmp is not a git repo");
+const notGitRepo = await manager.validateGitRepo('/tmp');
+assert(!notGitRepo, '/tmp is not a git repo');
 
 // --- create / verify / remove ---
 let info: Awaited<ReturnType<typeof manager.create>> | undefined;
@@ -70,53 +66,34 @@ try {
   console.log(`   path:   ${info.path}`);
   console.log(`   branch: ${info.branch}`);
 
-  assert(await pathExists(info.path), "worktree directory exists");
-  assert(
-    await branchExists(info.branch, projectDir),
-    `branch ${info.branch} exists`
-  );
+  assert(await pathExists(info.path), 'worktree directory exists');
+  assert(await branchExists(info.branch, projectDir), `branch ${info.branch} exists`);
 
-  assert(
-    await pathExists(join(info.path, "package.json")),
-    "worktree contains package.json"
-  );
+  assert(await pathExists(join(info.path, 'package.json')), 'worktree contains package.json');
 
-  const { stdout: worktreeList } = await execFileAsync(
-    "git",
-    ["worktree", "list"],
-    { cwd: projectDir }
-  );
-  assert(
-    worktreeList.includes(info.path),
-    "worktree appears in git worktree list"
-  );
+  const { stdout: worktreeList } = await execFileAsync('git', ['worktree', 'list'], {
+    cwd: projectDir,
+  });
+  assert(worktreeList.includes(info.path), 'worktree appears in git worktree list');
 
   // --- remove ---
-  console.log("\n3. remove()");
+  console.log('\n3. remove()');
   await manager.remove(info);
   removed = true;
 
-  assert(!(await pathExists(info.path)), "worktree directory removed");
-  assert(
-    !(await branchExists(info.branch, projectDir)),
-    `branch ${info.branch} deleted`
-  );
+  assert(!(await pathExists(info.path)), 'worktree directory removed');
+  assert(!(await branchExists(info.branch, projectDir)), `branch ${info.branch} deleted`);
 
-  const { stdout: worktreeListAfter } = await execFileAsync(
-    "git",
-    ["worktree", "list"],
-    { cwd: projectDir }
-  );
-  assert(
-    !worktreeListAfter.includes(info.path),
-    "worktree gone from git worktree list"
-  );
+  const { stdout: worktreeListAfter } = await execFileAsync('git', ['worktree', 'list'], {
+    cwd: projectDir,
+  });
+  assert(!worktreeListAfter.includes(info.path), 'worktree gone from git worktree list');
 } finally {
   if (info && !removed) {
     try {
       await manager.remove(info);
     } catch (err) {
-      console.error("Failed to clean up worktree in test harness:", err);
+      console.error('Failed to clean up worktree in test harness:', err);
     }
   }
 }

--- a/src/agents/echo-agent.ts
+++ b/src/agents/echo-agent.ts
@@ -1,6 +1,6 @@
-import * as acp from "@agentclientprotocol/sdk";
-import { randomUUID } from "node:crypto";
-import { Writable, Readable } from "node:stream";
+import * as acp from '@agentclientprotocol/sdk';
+import { randomUUID } from 'node:crypto';
+import { Writable, Readable } from 'node:stream';
 
 const output = Writable.toWeb(process.stdout) as WritableStream<Uint8Array>;
 const input = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
@@ -24,9 +24,9 @@ new acp.AgentSideConnection(
     async prompt(params) {
       // Extract text from the prompt content blocks
       const userText = params.prompt
-        .filter((block): block is { type: "text"; text: string } => block.type === "text")
+        .filter((block): block is { type: 'text'; text: string } => block.type === 'text')
         .map((block) => block.text)
-        .join("");
+        .join('');
 
       const reply = `Echo: ${userText}`;
 
@@ -37,14 +37,14 @@ new acp.AgentSideConnection(
         await connection.sessionUpdate({
           sessionId: params.sessionId,
           update: {
-            sessionUpdate: "agent_message_chunk",
-            content: { type: "text", text: chunk },
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: chunk },
           },
         });
         await new Promise((r) => setTimeout(r, 50));
       }
 
-      return { stopReason: "end_turn" };
+      return { stopReason: 'end_turn' };
     },
 
     async cancel(params) {
@@ -59,7 +59,7 @@ new acp.AgentSideConnection(
       return {};
     },
   }),
-  stream
+  stream,
 );
 
-process.stderr.write("Echo agent started\n");
+process.stderr.write('Echo agent started\n');

--- a/src/agents/replay-agent.ts
+++ b/src/agents/replay-agent.ts
@@ -1,12 +1,12 @@
-import * as acp from "@agentclientprotocol/sdk";
-import { randomUUID } from "node:crypto";
-import { Writable, Readable } from "node:stream";
-import * as fs from "node:fs/promises";
-import { constants as fsConstants } from "node:fs";
-import { execSync } from "node:child_process";
-import { dirname } from "node:path";
-import { homedir, userInfo } from "node:os";
-import type { ReplayToolCall, ReplayResult } from "../main/types.js";
+import * as acp from '@agentclientprotocol/sdk';
+import { randomUUID } from 'node:crypto';
+import { Writable, Readable } from 'node:stream';
+import * as fs from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { dirname } from 'node:path';
+import { homedir, userInfo } from 'node:os';
+import type { ReplayToolCall, ReplayResult } from '../main/types.js';
 
 // Environment-based config (set by session manager before spawn)
 const WORKTREE_PATH = process.env.REPLAY_WORKTREE_PATH ?? process.cwd();
@@ -23,7 +23,7 @@ function getSafeUsername(): string {
   try {
     return userInfo().username;
   } catch {
-    return process.env.USER || process.env.USERNAME || "unknown";
+    return process.env.USER || process.env.USERNAME || 'unknown';
   }
 }
 
@@ -47,14 +47,14 @@ function deanonymizeCommand(command: string, ctx: ReplayContext): string {
     .replace(/\{user\}/g, ctx.username);
 }
 
-const PATH_FIELDS = ["file_path", "path", "command", "url", "cwd"] as const;
+const PATH_FIELDS = ['file_path', 'path', 'command', 'url', 'cwd'] as const;
 
 function hasUnresolvablePath(input: Record<string, unknown>): boolean {
   for (const key of PATH_FIELDS) {
     const val = input[key];
-    if (typeof val !== "string") continue;
-    if (val.includes("{project-name}")) return true;
-    if (val.includes(".claude/")) return true;
+    if (typeof val !== 'string') continue;
+    if (val.includes('{project-name}')) return true;
+    if (val.includes('.claude/')) return true;
   }
   return false;
 }
@@ -62,39 +62,51 @@ function hasUnresolvablePath(input: Record<string, unknown>): boolean {
 // --- Skip rules for non-replayable tools ---
 
 const SKIP_TOOLS = new Set([
-  "WebSearch", "Task", "Agent", "TodoWrite",
-  "EnterPlanMode", "ExitPlanMode", "ToolSearch",
-  "Skill", "AskUserQuestion", "TaskOutput", "TaskStop",
-  "EnterWorktree", "ExitWorktree", "NotebookEdit",
-  "SendMessage", "CronCreate", "CronDelete", "CronList",
-  "RemoteTrigger", "TeamCreate", "TeamDelete",
+  'WebSearch',
+  'Task',
+  'Agent',
+  'TodoWrite',
+  'EnterPlanMode',
+  'ExitPlanMode',
+  'ToolSearch',
+  'Skill',
+  'AskUserQuestion',
+  'TaskOutput',
+  'TaskStop',
+  'EnterWorktree',
+  'ExitWorktree',
+  'NotebookEdit',
+  'SendMessage',
+  'CronCreate',
+  'CronDelete',
+  'CronList',
+  'RemoteTrigger',
+  'TeamCreate',
+  'TeamDelete',
 ]);
 
 function shouldSkip(tool: string): boolean {
   if (SKIP_TOOLS.has(tool)) return true;
-  if (tool.startsWith("mcp__")) return true;
+  if (tool.startsWith('mcp__')) return true;
   return false;
 }
 
 // --- Error classification ---
 
-function classifyError(err: unknown): "blocked" | "error" {
+function classifyError(err: unknown): 'blocked' | 'error' {
   // Prefer structured error code for Node filesystem/process errors
   const code = (err as NodeJS.ErrnoException)?.code;
-  if (code === "EPERM" || code === "EACCES") {
-    return "blocked";
+  if (code === 'EPERM' || code === 'EACCES') {
+    return 'blocked';
   }
   // Fallback to message matching for non-Node errors (e.g. sandbox stderr)
   if (err instanceof Error) {
     const msg = err.message.toLowerCase();
-    if (
-      msg.includes("operation not permitted") ||
-      msg.includes("permission denied")
-    ) {
-      return "blocked";
+    if (msg.includes('operation not permitted') || msg.includes('permission denied')) {
+      return 'blocked';
     }
   }
-  return "error";
+  return 'error';
 }
 
 function errorMessage(err: unknown): string {
@@ -104,99 +116,120 @@ function errorMessage(err: unknown): string {
 
 // --- Tool executors ---
 
-async function executeRead(input: Record<string, unknown>, ctx: ReplayContext): Promise<Pick<ReplayResult, "replay_outcome" | "error_message">> {
+async function executeRead(
+  input: Record<string, unknown>,
+  ctx: ReplayContext,
+): Promise<Pick<ReplayResult, 'replay_outcome' | 'error_message'>> {
   const raw = input.file_path as string;
-  if (!raw) return { replay_outcome: "error", error_message: "missing file_path" };
+  if (!raw) return { replay_outcome: 'error', error_message: 'missing file_path' };
   const filePath = deanonymizePath(raw, ctx);
   try {
     await fs.access(filePath, fsConstants.R_OK);
-    return { replay_outcome: "allowed" };
+    return { replay_outcome: 'allowed' };
   } catch (err) {
     return { replay_outcome: classifyError(err), error_message: errorMessage(err) };
   }
 }
 
-async function executeWrite(input: Record<string, unknown>, ctx: ReplayContext): Promise<Pick<ReplayResult, "replay_outcome" | "error_message">> {
+async function executeWrite(
+  input: Record<string, unknown>,
+  ctx: ReplayContext,
+): Promise<Pick<ReplayResult, 'replay_outcome' | 'error_message'>> {
   const raw = input.file_path as string;
-  if (!raw) return { replay_outcome: "error", error_message: "missing file_path" };
+  if (!raw) return { replay_outcome: 'error', error_message: 'missing file_path' };
   const filePath = deanonymizePath(raw, ctx);
   try {
     await fs.mkdir(dirname(filePath), { recursive: true });
-    await fs.writeFile(filePath, "// replay-stub\n");
-    return { replay_outcome: "allowed" };
+    await fs.writeFile(filePath, '// replay-stub\n');
+    return { replay_outcome: 'allowed' };
   } catch (err) {
     return { replay_outcome: classifyError(err), error_message: errorMessage(err) };
   }
 }
 
-async function executeEdit(input: Record<string, unknown>, ctx: ReplayContext): Promise<Pick<ReplayResult, "replay_outcome" | "error_message">> {
+async function executeEdit(
+  input: Record<string, unknown>,
+  ctx: ReplayContext,
+): Promise<Pick<ReplayResult, 'replay_outcome' | 'error_message'>> {
   const raw = input.file_path as string;
-  if (!raw) return { replay_outcome: "error", error_message: "missing file_path" };
+  if (!raw) return { replay_outcome: 'error', error_message: 'missing file_path' };
   const filePath = deanonymizePath(raw, ctx);
   try {
-    let content = await fs.readFile(filePath, "utf-8");
+    let content = await fs.readFile(filePath, 'utf-8');
     const oldString = input.old_string as string | undefined;
     const newString = input.new_string as string | undefined;
     if (oldString !== undefined && newString !== undefined) {
       content = content.replace(oldString, newString);
     }
     await fs.writeFile(filePath, content);
-    return { replay_outcome: "allowed" };
+    return { replay_outcome: 'allowed' };
   } catch (err) {
     return { replay_outcome: classifyError(err), error_message: errorMessage(err) };
   }
 }
 
-async function executeGrep(input: Record<string, unknown>, ctx: ReplayContext): Promise<Pick<ReplayResult, "replay_outcome" | "error_message">> {
+async function executeGrep(
+  input: Record<string, unknown>,
+  ctx: ReplayContext,
+): Promise<Pick<ReplayResult, 'replay_outcome' | 'error_message'>> {
   const raw = (input.path as string) ?? ctx.worktreePath;
   const path = deanonymizePath(raw, ctx);
   try {
     await fs.access(path, fsConstants.R_OK);
-    return { replay_outcome: "allowed" };
+    return { replay_outcome: 'allowed' };
   } catch (err) {
     return { replay_outcome: classifyError(err), error_message: errorMessage(err) };
   }
 }
 
-async function executeGlob(input: Record<string, unknown>, ctx: ReplayContext): Promise<Pick<ReplayResult, "replay_outcome" | "error_message">> {
+async function executeGlob(
+  input: Record<string, unknown>,
+  ctx: ReplayContext,
+): Promise<Pick<ReplayResult, 'replay_outcome' | 'error_message'>> {
   const raw = (input.path as string) ?? ctx.worktreePath;
   const path = deanonymizePath(raw, ctx);
   try {
     await fs.readdir(path);
-    return { replay_outcome: "allowed" };
+    return { replay_outcome: 'allowed' };
   } catch (err) {
     return { replay_outcome: classifyError(err), error_message: errorMessage(err) };
   }
 }
 
-async function executeBash(input: Record<string, unknown>, ctx: ReplayContext): Promise<Pick<ReplayResult, "replay_outcome" | "error_message">> {
+async function executeBash(
+  input: Record<string, unknown>,
+  ctx: ReplayContext,
+): Promise<Pick<ReplayResult, 'replay_outcome' | 'error_message'>> {
   const raw = input.command as string;
-  if (!raw) return { replay_outcome: "error", error_message: "missing command" };
-  if (raw.includes("{host}")) return { replay_outcome: "skipped" };
+  if (!raw) return { replay_outcome: 'error', error_message: 'missing command' };
+  if (raw.includes('{host}')) return { replay_outcome: 'skipped' };
   const command = deanonymizeCommand(raw, ctx);
   try {
     execSync(command, {
       cwd: ctx.worktreePath,
       timeout: 5000,
-      stdio: ["pipe", "pipe", "pipe"],
+      stdio: ['pipe', 'pipe', 'pipe'],
       env: process.env,
     });
-    return { replay_outcome: "allowed" };
+    return { replay_outcome: 'allowed' };
   } catch (err) {
     // classifyError handles err.code (EPERM/EACCES) and message fallback
     const outcome = classifyError(err);
-    const stderr = (err as { stderr?: Buffer })?.stderr?.toString() ?? "";
+    const stderr = (err as { stderr?: Buffer })?.stderr?.toString() ?? '';
     const detail = stderr || errorMessage(err);
     return { replay_outcome: outcome, error_message: detail.slice(0, 200) };
   }
 }
 
-async function executeWebFetch(input: Record<string, unknown>, _ctx: ReplayContext): Promise<Pick<ReplayResult, "replay_outcome" | "error_message">> {
+async function executeWebFetch(
+  input: Record<string, unknown>,
+  _ctx: ReplayContext,
+): Promise<Pick<ReplayResult, 'replay_outcome' | 'error_message'>> {
   const url = input.url as string;
-  if (!url || url.includes("{host}")) return { replay_outcome: "skipped" };
+  if (!url || url.includes('{host}')) return { replay_outcome: 'skipped' };
   try {
     await fetch(url, { signal: AbortSignal.timeout(3000) });
-    return { replay_outcome: "allowed" };
+    return { replay_outcome: 'allowed' };
   } catch (err) {
     return { replay_outcome: classifyError(err), error_message: errorMessage(err) };
   }
@@ -204,27 +237,38 @@ async function executeWebFetch(input: Record<string, unknown>, _ctx: ReplayConte
 
 // --- Main dispatch ---
 
-async function executeToolCall(call: ReplayToolCall, ctx: ReplayContext): Promise<Pick<ReplayResult, "replay_outcome" | "error_message">> {
+async function executeToolCall(
+  call: ReplayToolCall,
+  ctx: ReplayContext,
+): Promise<Pick<ReplayResult, 'replay_outcome' | 'error_message'>> {
   if (shouldSkip(call.tool)) {
-    return { replay_outcome: "skipped" };
+    return { replay_outcome: 'skipped' };
   }
 
   // Skip tool calls with un-resolvable placeholders
   if (hasUnresolvablePath(call.input)) {
-    return { replay_outcome: "skipped", error_message: "un-resolvable path placeholder" };
+    return { replay_outcome: 'skipped', error_message: 'un-resolvable path placeholder' };
   }
 
   switch (call.tool) {
-    case "Read": return executeRead(call.input, ctx);
-    case "Write": return executeWrite(call.input, ctx);
-    case "Edit": return executeEdit(call.input, ctx);
-    case "Grep": return executeGrep(call.input, ctx);
-    case "Glob": return executeGlob(call.input, ctx);
-    case "Bash": return executeBash(call.input, ctx);
-    case "WebFetch": return executeWebFetch(call.input, ctx);
-    case "WebSearch": return { replay_outcome: "skipped" };
+    case 'Read':
+      return executeRead(call.input, ctx);
+    case 'Write':
+      return executeWrite(call.input, ctx);
+    case 'Edit':
+      return executeEdit(call.input, ctx);
+    case 'Grep':
+      return executeGrep(call.input, ctx);
+    case 'Glob':
+      return executeGlob(call.input, ctx);
+    case 'Bash':
+      return executeBash(call.input, ctx);
+    case 'WebFetch':
+      return executeWebFetch(call.input, ctx);
+    case 'WebSearch':
+      return { replay_outcome: 'skipped' };
     default:
-      return { replay_outcome: "skipped", error_message: `unknown tool: ${call.tool}` };
+      return { replay_outcome: 'skipped', error_message: `unknown tool: ${call.tool}` };
   }
 }
 
@@ -252,9 +296,9 @@ new acp.AgentSideConnection(
     async prompt(params) {
       // Extract text from the prompt content blocks
       const userText = params.prompt
-        .filter((block): block is { type: "text"; text: string } => block.type === "text")
+        .filter((block): block is { type: 'text'; text: string } => block.type === 'text')
         .map((block) => block.text)
-        .join("");
+        .join('');
 
       // Parse the prompt text as a JSON array of ReplayToolCall
       let toolCalls: ReplayToolCall[];
@@ -265,16 +309,20 @@ new acp.AgentSideConnection(
         }
         toolCalls = parsed as ReplayToolCall[];
       } catch (err) {
-        const errMsg = err instanceof Error ? err.message : "Unknown parse error";
-        const preview = userText.length > 200 ? `${userText.slice(0, 200)}... [truncated]` : userText;
+        const errMsg = err instanceof Error ? err.message : 'Unknown parse error';
+        const preview =
+          userText.length > 200 ? `${userText.slice(0, 200)}... [truncated]` : userText;
         await connection.sessionUpdate({
           sessionId: params.sessionId,
           update: {
-            sessionUpdate: "agent_message_chunk",
-            content: { type: "text", text: `Error parsing ReplayToolCall[]: ${errMsg}\nInput: ${preview}` },
+            sessionUpdate: 'agent_message_chunk',
+            content: {
+              type: 'text',
+              text: `Error parsing ReplayToolCall[]: ${errMsg}\nInput: ${preview}`,
+            },
           },
         });
-        return { stopReason: "end_turn" };
+        return { stopReason: 'end_turn' };
       }
 
       // Execute each tool call and emit results
@@ -295,10 +343,10 @@ new acp.AgentSideConnection(
         await connection.sessionUpdate({
           sessionId: params.sessionId,
           update: {
-            sessionUpdate: "tool_call",
+            sessionUpdate: 'tool_call',
             toolCallId,
             title: `[replay] ${call.tool}`,
-            status: "completed",
+            status: 'completed',
             rawInput: call.input,
             rawOutput: JSON.stringify(result),
             _meta: {
@@ -313,15 +361,15 @@ new acp.AgentSideConnection(
       await connection.sessionUpdate({
         sessionId: params.sessionId,
         update: {
-          sessionUpdate: "agent_message_chunk",
+          sessionUpdate: 'agent_message_chunk',
           content: {
-            type: "text",
+            type: 'text',
             text: `Replay complete: ${toolCalls.length} call(s) — ${counts.allowed} allowed, ${counts.blocked} blocked, ${counts.skipped} skipped, ${counts.error} error. Worktree: ${WORKTREE_PATH}`,
           },
         },
       });
 
-      return { stopReason: "end_turn" };
+      return { stopReason: 'end_turn' };
     },
 
     async cancel(_params) {
@@ -336,7 +384,7 @@ new acp.AgentSideConnection(
       return {};
     },
   }),
-  stream
+  stream,
 );
 
 process.stderr.write(`Replay agent started (worktree: ${WORKTREE_PATH})\n`);

--- a/src/main/container-monitor.ts
+++ b/src/main/container-monitor.ts
@@ -7,10 +7,10 @@
  * parsing and don't need a separate monitor.
  */
 
-import { spawn, type ChildProcess } from "node:child_process";
-import { EventEmitter } from "node:events";
-import { createInterface, type Interface as ReadlineInterface } from "node:readline";
-import type { SandboxMonitorEvents } from "./sandbox-monitor.js";
+import { spawn, type ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { createInterface, type Interface as ReadlineInterface } from 'node:readline';
+import type { SandboxMonitorEvents } from './sandbox-monitor.js';
 
 export class ContainerMonitor extends EventEmitter<SandboxMonitorEvents> {
   private dockerProcess: ChildProcess | null = null;
@@ -24,25 +24,21 @@ export class ContainerMonitor extends EventEmitter<SandboxMonitorEvents> {
     this.stop();
 
     this.dockerProcess = spawn(
-      "docker",
-      [
-        "events",
-        "--filter", `container=${containerName}`,
-        "--format", "{{json .}}",
-      ],
-      { stdio: ["ignore", "pipe", "ignore"] },
+      'docker',
+      ['events', '--filter', `container=${containerName}`, '--format', '{{json .}}'],
+      { stdio: ['ignore', 'pipe', 'ignore'] },
     );
 
     this.rl = createInterface({ input: this.dockerProcess.stdout! });
-    this.rl.on("line", (line) => {
+    this.rl.on('line', (line) => {
       this.parseEvent(line, containerName);
     });
 
-    this.dockerProcess.on("error", (err) => {
+    this.dockerProcess.on('error', (err) => {
       console.warn(`[container-monitor] docker events error: ${err.message}`);
     });
 
-    this.dockerProcess.on("exit", (code) => {
+    this.dockerProcess.on('exit', (code) => {
       if (code !== null && code !== 0) {
         console.warn(`[container-monitor] docker events exited with code ${code}`);
       }
@@ -70,29 +66,27 @@ export class ContainerMonitor extends EventEmitter<SandboxMonitorEvents> {
         Actor?: { Attributes?: Record<string, string> };
       };
 
-      const action = event.Action ?? event.status ?? "";
+      const action = event.Action ?? event.status ?? '';
       // Use event timestamp from Docker when available
-      const timestamp = event.time
-        ? new Date(event.time * 1000)
-        : new Date();
+      const timestamp = event.time ? new Date(event.time * 1000) : new Date();
 
       // OOM kill
-      if (action === "oom") {
-        this.emit("violation", {
+      if (action === 'oom') {
+        this.emit('violation', {
           timestamp,
           pid: 0,
           processName: containerName,
-          operation: "oom-kill",
+          operation: 'oom-kill',
           path: undefined,
           raw: line,
         });
       }
 
       // Unexpected die (non-zero exit)
-      if (action === "die") {
+      if (action === 'die') {
         const exitCode = event.Actor?.Attributes?.exitCode;
-        if (exitCode && exitCode !== "0") {
-          this.emit("violation", {
+        if (exitCode && exitCode !== '0') {
+          this.emit('violation', {
             timestamp,
             pid: 0,
             processName: containerName,

--- a/src/main/container.ts
+++ b/src/main/container.ts
@@ -5,16 +5,16 @@
  * Phase 2: container spawn, teardown, and orphan cleanup.
  */
 
-import { execFile, spawn, ChildProcess } from "node:child_process";
-import { promisify } from "node:util";
-import { readFile } from "node:fs/promises";
-import { createHash } from "node:crypto";
-import { join, dirname } from "node:path";
+import { execFile, spawn, ChildProcess } from 'node:child_process';
+import { promisify } from 'node:util';
+import { readFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { join, dirname } from 'node:path';
 
 const execFileAsync = promisify(execFile);
 
-export const AGENT_IMAGE_PREFIX = "bouncer-agent";
-const CONTAINER_PREFIX = "bouncer";
+export const AGENT_IMAGE_PREFIX = 'bouncer-agent';
+const CONTAINER_PREFIX = 'bouncer';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -33,7 +33,7 @@ export interface ContainerConfig {
   workdir: string;
   mounts: ContainerMount[];
   env: Record<string, string>;
-  networkMode: "none" | "bridge" | "proxy";
+  networkMode: 'none' | 'bridge' | 'proxy';
   /** Docker network name (required when networkMode is "proxy") */
   networkName?: string;
 }
@@ -63,7 +63,7 @@ export async function isDockerAvailable(): Promise<boolean> {
     return false;
   }
   try {
-    await execFileAsync("docker", ["info"], { timeout: 10_000 });
+    await execFileAsync('docker', ['info'], { timeout: 10_000 });
     _dockerAvailable = true;
   } catch {
     _dockerAvailable = false;
@@ -77,21 +77,21 @@ export async function isDockerAvailable(): Promise<boolean> {
 // ---------------------------------------------------------------------------
 
 async function resolveDockerfilePath(): Promise<string> {
-  const { app } = await import("electron");
+  const { app } = await import('electron');
   if (app.isPackaged) {
-    return join(process.resourcesPath, "docker", "agent.Dockerfile");
+    return join(process.resourcesPath, 'docker', 'agent.Dockerfile');
   }
-  return join(app.getAppPath(), "docker", "agent.Dockerfile");
+  return join(app.getAppPath(), 'docker', 'agent.Dockerfile');
 }
 
 export async function ensureAgentImage(): Promise<string> {
   const dockerfilePath = await resolveDockerfilePath();
-  const content = await readFile(dockerfilePath, "utf-8");
-  const hash = createHash("sha256").update(content).digest("hex").slice(0, 12);
+  const content = await readFile(dockerfilePath, 'utf-8');
+  const hash = createHash('sha256').update(content).digest('hex').slice(0, 12);
   const imageTag = `${AGENT_IMAGE_PREFIX}:${hash}`;
 
   try {
-    await execFileAsync("docker", ["image", "inspect", imageTag], {
+    await execFileAsync('docker', ['image', 'inspect', imageTag], {
       timeout: 10_000,
     });
     console.log(`[container] Image ${imageTag} already exists, skipping build`);
@@ -102,11 +102,9 @@ export async function ensureAgentImage(): Promise<string> {
 
   const dockerDir = dirname(dockerfilePath);
   console.log(`[container] Building image ${imageTag}...`);
-  await execFileAsync(
-    "docker",
-    ["build", "-t", imageTag, "-f", dockerfilePath, dockerDir],
-    { timeout: 600_000 },
-  );
+  await execFileAsync('docker', ['build', '-t', imageTag, '-f', dockerfilePath, dockerDir], {
+    timeout: 600_000,
+  });
   console.log(`[container] Image ${imageTag} built successfully`);
   return imageTag;
 }
@@ -127,35 +125,38 @@ function containerName(sessionId: string): string {
 export function buildDockerRunArgs(config: ContainerConfig): string[] {
   const name = containerName(config.sessionId);
   const args: string[] = [
-    "run", "-i", "--rm",
-    "--name", name,
-    "--label", "bouncer.managed=true",
-    "--label", `bouncer.sessionId=${config.sessionId}`,
+    'run',
+    '-i',
+    '--rm',
+    '--name',
+    name,
+    '--label',
+    'bouncer.managed=true',
+    '--label',
+    `bouncer.sessionId=${config.sessionId}`,
   ];
 
   for (const m of config.mounts) {
     const flag = m.readOnly
       ? `${m.hostPath}:${m.containerPath}:ro`
       : `${m.hostPath}:${m.containerPath}`;
-    args.push("-v", flag);
+    args.push('-v', flag);
   }
 
   for (const [key, value] of Object.entries(config.env)) {
-    args.push("-e", `${key}=${value}`);
+    args.push('-e', `${key}=${value}`);
   }
 
-  args.push("-w", config.workdir);
-  if (config.networkMode === "proxy") {
+  args.push('-w', config.workdir);
+  if (config.networkMode === 'proxy') {
     if (!config.networkName) {
-      throw new Error(
-        'ContainerConfig.networkName is required when networkMode is "proxy"',
-      );
+      throw new Error('ContainerConfig.networkName is required when networkMode is "proxy"');
     }
-    args.push("--network", config.networkName);
+    args.push('--network', config.networkName);
     // Ensure host.docker.internal resolves on Linux Docker engines
-    args.push("--add-host=host.docker.internal:host-gateway");
+    args.push('--add-host=host.docker.internal:host-gateway');
   } else {
-    args.push("--network", config.networkMode);
+    args.push('--network', config.networkMode);
   }
   args.push(config.image);
   args.push(...config.command);
@@ -170,11 +171,11 @@ export function spawnContainer(config: ContainerConfig): ContainerHandle {
   const args = buildDockerRunArgs(config);
   const name = containerName(config.sessionId);
 
-  const proc = spawn("docker", args, {
-    stdio: ["pipe", "pipe", "pipe"],
+  const proc = spawn('docker', args, {
+    stdio: ['pipe', 'pipe', 'pipe'],
   });
 
-  proc.on("error", (err) => {
+  proc.on('error', (err) => {
     console.error(`[container] Failed to spawn docker process for ${name}:`, err);
   });
 
@@ -185,7 +186,7 @@ export function spawnContainer(config: ContainerConfig): ContainerHandle {
       proc.kill();
       // Force-remove in case the process doesn't exit cleanly.
       // Fire-and-forget — removeContainer is idempotent.
-      execFileAsync("docker", ["rm", "-f", name]).catch(() => {});
+      execFileAsync('docker', ['rm', '-f', name]).catch(() => {});
     },
   };
 }
@@ -197,7 +198,7 @@ export function spawnContainer(config: ContainerConfig): ContainerHandle {
 export async function removeContainer(sessionId: string): Promise<void> {
   const name = containerName(sessionId);
   try {
-    await execFileAsync("docker", ["rm", "-f", name], { timeout: 10_000 });
+    await execFileAsync('docker', ['rm', '-f', name], { timeout: 10_000 });
   } catch {
     // Container already gone — fine
   }
@@ -207,28 +208,33 @@ export async function removeContainer(sessionId: string): Promise<void> {
  * Find and remove any bouncer containers that don't belong to active
  * sessions. Called at startup to clean up after crashes.
  */
-export async function cleanupOrphanContainers(
-  activeSessionIds: Set<string>,
-): Promise<void> {
+export async function cleanupOrphanContainers(activeSessionIds: Set<string>): Promise<void> {
   let stdout: string;
   try {
-    const result = await execFileAsync("docker", [
-      "ps", "-a",
-      "--filter", "label=bouncer.managed=true",
-      "--format", "{{.Label \"bouncer.sessionId\"}}\t{{.Names}}",
-    ], { timeout: 10_000 });
+    const result = await execFileAsync(
+      'docker',
+      [
+        'ps',
+        '-a',
+        '--filter',
+        'label=bouncer.managed=true',
+        '--format',
+        '{{.Label "bouncer.sessionId"}}\t{{.Names}}',
+      ],
+      { timeout: 10_000 },
+    );
     stdout = result.stdout;
   } catch {
     return; // Docker not available or error — nothing to clean up
   }
 
-  const lines = stdout.trim().split("\n").filter(Boolean);
+  const lines = stdout.trim().split('\n').filter(Boolean);
   for (const line of lines) {
-    const [sessionId, name] = line.split("\t");
+    const [sessionId, name] = line.split('\t');
     if (sessionId && name && !activeSessionIds.has(sessionId)) {
       console.log(`[container] Removing orphan container: ${name}`);
       try {
-        await execFileAsync("docker", ["rm", "-f", name], { timeout: 10_000 });
+        await execFileAsync('docker', ['rm', '-f', name], { timeout: 10_000 });
       } catch {
         console.warn(`[container] Failed to remove orphan container: ${name}`);
       }

--- a/src/main/dataset-loader.ts
+++ b/src/main/dataset-loader.ts
@@ -1,6 +1,6 @@
-import { createReadStream } from "node:fs";
-import { createInterface } from "node:readline";
-import type { ReplayToolCall } from "./types.js";
+import { createReadStream } from 'node:fs';
+import { createInterface } from 'node:readline';
+import type { ReplayToolCall } from './types.js';
 
 interface DatasetRecord {
   id: number;
@@ -28,13 +28,11 @@ function toReplayToolCall(record: DatasetRecord): ReplayToolCall {
  * Load the dataset and group records by session.
  * Returns a Map from session ID to sorted tool-call array.
  */
-export async function loadDataset(
-  datasetPath: string,
-): Promise<Map<string, ReplayToolCall[]>> {
+export async function loadDataset(datasetPath: string): Promise<Map<string, ReplayToolCall[]>> {
   const sessions = new Map<string, { calls: ReplayToolCall[]; timestamps: number[] }>();
 
   const rl = createInterface({
-    input: createReadStream(datasetPath, "utf-8"),
+    input: createReadStream(datasetPath, 'utf-8'),
     crlfDelay: Infinity,
   });
 
@@ -55,7 +53,10 @@ export async function loadDataset(
   for (const [sessionId, { calls, timestamps }] of sessions) {
     const indices = calls.map((_, i) => i);
     indices.sort((a, b) => timestamps[a] - timestamps[b]);
-    result.set(sessionId, indices.map((i) => calls[i]));
+    result.set(
+      sessionId,
+      indices.map((i) => calls[i]),
+    );
   }
 
   return result;
@@ -74,7 +75,7 @@ export async function loadSession(
   const timestamps: number[] = [];
 
   const rl = createInterface({
-    input: createReadStream(datasetPath, "utf-8"),
+    input: createReadStream(datasetPath, 'utf-8'),
     crlfDelay: Infinity,
   });
 
@@ -103,13 +104,11 @@ export interface SessionInfo {
  * List sessions with basic metadata.
  * Requires a second pass over the raw dataset to extract project info.
  */
-export async function listSessions(
-  datasetPath: string,
-): Promise<SessionInfo[]> {
+export async function listSessions(datasetPath: string): Promise<SessionInfo[]> {
   const sessionMap = new Map<string, { project: string; callCount: number; tools: Set<string> }>();
 
   const rl = createInterface({
-    input: createReadStream(datasetPath, "utf-8"),
+    input: createReadStream(datasetPath, 'utf-8'),
     crlfDelay: Infinity,
   });
 
@@ -136,9 +135,11 @@ export async function listSessions(
 /**
  * Get summary statistics for the loaded dataset.
  */
-export function datasetSummary(
-  sessions: Map<string, ReplayToolCall[]>,
-): { sessionCount: number; recordCount: number; toolDistribution: Record<string, number> } {
+export function datasetSummary(sessions: Map<string, ReplayToolCall[]>): {
+  sessionCount: number;
+  recordCount: number;
+  toolDistribution: Record<string, number>;
+} {
   let recordCount = 0;
   const toolDistribution: Record<string, number> = {};
 

--- a/src/main/gh-credential-helper.ts
+++ b/src/main/gh-credential-helper.ts
@@ -16,17 +16,19 @@
 
 function readStdin(): Promise<string> {
   return new Promise((resolve) => {
-    let data = "";
-    process.stdin.setEncoding("utf-8");
-    process.stdin.on("data", (chunk: string) => { data += chunk; });
-    process.stdin.on("end", () => resolve(data));
+    let data = '';
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', (chunk: string) => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
   });
 }
 
 function parseCredentialInput(input: string): Record<string, string> {
   const kv: Record<string, string> = {};
   for (const line of input.split(/\r?\n/)) {
-    const idx = line.indexOf("=");
+    const idx = line.indexOf('=');
     if (idx === -1) continue;
     const key = line.slice(0, idx).trim();
     const value = line.slice(idx + 1).trim();
@@ -37,7 +39,7 @@ function parseCredentialInput(input: string): Record<string, string> {
 
 async function main(): Promise<void> {
   // Only respond to "get" requests
-  if (process.argv[2] !== "get") {
+  if (process.argv[2] !== 'get') {
     process.exit(0);
   }
 
@@ -45,17 +47,17 @@ async function main(): Promise<void> {
   const kv = parseCredentialInput(input);
 
   // Exact host match — prevent github.com.evil.com from matching
-  if (kv["host"] !== "github.com") {
+  if (kv['host'] !== 'github.com') {
     process.exit(0);
   }
-  if (kv["protocol"] && kv["protocol"] !== "https") {
+  if (kv['protocol'] && kv['protocol'] !== 'https') {
     process.exit(0);
   }
 
   const token = process.env.GH_TOKEN;
   if (!token) {
     // Exit 0 with no output so git can fall back to other helpers
-    process.stderr.write("gh-credential-helper: GH_TOKEN is not set\n");
+    process.stderr.write('gh-credential-helper: GH_TOKEN is not set\n');
     process.exit(0);
   }
 

--- a/src/main/gh-shim.ts
+++ b/src/main/gh-shim.ts
@@ -11,16 +11,16 @@
  * then either execs real gh or exits with a policy error.
  */
 
-import { execFileSync } from "node:child_process";
-import { readPolicyState, writePolicyState } from "./github-policy.js";
-import type { GitHubPolicy } from "./types.js";
+import { execFileSync } from 'node:child_process';
+import { readPolicyState, writePolicyState } from './github-policy.js';
+import type { GitHubPolicy } from './types.js';
 import {
   parseApiEndpoint,
   evaluateApiPulls,
   evaluateApiIssues,
   type ApiEndpointMatch,
   type PolicyDecision,
-} from "./github-policy-engine.js";
+} from './github-policy-engine.js';
 
 // Re-export types and functions that tests import from this module
 export { parseApiEndpoint, type ApiEndpointMatch, type PolicyDecision };
@@ -47,20 +47,33 @@ export interface ParsedGhCommand {
 
 /** Commands that have subcommands. */
 const COMMANDS_WITH_SUBCOMMANDS = new Set([
-  "pr", "issue", "repo", "release", "run", "workflow", "gist",
+  'pr',
+  'issue',
+  'repo',
+  'release',
+  'run',
+  'workflow',
+  'gist',
 ]);
 
 /** Flags that consume the next argument as their value. */
 const FLAGS_WITH_VALUES = new Set([
-  "-R", "--repo", "--method", "-X",
-  "--title", "--body", "--base", "--head",
-  "-f", "--field", "-F", "--raw-field",
+  '-R',
+  '--repo',
+  '--method',
+  '-X',
+  '--title',
+  '--body',
+  '--base',
+  '--head',
+  '-f',
+  '--field',
+  '-F',
+  '--raw-field',
 ]);
 
 /** Flags whose presence implies a POST body. */
-const BODY_PARAM_FLAGS = new Set([
-  "-f", "-F", "--field", "--raw-field",
-]);
+const BODY_PARAM_FLAGS = new Set(['-f', '-F', '--field', '--raw-field']);
 
 /**
  * Try to extract a flag value from a single argument using = or short-flag syntax.
@@ -74,7 +87,7 @@ function tryExtractInlineFlag(arg: string): { flag: string; value: string } | nu
     return { flag: eqMatch[1], value: eqMatch[2] };
   }
   // -Rvalue, -Xvalue (short flags with value concatenated)
-  if (arg.length > 2 && arg[0] === "-" && arg[1] !== "-") {
+  if (arg.length > 2 && arg[0] === '-' && arg[1] !== '-') {
     const shortFlag = arg.substring(0, 2);
     if (FLAGS_WITH_VALUES.has(shortFlag)) {
       return { flag: shortFlag, value: arg.substring(2) };
@@ -89,7 +102,7 @@ function tryExtractInlineFlag(arg: string): { flag: string; value: string } | nu
  */
 export function parseGhArgs(args: string[]): ParsedGhCommand {
   const result: ParsedGhCommand = {
-    command: "",
+    command: '',
     subcommand: null,
     positionalArgs: [],
     flags: { fields: [] },
@@ -99,15 +112,15 @@ export function parseGhArgs(args: string[]): ParsedGhCommand {
   let i = 0;
 
   // Skip global flags before the command
-  while (i < args.length && args[i].startsWith("-")) {
+  while (i < args.length && args[i].startsWith('-')) {
     const flag = args[i];
     // Global flags like --help, --version become the "command"
-    if (flag === "--help" || flag === "--version") {
+    if (flag === '--help' || flag === '--version') {
       result.command = flag;
       return result;
     }
     // -R / --repo with separate value
-    if ((flag === "-R" || flag === "--repo") && i + 1 < args.length) {
+    if ((flag === '-R' || flag === '--repo') && i + 1 < args.length) {
       result.flags.repo = args[i + 1];
       i += 2;
       continue;
@@ -123,7 +136,7 @@ export function parseGhArgs(args: string[]): ParsedGhCommand {
   }
 
   if (i >= args.length) {
-    result.command = "--help"; // bare "gh" acts like --help
+    result.command = '--help'; // bare "gh" acts like --help
     return result;
   }
 
@@ -134,10 +147,10 @@ export function parseGhArgs(args: string[]): ParsedGhCommand {
   // If this command has subcommands, next non-flag arg is the subcommand
   if (COMMANDS_WITH_SUBCOMMANDS.has(result.command)) {
     // Skip flags to find the subcommand, but treat --help as the subcommand
-    while (i < args.length && args[i].startsWith("-")) {
+    while (i < args.length && args[i].startsWith('-')) {
       const flag = args[i];
-      if (flag === "--help") {
-        result.subcommand = "--help";
+      if (flag === '--help') {
+        result.subcommand = '--help';
         i++;
         break;
       }
@@ -164,7 +177,7 @@ export function parseGhArgs(args: string[]): ParsedGhCommand {
   // Parse remaining args
   while (i < args.length) {
     const arg = args[i];
-    if (arg.startsWith("-")) {
+    if (arg.startsWith('-')) {
       if (FLAGS_WITH_VALUES.has(arg) && i + 1 < args.length) {
         extractFlag(result, arg, args[i + 1]);
         i += 2;
@@ -189,32 +202,32 @@ export function parseGhArgs(args: string[]): ParsedGhCommand {
 
 function extractFlag(result: ParsedGhCommand, flag: string, value: string): void {
   switch (flag) {
-    case "-R":
-    case "--repo":
+    case '-R':
+    case '--repo':
       result.flags.repo = value;
       break;
-    case "--method":
-    case "-X":
+    case '--method':
+    case '-X':
       result.flags.method = value;
       break;
-    case "--title":
+    case '--title':
       result.flags.title = value;
       break;
-    case "--body":
+    case '--body':
       result.flags.body = value;
       break;
-    case "--base":
+    case '--base':
       result.flags.base = value;
       break;
-    case "--head":
+    case '--head':
       result.flags.head = value;
       break;
-    case "-f":
-    case "--field":
-    case "-F":
-    case "--raw-field": {
+    case '-f':
+    case '--field':
+    case '-F':
+    case '--raw-field': {
       result.flags.hasBodyParams = true;
-      const eqIdx = value.indexOf("=");
+      const eqIdx = value.indexOf('=');
       if (eqIdx !== -1) {
         result.flags.fields.push({ key: value.slice(0, eqIdx), value: value.slice(eqIdx + 1) });
       }
@@ -228,97 +241,105 @@ function extractFlag(result: ParsedGhCommand, flag: string, value: string): void
 /**
  * Evaluate a parsed gh command against the session policy.
  */
-export function evaluatePolicy(
-  parsed: ParsedGhCommand,
-  policy: GitHubPolicy,
-): PolicyDecision {
+export function evaluatePolicy(parsed: ParsedGhCommand, policy: GitHubPolicy): PolicyDecision {
   const { command, subcommand } = parsed;
 
   // Global help/version — always allow
-  if (command === "--help" || command === "--version") {
-    return { action: "allow" };
+  if (command === '--help' || command === '--version') {
+    return { action: 'allow' };
   }
 
   // Check -R flag: if targeting a different repo, deny
   if (parsed.flags.repo && parsed.flags.repo !== policy.repo) {
-    return { action: "deny", reason: `cross-repo access denied: '${parsed.flags.repo}' (session repo: '${policy.repo}')` };
+    return {
+      action: 'deny',
+      reason: `cross-repo access denied: '${parsed.flags.repo}' (session repo: '${policy.repo}')`,
+    };
   }
 
   switch (command) {
-    case "pr":
+    case 'pr':
       return evaluatePrPolicy(subcommand, parsed.positionalArgs, policy);
-    case "issue":
+    case 'issue':
       return evaluateIssuePolicy(subcommand);
-    case "repo":
+    case 'repo':
       return evaluateRepoPolicy(subcommand);
-    case "release":
+    case 'release':
       return evaluateReleasePolicy(subcommand);
-    case "run":
+    case 'run':
       return evaluateRunPolicy(subcommand);
-    case "workflow":
+    case 'workflow':
       return evaluateWorkflowPolicy(subcommand);
-    case "api":
+    case 'api':
       return evaluateApiPolicy(parsed.positionalArgs, parsed.flags, policy);
-    case "search":
-    case "browse":
-    case "status":
-      return { action: "allow" };
-    case "auth":
-      return { action: "deny", reason: "auth commands are not allowed" };
-    case "config":
-      return { action: "deny", reason: "config commands are not allowed" };
-    case "gist":
-      return { action: "deny", reason: "gist commands are not allowed" };
-    case "codespace":
-      return { action: "deny", reason: "codespace commands are not allowed" };
-    case "ssh-key":
-    case "gpg-key":
-      return { action: "deny", reason: "credential management is not allowed" };
-    case "secret":
-    case "variable":
-      return { action: "deny", reason: "repository settings commands are not allowed" };
-    case "label":
-      return { action: "deny", reason: "label commands are not allowed" };
-    case "extension":
-      return { action: "deny", reason: "extension commands are not allowed" };
+    case 'search':
+    case 'browse':
+    case 'status':
+      return { action: 'allow' };
+    case 'auth':
+      return { action: 'deny', reason: 'auth commands are not allowed' };
+    case 'config':
+      return { action: 'deny', reason: 'config commands are not allowed' };
+    case 'gist':
+      return { action: 'deny', reason: 'gist commands are not allowed' };
+    case 'codespace':
+      return { action: 'deny', reason: 'codespace commands are not allowed' };
+    case 'ssh-key':
+    case 'gpg-key':
+      return { action: 'deny', reason: 'credential management is not allowed' };
+    case 'secret':
+    case 'variable':
+      return { action: 'deny', reason: 'repository settings commands are not allowed' };
+    case 'label':
+      return { action: 'deny', reason: 'label commands are not allowed' };
+    case 'extension':
+      return { action: 'deny', reason: 'extension commands are not allowed' };
     default:
-      return { action: "deny", reason: `command '${command}' is not allowed` };
+      return { action: 'deny', reason: `command '${command}' is not allowed` };
   }
 }
 
 // --- PR Policy ---
 
-const PR_READ_ONLY = new Set(["view", "list", "status", "checks", "diff"]);
-const PR_OWNED_ONLY = new Set(["edit", "comment", "ready", "update-branch"]);
-const PR_ALWAYS_DENY = new Set(["checkout", "close", "merge", "reopen", "review", "lock", "unlock"]);
+const PR_READ_ONLY = new Set(['view', 'list', 'status', 'checks', 'diff']);
+const PR_OWNED_ONLY = new Set(['edit', 'comment', 'ready', 'update-branch']);
+const PR_ALWAYS_DENY = new Set([
+  'checkout',
+  'close',
+  'merge',
+  'reopen',
+  'review',
+  'lock',
+  'unlock',
+]);
 
 function evaluatePrPolicy(
   subcommand: string | null,
   positionalArgs: string[],
   policy: GitHubPolicy,
 ): PolicyDecision {
-  if (!subcommand || subcommand === "--help") return { action: "allow" };
+  if (!subcommand || subcommand === '--help') return { action: 'allow' };
 
   if (PR_ALWAYS_DENY.has(subcommand)) {
-    return { action: "deny", reason: `'pr ${subcommand}' is not allowed` };
+    return { action: 'deny', reason: `'pr ${subcommand}' is not allowed` };
   }
 
-  if (subcommand === "create") {
+  if (subcommand === 'create') {
     if (!policy.canCreatePr) {
-      return { action: "deny", reason: "PR already created for this session" };
+      return { action: 'deny', reason: 'PR already created for this session' };
     }
-    return { action: "allow-and-capture-pr" };
+    return { action: 'allow-and-capture-pr' };
   }
 
   if (PR_READ_ONLY.has(subcommand)) {
-    return { action: "allow" };
+    return { action: 'allow' };
   }
 
   if (PR_OWNED_ONLY.has(subcommand)) {
     return checkOwnedPr(positionalArgs, policy, subcommand);
   }
 
-  return { action: "deny", reason: `'pr ${subcommand}' is not allowed` };
+  return { action: 'deny', reason: `'pr ${subcommand}' is not allowed` };
 }
 
 /**
@@ -334,16 +355,16 @@ function checkOwnedPr(
   if (targetPr === null) {
     // No explicit PR number — only allow if the session has an owned PR
     if (policy.ownedPrNumber === null) {
-      return { action: "deny", reason: `'pr ${subcommand}' denied: no owned PR for this session` };
+      return { action: 'deny', reason: `'pr ${subcommand}' denied: no owned PR for this session` };
     }
-    return { action: "allow" };
+    return { action: 'allow' };
   }
   if (policy.ownedPrNumber !== null && targetPr === policy.ownedPrNumber) {
-    return { action: "allow" };
+    return { action: 'allow' };
   }
   return {
-    action: "deny",
-    reason: `'pr ${subcommand}' denied: PR #${targetPr} is not owned by this session (owned: #${policy.ownedPrNumber ?? "none"})`,
+    action: 'deny',
+    reason: `'pr ${subcommand}' denied: PR #${targetPr} is not owned by this session (owned: #${policy.ownedPrNumber ?? 'none'})`,
   };
 }
 
@@ -357,98 +378,101 @@ function extractTargetPrNumber(positionalArgs: string[]): number | null {
 
 // --- Issue Policy ---
 
-const ISSUE_READ_ONLY = new Set(["view", "list", "status"]);
+const ISSUE_READ_ONLY = new Set(['view', 'list', 'status']);
 
 function evaluateIssuePolicy(subcommand: string | null): PolicyDecision {
-  if (!subcommand || subcommand === "--help") return { action: "allow" };
-  if (ISSUE_READ_ONLY.has(subcommand)) return { action: "allow" };
-  return { action: "deny", reason: `'issue ${subcommand}' is not allowed` };
+  if (!subcommand || subcommand === '--help') return { action: 'allow' };
+  if (ISSUE_READ_ONLY.has(subcommand)) return { action: 'allow' };
+  return { action: 'deny', reason: `'issue ${subcommand}' is not allowed` };
 }
 
 // --- Repo Policy ---
 
 function evaluateRepoPolicy(subcommand: string | null): PolicyDecision {
-  if (!subcommand || subcommand === "--help") return { action: "allow" };
-  if (subcommand === "view") return { action: "allow" };
-  return { action: "deny", reason: `'repo ${subcommand}' is not allowed` };
+  if (!subcommand || subcommand === '--help') return { action: 'allow' };
+  if (subcommand === 'view') return { action: 'allow' };
+  return { action: 'deny', reason: `'repo ${subcommand}' is not allowed` };
 }
 
 // --- Release Policy ---
 
-const RELEASE_READ_ONLY = new Set(["list", "view"]);
+const RELEASE_READ_ONLY = new Set(['list', 'view']);
 
 function evaluateReleasePolicy(subcommand: string | null): PolicyDecision {
-  if (!subcommand || subcommand === "--help") return { action: "allow" };
-  if (RELEASE_READ_ONLY.has(subcommand)) return { action: "allow" };
-  return { action: "deny", reason: `'release ${subcommand}' is not allowed` };
+  if (!subcommand || subcommand === '--help') return { action: 'allow' };
+  if (RELEASE_READ_ONLY.has(subcommand)) return { action: 'allow' };
+  return { action: 'deny', reason: `'release ${subcommand}' is not allowed` };
 }
 
 // --- Run Policy ---
 
-const RUN_READ_ONLY = new Set(["view", "list"]);
+const RUN_READ_ONLY = new Set(['view', 'list']);
 
 function evaluateRunPolicy(subcommand: string | null): PolicyDecision {
-  if (!subcommand || subcommand === "--help") return { action: "allow" };
-  if (RUN_READ_ONLY.has(subcommand)) return { action: "allow" };
-  return { action: "deny", reason: `'run ${subcommand}' is not allowed` };
+  if (!subcommand || subcommand === '--help') return { action: 'allow' };
+  if (RUN_READ_ONLY.has(subcommand)) return { action: 'allow' };
+  return { action: 'deny', reason: `'run ${subcommand}' is not allowed` };
 }
 
 // --- Workflow Policy ---
 
-const WORKFLOW_READ_ONLY = new Set(["view", "list"]);
+const WORKFLOW_READ_ONLY = new Set(['view', 'list']);
 
 function evaluateWorkflowPolicy(subcommand: string | null): PolicyDecision {
-  if (!subcommand || subcommand === "--help") return { action: "allow" };
-  if (WORKFLOW_READ_ONLY.has(subcommand)) return { action: "allow" };
-  return { action: "deny", reason: `'workflow ${subcommand}' is not allowed` };
+  if (!subcommand || subcommand === '--help') return { action: 'allow' };
+  if (WORKFLOW_READ_ONLY.has(subcommand)) return { action: 'allow' };
+  return { action: 'deny', reason: `'workflow ${subcommand}' is not allowed` };
 }
 
 // --- API Policy ---
 
 function evaluateApiPolicy(
   positionalArgs: string[],
-  flags: ParsedGhCommand["flags"],
+  flags: ParsedGhCommand['flags'],
   policy: GitHubPolicy,
 ): PolicyDecision {
   const endpoint = positionalArgs[0];
   if (!endpoint) {
-    return { action: "deny", reason: "gh api requires an endpoint argument" };
+    return { action: 'deny', reason: 'gh api requires an endpoint argument' };
   }
 
   const match = parseApiEndpoint(endpoint, flags);
 
   // GraphQL: allow but flag as unaudited (query content not inspected)
   if (match.isGraphQL) {
-    return { action: "allow" };
+    return { action: 'allow' };
   }
 
   // DELETE is always denied
-  if (match.method === "DELETE") {
-    return { action: "deny", reason: "DELETE requests are not allowed" };
+  if (match.method === 'DELETE') {
+    return { action: 'deny', reason: 'DELETE requests are not allowed' };
   }
 
   // Check repo scope for /repos/ endpoints
   if (match.ownerRepo !== null && match.ownerRepo !== policy.repo) {
-    return { action: "deny", reason: `cross-repo API access denied: '${match.ownerRepo}' (session repo: '${policy.repo}')` };
+    return {
+      action: 'deny',
+      reason: `cross-repo API access denied: '${match.ownerRepo}' (session repo: '${policy.repo}')`,
+    };
   }
 
   // /repos/{owner}/{repo} (repo metadata)
-  if (match.resource === "" && match.method === "GET") {
-    return { action: "allow" };
+  if (match.resource === '' && match.method === 'GET') {
+    return { action: 'allow' };
   }
 
   // /repos/{owner}/{repo}/pulls
-  if (match.resource === "pulls") {
+  if (match.resource === 'pulls') {
     return evaluateApiPulls(match, policy);
   }
 
   // /repos/{owner}/{repo}/issues
-  if (match.resource === "issues") {
+  if (match.resource === 'issues') {
     return evaluateApiIssues(match);
   }
 
   // Unrecognized API endpoint — deny
-  return { action: "deny", reason: `API endpoint '${endpoint}' (${match.method}) is not allowed` };
+  return { action: 'deny', reason: `API endpoint '${endpoint}' (${match.method}) is not allowed` };
 }
 
 // --- Direct API Mode (Phase 6) ---
@@ -465,33 +489,32 @@ async function executeViaApi(
 ): Promise<void> {
   const token = process.env.GH_TOKEN;
   if (!token) {
-    process.stderr.write("[bouncer:gh] error: GH_TOKEN is required for API mode\n");
+    process.stderr.write('[bouncer:gh] error: GH_TOKEN is required for API mode\n');
     process.exit(1);
   }
 
   const { command, subcommand } = parsed;
 
-  if (command === "pr" && subcommand === "create") {
+  if (command === 'pr' && subcommand === 'create') {
     await apiPrCreate(parsed, policy, policyPath, token, decision);
-  } else if (command === "pr" && subcommand === "view") {
+  } else if (command === 'pr' && subcommand === 'view') {
     await apiPrView(parsed, policy, token);
-  } else if (command === "pr" && subcommand === "edit") {
+  } else if (command === 'pr' && subcommand === 'edit') {
     await apiPrEdit(parsed, policy, token);
-  } else if (command === "pr" && subcommand === "list") {
+  } else if (command === 'pr' && subcommand === 'list') {
     await apiPrList(policy, token);
-  } else if (command === "issue" && subcommand === "list") {
+  } else if (command === 'issue' && subcommand === 'list') {
     await apiIssueList(policy, token);
-  } else if (command === "issue" && subcommand === "view") {
+  } else if (command === 'issue' && subcommand === 'view') {
     await apiIssueView(parsed, policy, token);
-  } else if (command === "api") {
+  } else if (command === 'api') {
     await apiDirect(parsed, policy, token);
-  } else if (command === "--help" || command === "--version" ||
-             subcommand === "--help") {
+  } else if (command === '--help' || command === '--version' || subcommand === '--help') {
     // Help/version — just print a stub
     process.stdout.write(`gh shim (bouncer API mode)\n`);
   } else {
     process.stderr.write(
-      `error: 'gh ${command}${subcommand ? " " + subcommand : ""}' is not available in this sandbox environment\n`
+      `error: 'gh ${command}${subcommand ? ' ' + subcommand : ''}' is not available in this sandbox environment\n`,
     );
     process.exit(1);
   }
@@ -502,14 +525,14 @@ async function githubFetch(
   token: string,
   opts: { method?: string; body?: Record<string, unknown> } = {},
 ): Promise<unknown> {
-  const url = path.startsWith("http") ? path : `https://api.github.com${path}`;
+  const url = path.startsWith('http') ? path : `https://api.github.com${path}`;
   const resp = await fetch(url, {
-    method: opts.method ?? "GET",
+    method: opts.method ?? 'GET',
     headers: {
       Authorization: `Bearer ${token}`,
-      Accept: "application/vnd.github+json",
-      "X-GitHub-Api-Version": "2022-11-28",
-      ...(opts.body ? { "Content-Type": "application/json" } : {}),
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      ...(opts.body ? { 'Content-Type': 'application/json' } : {}),
     },
     body: opts.body ? JSON.stringify(opts.body) : undefined,
   });
@@ -531,13 +554,13 @@ async function apiPrCreate(
   decision: PolicyDecision,
 ): Promise<void> {
   if (!parsed.flags.head) {
-    process.stderr.write("[bouncer:gh] error: --head is required for pr create\n");
+    process.stderr.write('[bouncer:gh] error: --head is required for pr create\n');
     process.exit(1);
   }
 
   const body: Record<string, unknown> = {
-    title: parsed.flags.title ?? "Untitled PR",
-    body: parsed.flags.body ?? "",
+    title: parsed.flags.title ?? 'Untitled PR',
+    body: parsed.flags.body ?? '',
     head: parsed.flags.head,
   };
   // Only include base if explicitly provided — let GitHub default to the repo's default branch
@@ -545,15 +568,15 @@ async function apiPrCreate(
     body.base = parsed.flags.base;
   }
 
-  const data = await githubFetch(`/repos/${policy.repo}/pulls`, token, {
-    method: "POST",
+  const data = (await githubFetch(`/repos/${policy.repo}/pulls`, token, {
+    method: 'POST',
     body,
-  }) as { html_url: string; number: number };
+  })) as { html_url: string; number: number };
   // Print PR URL to stdout (same as real gh)
   process.stdout.write(`${data.html_url}\n`);
 
   // Capture PR number if policy requires it
-  if (decision.action === "allow-and-capture-pr") {
+  if (decision.action === 'allow-and-capture-pr') {
     const sessionId = deriveSessionId(policyPath);
     if (sessionId) {
       policy.canCreatePr = false;
@@ -571,11 +594,11 @@ async function apiPrView(
 ): Promise<void> {
   const prNumber = parsed.positionalArgs[0] ?? policy.ownedPrNumber;
   if (!prNumber) {
-    process.stderr.write("[bouncer:gh] error: PR number required\n");
+    process.stderr.write('[bouncer:gh] error: PR number required\n');
     process.exit(1);
   }
   const data = await githubFetch(`/repos/${policy.repo}/pulls/${prNumber}`, token);
-  process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+  process.stdout.write(JSON.stringify(data, null, 2) + '\n');
 }
 
 async function apiPrEdit(
@@ -585,7 +608,7 @@ async function apiPrEdit(
 ): Promise<void> {
   const prNumber = parsed.positionalArgs[0] ?? policy.ownedPrNumber;
   if (!prNumber) {
-    process.stderr.write("[bouncer:gh] error: PR number required\n");
+    process.stderr.write('[bouncer:gh] error: PR number required\n');
     process.exit(1);
   }
   const body: Record<string, unknown> = {};
@@ -593,26 +616,20 @@ async function apiPrEdit(
   if (parsed.flags.body) body.body = parsed.flags.body;
 
   const data = await githubFetch(`/repos/${policy.repo}/pulls/${prNumber}`, token, {
-    method: "PATCH",
+    method: 'PATCH',
     body,
   });
-  process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+  process.stdout.write(JSON.stringify(data, null, 2) + '\n');
 }
 
-async function apiPrList(
-  policy: GitHubPolicy,
-  token: string,
-): Promise<void> {
+async function apiPrList(policy: GitHubPolicy, token: string): Promise<void> {
   const data = await githubFetch(`/repos/${policy.repo}/pulls`, token);
-  process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+  process.stdout.write(JSON.stringify(data, null, 2) + '\n');
 }
 
-async function apiIssueList(
-  policy: GitHubPolicy,
-  token: string,
-): Promise<void> {
+async function apiIssueList(policy: GitHubPolicy, token: string): Promise<void> {
   const data = await githubFetch(`/repos/${policy.repo}/issues`, token);
-  process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+  process.stdout.write(JSON.stringify(data, null, 2) + '\n');
 }
 
 async function apiIssueView(
@@ -622,11 +639,11 @@ async function apiIssueView(
 ): Promise<void> {
   const issueNumber = parsed.positionalArgs[0];
   if (!issueNumber) {
-    process.stderr.write("[bouncer:gh] error: issue number required\n");
+    process.stderr.write('[bouncer:gh] error: issue number required\n');
     process.exit(1);
   }
   const data = await githubFetch(`/repos/${policy.repo}/issues/${issueNumber}`, token);
-  process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+  process.stdout.write(JSON.stringify(data, null, 2) + '\n');
 }
 
 async function apiDirect(
@@ -636,20 +653,20 @@ async function apiDirect(
 ): Promise<void> {
   const endpoint = parsed.positionalArgs[0];
   if (!endpoint) {
-    process.stderr.write("[bouncer:gh] error: API endpoint required\n");
+    process.stderr.write('[bouncer:gh] error: API endpoint required\n');
     process.exit(1);
   }
 
   // Expand {owner} and {repo} placeholders
   const expandedEndpoint = endpoint
-    .replace("{owner}", policy.repo.split("/")[0] ?? "")
-    .replace("{repo}", policy.repo.split("/")[1] ?? "");
+    .replace('{owner}', policy.repo.split('/')[0] ?? '')
+    .replace('{repo}', policy.repo.split('/')[1] ?? '');
 
   // Infer POST when body params are present (same as real gh / parseApiEndpoint)
-  let method = (parsed.flags.method ?? "GET").toUpperCase();
+  let method = (parsed.flags.method ?? 'GET').toUpperCase();
   let body: Record<string, unknown> | undefined;
   if (parsed.flags.fields.length > 0) {
-    if (method === "GET") method = "POST";
+    if (method === 'GET') method = 'POST';
     body = {};
     for (const { key, value } of parsed.flags.fields) {
       body[key] = value;
@@ -657,7 +674,7 @@ async function apiDirect(
   }
 
   const data = await githubFetch(expandedEndpoint, token, { method, body });
-  process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+  process.stdout.write(JSON.stringify(data, null, 2) + '\n');
 }
 
 // --- Main (standalone entry point) ---
@@ -680,11 +697,11 @@ function execRealGhCommand(
   policy: GitHubPolicy,
   policyPath: string,
 ): void {
-  if (decision.action === "allow-and-capture-pr") {
+  if (decision.action === 'allow-and-capture-pr') {
     try {
       const result = execFileSync(realGh, args, {
-        stdio: ["inherit", "pipe", "inherit"],
-        encoding: "utf-8",
+        stdio: ['inherit', 'pipe', 'inherit'],
+        encoding: 'utf-8',
       });
       const stdout = result as string;
       process.stdout.write(stdout);
@@ -693,7 +710,11 @@ function execRealGhCommand(
       if (prNumber === null) {
         try {
           const parsed = JSON.parse(stdout);
-          if (parsed && typeof parsed === "object" && typeof (parsed as { number?: unknown }).number === "number") {
+          if (
+            parsed &&
+            typeof parsed === 'object' &&
+            typeof (parsed as { number?: unknown }).number === 'number'
+          ) {
             prNumber = (parsed as { number: number }).number;
           }
         } catch {
@@ -721,7 +742,7 @@ function execRealGhCommand(
 
   // action === "allow" — exec real gh with inherited stdio
   try {
-    execFileSync(realGh, args, { stdio: "inherit" });
+    execFileSync(realGh, args, { stdio: 'inherit' });
   } catch (err: unknown) {
     const exitCode = (err as { status?: number }).status ?? 1;
     process.exit(exitCode);
@@ -733,9 +754,7 @@ async function main(): Promise<void> {
   const realGh = process.env.BOUNCER_REAL_GH; // may be undefined in container
 
   if (!policyPath) {
-    process.stderr.write(
-      "[bouncer:gh] error: BOUNCER_GITHUB_POLICY must be set\n"
-    );
+    process.stderr.write('[bouncer:gh] error: BOUNCER_GITHUB_POLICY must be set\n');
     process.exit(1);
   }
 
@@ -754,8 +773,8 @@ async function main(): Promise<void> {
   // Log deny decisions to stderr for the policy event parser.
   const op = [parsed.command, parsed.subcommand, ...parsed.positionalArgs]
     .filter(Boolean)
-    .join(" ");
-  if (decision.action === "deny") {
+    .join(' ');
+  if (decision.action === 'deny') {
     process.stderr.write(`[bouncer:gh] DENY ${op} — ${decision.reason}\n`, () => {
       process.exit(1);
     });
@@ -776,7 +795,7 @@ async function main(): Promise<void> {
  * Path format: <POLICY_DIR>/<sessionId>-github-policy.json
  */
 function deriveSessionId(policyPath: string): string | null {
-  const basename = policyPath.split("/").pop();
+  const basename = policyPath.split('/').pop();
   if (!basename) return null;
   const match = basename.match(/^(.+)-github-policy\.json$/);
   return match ? match[1] : null;

--- a/src/main/github-policy-engine.ts
+++ b/src/main/github-policy-engine.ts
@@ -3,16 +3,16 @@
 // Shared GitHub policy evaluation logic used by both the gh shim (CLI-level)
 // and the proxy (network-level). Extracted from gh-shim.ts in Phase 4.
 
-import type { GitHubPolicy } from "./types.js";
+import type { GitHubPolicy } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
 export type PolicyDecision =
-  | { action: "allow" }
-  | { action: "allow-and-capture-pr" }
-  | { action: "deny"; reason: string };
+  | { action: 'allow' }
+  | { action: 'allow-and-capture-pr' }
+  | { action: 'deny'; reason: string };
 
 export interface ApiEndpointMatch {
   resource: string;
@@ -35,21 +35,21 @@ export function parseApiEndpoint(
   endpoint: string,
   flags: { method?: string; hasBodyParams?: boolean; [key: string]: unknown },
 ): ApiEndpointMatch {
-  let method = (flags.method ?? "GET").toUpperCase();
-  if (method === "GET" && flags.hasBodyParams) {
-    method = "POST";
+  let method = (flags.method ?? 'GET').toUpperCase();
+  if (method === 'GET' && flags.hasBodyParams) {
+    method = 'POST';
   }
 
   // Normalize: strip query string, hash, and trailing slash
-  let path = endpoint.split("?")[0].split("#")[0];
-  if (path.length > 1 && path.endsWith("/")) {
+  let path = endpoint.split('?')[0].split('#')[0];
+  if (path.length > 1 && path.endsWith('/')) {
     path = path.slice(0, -1);
   }
 
   // GraphQL
-  if (path === "graphql" || path === "/graphql") {
+  if (path === 'graphql' || path === '/graphql') {
     return {
-      resource: "graphql",
+      resource: 'graphql',
       method,
       ownerRepo: null,
       number: null,
@@ -59,13 +59,11 @@ export function parseApiEndpoint(
   }
 
   // Parse /repos/{owner}/{repo}/... paths
-  const reposMatch = path.match(
-    /^\/repos\/([^/]+\/[^/]+)(?:\/([^/]+))?(?:\/(\d+))?(?:\/(.+))?$/,
-  );
+  const reposMatch = path.match(/^\/repos\/([^/]+\/[^/]+)(?:\/([^/]+))?(?:\/(\d+))?(?:\/(.+))?$/);
 
   if (reposMatch) {
     const ownerRepo = expandPlaceholder(reposMatch[1]);
-    const resource = reposMatch[2] ?? "";
+    const resource = reposMatch[2] ?? '';
     const number = reposMatch[3] ? parseInt(reposMatch[3], 10) : null;
     const subResource = reposMatch[4] ?? null;
     return {
@@ -94,7 +92,7 @@ export function parseApiEndpoint(
  * gh CLI expands these at runtime, but we need to handle them in parsing.
  */
 export function expandPlaceholder(ownerRepo: string): string | null {
-  if (ownerRepo.includes("{")) return null;
+  if (ownerRepo.includes('{')) return null;
   return ownerRepo;
 }
 
@@ -102,57 +100,51 @@ export function expandPlaceholder(ownerRepo: string): string | null {
 // REST API resource evaluators
 // ---------------------------------------------------------------------------
 
-export function evaluateApiPulls(
-  match: ApiEndpointMatch,
-  policy: GitHubPolicy,
-): PolicyDecision {
+export function evaluateApiPulls(match: ApiEndpointMatch, policy: GitHubPolicy): PolicyDecision {
   // GET /pulls or /pulls/{number} — read-only, allow
-  if (match.method === "GET") {
-    return { action: "allow" };
+  if (match.method === 'GET') {
+    return { action: 'allow' };
   }
 
   // PUT /pulls/{number}/merge — deny
-  if (match.method === "PUT" && match.subResource === "merge") {
-    return { action: "deny", reason: "merging PRs via API is not allowed" };
+  if (match.method === 'PUT' && match.subResource === 'merge') {
+    return { action: 'deny', reason: 'merging PRs via API is not allowed' };
   }
 
   // POST /pulls — create PR
-  if (match.method === "POST" && match.number === null) {
+  if (match.method === 'POST' && match.number === null) {
     if (!policy.canCreatePr) {
-      return { action: "deny", reason: "PR already created for this session" };
+      return { action: 'deny', reason: 'PR already created for this session' };
     }
-    return { action: "allow-and-capture-pr" };
+    return { action: 'allow-and-capture-pr' };
   }
 
   // PATCH /pulls/{number} — edit PR
-  if (match.method === "PATCH" && match.number !== null) {
-    if (
-      policy.ownedPrNumber !== null &&
-      match.number === policy.ownedPrNumber
-    ) {
-      return { action: "allow" };
+  if (match.method === 'PATCH' && match.number !== null) {
+    if (policy.ownedPrNumber !== null && match.number === policy.ownedPrNumber) {
+      return { action: 'allow' };
     }
     if (policy.ownedPrNumber === null) {
       return {
-        action: "deny",
+        action: 'deny',
         reason: `cannot edit PR #${match.number}: no PR owned by this session`,
       };
     }
     return {
-      action: "deny",
+      action: 'deny',
       reason: `cannot edit PR #${match.number}: not owned (owned: #${policy.ownedPrNumber})`,
     };
   }
 
-  return { action: "deny", reason: `API pulls ${match.method} is not allowed` };
+  return { action: 'deny', reason: `API pulls ${match.method} is not allowed` };
 }
 
 export function evaluateApiIssues(match: ApiEndpointMatch): PolicyDecision {
-  if (match.method === "GET") {
-    return { action: "allow" };
+  if (match.method === 'GET') {
+    return { action: 'allow' };
   }
   return {
-    action: "deny",
+    action: 'deny',
     reason: `API issues ${match.method} is not allowed`,
   };
 }
@@ -175,40 +167,40 @@ export function evaluateGitHubRequest(
 
   // GraphQL: deny (opaque — can't inspect query content)
   if (match.isGraphQL) {
-    return { action: "deny", reason: "GraphQL endpoint is not allowed" };
+    return { action: 'deny', reason: 'GraphQL endpoint is not allowed' };
   }
 
   // DELETE is always denied
-  if (match.method === "DELETE") {
-    return { action: "deny", reason: "DELETE requests are not allowed" };
+  if (match.method === 'DELETE') {
+    return { action: 'deny', reason: 'DELETE requests are not allowed' };
   }
 
   // Cross-repo check
   if (match.ownerRepo !== null && match.ownerRepo !== policy.repo) {
     return {
-      action: "deny",
+      action: 'deny',
       reason: `cross-repo access denied: '${match.ownerRepo}' (session repo: '${policy.repo}')`,
     };
   }
 
   // /repos/{owner}/{repo} (repo metadata)
-  if (match.resource === "" && match.method === "GET") {
-    return { action: "allow" };
+  if (match.resource === '' && match.method === 'GET') {
+    return { action: 'allow' };
   }
 
   // /repos/{owner}/{repo}/pulls
-  if (match.resource === "pulls") {
+  if (match.resource === 'pulls') {
     return evaluateApiPulls(match, policy);
   }
 
   // /repos/{owner}/{repo}/issues
-  if (match.resource === "issues") {
+  if (match.resource === 'issues') {
     return evaluateApiIssues(match);
   }
 
   // Default deny
   return {
-    action: "deny",
+    action: 'deny',
     reason: `endpoint not in allowlist: ${method} ${path}`,
   };
 }
@@ -252,7 +244,7 @@ export function parseGitReceivePack(body: Buffer): ReceivePackResult {
     if (offset + 4 > body.length) {
       return { refs, ok: false };
     }
-    const lenHex = body.subarray(offset, offset + 4).toString("ascii");
+    const lenHex = body.subarray(offset, offset + 4).toString('ascii');
     const len = parseInt(lenHex, 16);
 
     if (isNaN(len)) {
@@ -272,19 +264,19 @@ export function parseGitReceivePack(body: Buffer): ReceivePackResult {
 
     const payload = body
       .subarray(offset + 4, offset + len)
-      .toString("utf-8")
-      .replace(/\n$/, "");
+      .toString('utf-8')
+      .replace(/\n$/, '');
 
     // Strip capabilities (after \0) from the first line
-    const withoutCaps = payload.split("\0")[0];
+    const withoutCaps = payload.split('\0')[0];
 
     // Parse: {old-sha} {new-sha} {ref-name}
-    const parts = withoutCaps.split(" ");
+    const parts = withoutCaps.split(' ');
     if (parts.length >= 3) {
       refs.push({
         oldSha: parts[0],
         newSha: parts[1],
-        refName: parts.slice(2).join(" "),
+        refName: parts.slice(2).join(' '),
       });
     }
 
@@ -306,11 +298,11 @@ export function evaluateGitPush(
   policy: GitHubPolicy,
 ): { allowed: boolean; deniedRef?: string; reason?: string } {
   if (!parseResult.ok) {
-    return { allowed: false, reason: "malformed pkt-line stream" };
+    return { allowed: false, reason: 'malformed pkt-line stream' };
   }
   for (const ref of parseResult.refs) {
     // Extract the branch name from refs/heads/{branch}
-    const branch = ref.refName.replace(/^refs\/heads\//, "");
+    const branch = ref.refName.replace(/^refs\/heads\//, '');
     if (!policy.allowedPushRefs.includes(branch)) {
       return { allowed: false, deniedRef: ref.refName };
     }

--- a/src/main/github-policy.ts
+++ b/src/main/github-policy.ts
@@ -6,12 +6,12 @@
  * gh shim reads at invocation time.
  */
 
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-import { chmod, mkdir, readdir, readFile, writeFile, rm } from "node:fs/promises";
-import { join } from "node:path";
-import { POLICY_DIR } from "./sandbox.js";
-import type { GitHubPolicy } from "./types.js";
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { chmod, mkdir, readdir, readFile, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { POLICY_DIR } from './sandbox.js';
+import type { GitHubPolicy } from './types.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -22,7 +22,7 @@ const execFileAsync = promisify(execFile);
  */
 export async function detectGitHubRepo(cwd: string): Promise<string | null> {
   try {
-    const { stdout } = await execFileAsync("git", ["-C", cwd, "remote", "get-url", "origin"]);
+    const { stdout } = await execFileAsync('git', ['-C', cwd, 'remote', 'get-url', 'origin']);
     return parseGitHubRemoteUrl(stdout.trim());
   } catch {
     return null;
@@ -79,14 +79,14 @@ export function policyStatePath(sessionId: string): string {
  */
 export async function writePolicyState(sessionId: string, policy: GitHubPolicy): Promise<void> {
   await mkdir(POLICY_DIR, { recursive: true });
-  await writeFile(policyStatePath(sessionId), JSON.stringify(policy, null, 2), "utf-8");
+  await writeFile(policyStatePath(sessionId), JSON.stringify(policy, null, 2), 'utf-8');
 }
 
 /**
  * Read the policy state file. Called by the gh shim on each invocation.
  */
 export async function readPolicyState(path: string): Promise<GitHubPolicy> {
-  const content = await readFile(path, "utf-8");
+  const content = await readFile(path, 'utf-8');
   return JSON.parse(content) as GitHubPolicy;
 }
 
@@ -127,13 +127,15 @@ let cachedBundlePath: string | null = null;
 async function buildShimBundle(ghShimTsPath: string): Promise<string> {
   if (cachedBundlePath) return cachedBundlePath;
 
-  const outPath = join(POLICY_DIR, "gh-shim-bundle.js");
+  const outPath = join(POLICY_DIR, 'gh-shim-bundle.js');
   await mkdir(POLICY_DIR, { recursive: true });
-  await execFileAsync("npx", ["esbuild", ghShimTsPath,
-    "--bundle",
-    "--platform=node",
-    "--format=esm",
-    "--packages=external",
+  await execFileAsync('npx', [
+    'esbuild',
+    ghShimTsPath,
+    '--bundle',
+    '--platform=node',
+    '--format=esm',
+    '--packages=external',
     `--outfile=${outPath}`,
   ]);
   cachedBundlePath = outPath;
@@ -157,8 +159,8 @@ export async function installGhShim(
 exec "${nodePath}" "${bundlePath}" "$@"
 `;
 
-  const shimPath = join(dir, "gh");
-  await writeFile(shimPath, shimScript, "utf-8");
+  const shimPath = join(dir, 'gh');
+  await writeFile(shimPath, shimScript, 'utf-8');
   await chmod(shimPath, 0o755);
   return dir;
 }
@@ -178,7 +180,7 @@ let cachedRealGh: string | null | undefined = undefined;
 export async function findRealGh(): Promise<string | null> {
   if (cachedRealGh !== undefined) return cachedRealGh;
   try {
-    const { stdout } = await execFileAsync("which", ["gh"]);
+    const { stdout } = await execFileAsync('which', ['gh']);
     const path = stdout.trim();
     cachedRealGh = path || null;
   } catch {

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -6,11 +6,11 @@
  * alongside the policy state JSON — no JSON parsing in bash needed.
  */
 
-import { mkdir, writeFile, chmod, rm } from "node:fs/promises";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-import { join } from "node:path";
-import { POLICY_DIR } from "./sandbox.js";
+import { mkdir, writeFile, chmod, rm } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { join } from 'node:path';
+import { POLICY_DIR } from './sandbox.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -82,7 +82,7 @@ exit 0
  * for the allowed-refs file (mounted at /etc/bouncer/allowed-refs.txt).
  */
 export function generatePrePushHookForContainer(): string {
-  return generatePrePushHook("/etc/bouncer/allowed-refs.txt");
+  return generatePrePushHook('/etc/bouncer/allowed-refs.txt');
 }
 
 /**
@@ -100,27 +100,24 @@ export async function installHooks(
 
   // Write the allowed-refs companion file
   const refsFile = allowedRefsPath(sessionId);
-  await writeFile(refsFile, allowedPushRefs.join("\n") + "\n", "utf-8");
+  await writeFile(refsFile, allowedPushRefs.join('\n') + '\n', 'utf-8');
 
   // Write the pre-push hook
-  const hookPath = join(dir, "pre-push");
-  await writeFile(hookPath, generatePrePushHook(refsFile), "utf-8");
+  const hookPath = join(dir, 'pre-push');
+  await writeFile(hookPath, generatePrePushHook(refsFile), 'utf-8');
   await chmod(hookPath, 0o755);
 
   // Point the worktree's git config to our hooks directory
-  await execFileAsync("git", ["-C", worktreePath, "config", "core.hooksPath", dir]);
+  await execFileAsync('git', ['-C', worktreePath, 'config', 'core.hooksPath', dir]);
 }
 
 /**
  * Remove the hooks directory, allowed-refs file, and unset core.hooksPath.
  */
-export async function cleanupHooks(
-  sessionId: string,
-  worktreePath: string,
-): Promise<void> {
+export async function cleanupHooks(sessionId: string, worktreePath: string): Promise<void> {
   // Unset core.hooksPath (catch errors — worktree may already be gone)
   try {
-    await execFileAsync("git", ["-C", worktreePath, "config", "--unset", "core.hooksPath"]);
+    await execFileAsync('git', ['-C', worktreePath, 'config', '--unset', 'core.hooksPath']);
   } catch {
     // Worktree may be gone or config already unset
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,12 +1,12 @@
-import { app, shell, ipcMain, dialog, BrowserWindow, nativeImage } from 'electron'
-import { join } from 'path'
-import { WorkspaceManager } from './workspace-manager.js'
-import { RepositoryStore } from './repository-store.js'
-import { PreferencesStore } from './preferences-store.js'
-import { loadSession } from './dataset-loader.js'
-import { isDockerAvailable, ensureAgentImage } from './container.js'
+import { app, shell, ipcMain, dialog, BrowserWindow, nativeImage } from 'electron';
+import { join } from 'path';
+import { WorkspaceManager } from './workspace-manager.js';
+import { RepositoryStore } from './repository-store.js';
+import { PreferencesStore } from './preferences-store.js';
+import { loadSession } from './dataset-loader.js';
+import { isDockerAvailable, ensureAgentImage } from './container.js';
 
-let mainWindow: BrowserWindow | null = null
+let mainWindow: BrowserWindow | null = null;
 
 function createWindow(): void {
   const window = new BrowserWindow({
@@ -19,218 +19,227 @@ function createWindow(): void {
       preload: join(__dirname, '../preload/index.cjs'),
       sandbox: true,
       contextIsolation: true,
-      nodeIntegration: false
-    }
-  })
-  mainWindow = window
+      nodeIntegration: false,
+    },
+  });
+  mainWindow = window;
 
   window.on('ready-to-show', () => {
-    window.show()
-  })
+    window.show();
+  });
 
   // Monitor renderer health
   window.webContents.on('render-process-gone', (_event, details) => {
-    console.error('[main] Renderer process gone:', details.reason, 'exitCode:', details.exitCode)
-  })
+    console.error('[main] Renderer process gone:', details.reason, 'exitCode:', details.exitCode);
+  });
   window.webContents.on('unresponsive', () => {
-    console.error('[main] Renderer became unresponsive')
-  })
+    console.error('[main] Renderer became unresponsive');
+  });
   window.webContents.on('responsive', () => {
-    console.log('[main] Renderer became responsive again')
-  })
+    console.log('[main] Renderer became responsive again');
+  });
 
   window.webContents.setWindowOpenHandler((details) => {
     try {
-      const parsedUrl = new URL(details.url)
+      const parsedUrl = new URL(details.url);
       if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
-        void shell.openExternal(details.url)
+        void shell.openExternal(details.url);
       }
     } catch {
       // Ignore invalid URLs
     }
-    return { action: 'deny' }
-  })
+    return { action: 'deny' };
+  });
 
   // HMR for renderer in dev, load from file in production
-  const isDev = !app.isPackaged
+  const isDev = !app.isPackaged;
   if (isDev && process.env['ELECTRON_RENDERER_URL']) {
-    window.loadURL(process.env['ELECTRON_RENDERER_URL'])
+    window.loadURL(process.env['ELECTRON_RENDERER_URL']);
   } else {
-    window.loadFile(join(__dirname, '../renderer/index.html'))
+    window.loadFile(join(__dirname, '../renderer/index.html'));
   }
 }
 
 app.whenReady().then(async () => {
   // Set Dock icon on macOS (works in dev mode too)
   if (process.platform === 'darwin' && app.dock) {
-    const iconPath = join(__dirname, '../../resources/icon.png')
-    app.dock.setIcon(nativeImage.createFromPath(iconPath))
+    const iconPath = join(__dirname, '../../resources/icon.png');
+    app.dock.setIcon(nativeImage.createFromPath(iconPath));
   }
 
-  createWindow()
+  createWindow();
 
   // Pre-warm Docker: check availability and build/cache the agent image
   isDockerAvailable().then((available) => {
-    console.log(`[main] Docker available: ${available}`)
+    console.log(`[main] Docker available: ${available}`);
     if (available) {
       ensureAgentImage().catch((err) => {
-        console.warn('[main] Failed to pre-build agent image:', err)
-      })
+        console.warn('[main] Failed to pre-build agent image:', err);
+      });
     }
-  })
+  });
 
   // Load persisted repository list and preferences
-  const repoStore = new RepositoryStore()
-  await repoStore.load()
-  const prefsStore = new PreferencesStore()
-  await prefsStore.load()
+  const repoStore = new RepositoryStore();
+  await repoStore.load();
+  const prefsStore = new PreferencesStore();
+  await prefsStore.load();
 
   // WorkspaceManager forwards events to the renderer via IPC
   // Track IPC throughput to diagnose renderer crashes
-  let ipcCount = 0
-  let ipcLastReport = Date.now()
+  let ipcCount = 0;
+  let ipcLastReport = Date.now();
   const workspaceManager = new WorkspaceManager(repoStore, (channel, data) => {
-    ipcCount++
-    const now = Date.now()
+    ipcCount++;
+    const now = Date.now();
     if (now - ipcLastReport >= 5000) {
-      console.log(`[main] IPC events in last 5s: ${ipcCount} (${(ipcCount / 5).toFixed(0)}/sec)`)
-      ipcCount = 0
-      ipcLastReport = now
+      console.log(`[main] IPC events in last 5s: ${ipcCount} (${(ipcCount / 5).toFixed(0)}/sec)`);
+      ipcCount = 0;
+      ipcLastReport = now;
     }
-    mainWindow?.webContents.send(channel, data)
-  })
+    mainWindow?.webContents.send(channel, data);
+  });
 
   // Clean up orphan worktrees and sandbox policies from previous crashes
   workspaceManager.cleanupOrphans().catch((err) => {
-    console.warn('Failed to clean up orphans:', err)
-  })
+    console.warn('Failed to clean up orphans:', err);
+  });
 
   // Repository IPC handlers
-  ipcMain.handle('repositories:list', () => repoStore.list())
+  ipcMain.handle('repositories:list', () => repoStore.list());
   ipcMain.handle('repositories:add', async (_e, localPath: unknown) => {
     if (typeof localPath !== 'string') {
-      throw new Error('Invalid argument: localPath must be a string')
+      throw new Error('Invalid argument: localPath must be a string');
     }
-    return repoStore.add(localPath)
-  })
+    return repoStore.add(localPath);
+  });
   ipcMain.handle('repositories:update', async (_e, id: unknown, changes: unknown) => {
     if (typeof id !== 'string') {
-      throw new Error('Invalid argument: id must be a string')
+      throw new Error('Invalid argument: id must be a string');
     }
     if (typeof changes !== 'object' || changes === null || Array.isArray(changes)) {
-      throw new Error('Invalid argument: changes must be an object')
+      throw new Error('Invalid argument: changes must be an object');
     }
-    const allowed = ['name', 'localPath', 'githubRepo', 'defaultPolicyId', 'defaultAgentType'] as const
-    const validated: Record<string, unknown> = {}
+    const allowed = [
+      'name',
+      'localPath',
+      'githubRepo',
+      'defaultPolicyId',
+      'defaultAgentType',
+    ] as const;
+    const validated: Record<string, unknown> = {};
     for (const key of allowed) {
       if (key in changes) {
-        validated[key] = (changes as Record<string, unknown>)[key]
+        validated[key] = (changes as Record<string, unknown>)[key];
       }
     }
-    return repoStore.update(id, validated)
-  })
+    return repoStore.update(id, validated);
+  });
   ipcMain.handle('repositories:remove', async (_e, id: unknown) => {
     if (typeof id !== 'string') {
-      throw new Error('Invalid argument: id must be a string')
+      throw new Error('Invalid argument: id must be a string');
     }
-    return repoStore.remove(id)
-  })
+    return repoStore.remove(id);
+  });
 
   // Preferences IPC handlers
-  ipcMain.handle('preferences:getFocusedRepoId', () => prefsStore.focusedRepoId)
+  ipcMain.handle('preferences:getFocusedRepoId', () => prefsStore.focusedRepoId);
   ipcMain.handle('preferences:setFocusedRepoId', async (_e, id: unknown) => {
-    if (typeof id !== 'string') throw new Error('Invalid argument: id must be a string')
-    return prefsStore.setFocusedRepoId(id)
-  })
+    if (typeof id !== 'string') throw new Error('Invalid argument: id must be a string');
+    return prefsStore.setFocusedRepoId(id);
+  });
 
   // Workspace IPC handlers
-  ipcMain.handle('workspaces:list', () => workspaceManager.listWorkspaces())
+  ipcMain.handle('workspaces:list', () => workspaceManager.listWorkspaces());
   ipcMain.handle('workspaces:create', (_e, repositoryId: unknown) => {
     if (typeof repositoryId !== 'string') {
-      throw new Error('Invalid argument: repositoryId must be a string')
+      throw new Error('Invalid argument: repositoryId must be a string');
     }
-    return workspaceManager.createWorkspaceFromRepo(repositoryId)
-  })
+    return workspaceManager.createWorkspaceFromRepo(repositoryId);
+  });
 
   ipcMain.handle('policies:list', () => {
-    return workspaceManager.policyRegistry.list()
-  })
+    return workspaceManager.policyRegistry.list();
+  });
   ipcMain.handle('workspaces:getMessages', (_e, sessionId: unknown) => {
     if (typeof sessionId !== 'string') {
-      throw new Error('Invalid argument: sessionId must be a string')
+      throw new Error('Invalid argument: sessionId must be a string');
     }
-    return workspaceManager.getMessages(sessionId)
-  })
+    return workspaceManager.getMessages(sessionId);
+  });
   ipcMain.handle('workspaces:sendMessage', (_e, sessionId: unknown, text: unknown) => {
     if (typeof sessionId !== 'string' || typeof text !== 'string') {
-      throw new Error('Invalid arguments: sessionId and text must be strings')
+      throw new Error('Invalid arguments: sessionId and text must be strings');
     }
-    return workspaceManager.sendMessage(sessionId, text)
-  })
+    return workspaceManager.sendMessage(sessionId, text);
+  });
   ipcMain.handle('workspaces:close', (_e, sessionId: unknown) => {
     if (typeof sessionId !== 'string') {
-      throw new Error('Invalid argument: sessionId must be a string')
+      throw new Error('Invalid argument: sessionId must be a string');
     }
-    return workspaceManager.closeWorkspace(sessionId)
-  })
+    return workspaceManager.closeWorkspace(sessionId);
+  });
   ipcMain.handle('workspaces:refreshCredentials', (_e, sessionId: unknown) => {
     if (typeof sessionId !== 'string') {
-      throw new Error('Invalid argument: sessionId must be a string')
+      throw new Error('Invalid argument: sessionId must be a string');
     }
-    return workspaceManager.refreshCredentials(sessionId)
-  })
+    return workspaceManager.refreshCredentials(sessionId);
+  });
 
   ipcMain.handle('workspaces:getSandboxViolations', (_e, sessionId: unknown) => {
     if (typeof sessionId !== 'string') {
-      throw new Error('Invalid argument: sessionId must be a string')
+      throw new Error('Invalid argument: sessionId must be a string');
     }
-    return workspaceManager.getSandboxViolations(sessionId)
-  })
+    return workspaceManager.getSandboxViolations(sessionId);
+  });
 
   ipcMain.handle('workspaces:loadReplayData', async (_e, datasetSessionId: unknown) => {
     if (typeof datasetSessionId !== 'string') {
-      throw new Error('Invalid argument: datasetSessionId must be a string')
+      throw new Error('Invalid argument: datasetSessionId must be a string');
     }
-    const toolCalls = await loadSession(join(app.getAppPath(), 'data', 'tool-use-dataset.jsonl'), datasetSessionId)
+    const toolCalls = await loadSession(
+      join(app.getAppPath(), 'data', 'tool-use-dataset.jsonl'),
+      datasetSessionId,
+    );
     if (toolCalls.length === 0) {
-      throw new Error(`Session not found in dataset: ${datasetSessionId}`)
+      throw new Error(`Session not found in dataset: ${datasetSessionId}`);
     }
-    return toolCalls
-  })
+    return toolCalls;
+  });
 
   ipcMain.handle('dialog:selectDirectory', async (event) => {
-    const window = BrowserWindow.fromWebContents(event.sender)
-    if (!window) return null
+    const window = BrowserWindow.fromWebContents(event.sender);
+    if (!window) return null;
     const result = await dialog.showOpenDialog(window, {
       properties: ['openDirectory'],
-      title: 'Select project directory'
-    })
-    if (result.canceled || result.filePaths.length === 0) return null
-    return result.filePaths[0]
-  })
+      title: 'Select project directory',
+    });
+    if (result.canceled || result.filePaths.length === 0) return null;
+    return result.filePaths[0];
+  });
 
   // Clean up all workspaces before quitting
   app.on('before-quit', (event) => {
-    event.preventDefault()
+    event.preventDefault();
     workspaceManager.listWorkspaces().then((workspaces) => {
-      const activeWorkspaces = workspaces.filter((s) => s.status !== 'closed')
+      const activeWorkspaces = workspaces.filter((s) => s.status !== 'closed');
       if (activeWorkspaces.length > 0) {
         workspaceManager.closeAllWorkspaces().finally(() => {
-          app.quit()
-        })
+          app.quit();
+        });
       } else {
-        app.exit()
+        app.exit();
       }
-    })
-  })
+    });
+  });
 
   app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow()
-  })
-})
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
-    app.quit()
+    app.quit();
   }
-})
+});

--- a/src/main/policy-container.ts
+++ b/src/main/policy-container.ts
@@ -3,8 +3,8 @@
  * Parallel to policy-sandbox.ts, which does the same for safehouse.
  */
 
-import type { PolicyTemplate } from "./types.js";
-import type { ContainerConfig, ContainerMount } from "./container.js";
+import type { PolicyTemplate } from './types.js';
+import type { ContainerConfig, ContainerMount } from './container.js';
 
 export interface ContainerSessionContext {
   sessionId: string;
@@ -39,7 +39,7 @@ export interface ContainerSessionContext {
  * credential helper configuration.
  */
 export function sanitizeGitconfig(content: string): string {
-  const lines = content.split("\n");
+  const lines = content.split('\n');
   const result: string[] = [];
   let inCredentialSection = false;
 
@@ -62,7 +62,7 @@ export function sanitizeGitconfig(content: string): string {
 
     result.push(line);
   }
-  return result.join("\n");
+  return result.join('\n');
 }
 
 /**
@@ -113,20 +113,20 @@ export function generateGitconfig(opts: {
   proxyUrl?: string;
 }): string {
   const lines: string[] = [];
-  lines.push("[core]");
+  lines.push('[core]');
   lines.push(`    hooksPath = ${opts.hooksPath}`);
   lines.push(`[credential "https://github.com"]`);
   lines.push(`    helper = !node ${opts.credentialHelperPath}`);
   if (opts.userName || opts.userEmail) {
-    lines.push("[user]");
+    lines.push('[user]');
     if (opts.userName) lines.push(`    name = ${opts.userName}`);
     if (opts.userEmail) lines.push(`    email = ${opts.userEmail}`);
   }
   if (opts.proxyUrl) {
-    lines.push("[http]");
+    lines.push('[http]');
     lines.push(`    proxy = ${opts.proxyUrl}`);
   }
-  return lines.join("\n") + "\n";
+  return lines.join('\n') + '\n';
 }
 
 /**
@@ -141,14 +141,14 @@ export function policyToContainerConfig(
   command: string[],
 ): ContainerConfig {
   const mounts: ContainerMount[] = [];
-  const isReadOnly = template.filesystem.worktreeAccess === "read-only";
+  const isReadOnly = template.filesystem.worktreeAccess === 'read-only';
 
   // --- Standard mounts (always present) ---
 
   // Worktree → /workspace
   mounts.push({
     hostPath: ctx.worktreePath,
-    containerPath: "/workspace",
+    containerPath: '/workspace',
     readOnly: isReadOnly,
   });
 
@@ -167,7 +167,7 @@ export function policyToContainerConfig(
   // Not read-only because Docker needs to create the node_modules mountpoint inside it.
   mounts.push({
     hostPath: ctx.agentBinPath,
-    containerPath: "/usr/local/lib/agent",
+    containerPath: '/usr/local/lib/agent',
     readOnly: false,
   });
 
@@ -176,7 +176,7 @@ export function policyToContainerConfig(
   // finds dependencies by walking up from the agent's package.json.
   mounts.push({
     hostPath: ctx.nodeModulesPath,
-    containerPath: "/usr/local/lib/agent/node_modules",
+    containerPath: '/usr/local/lib/agent/node_modules',
     readOnly: true,
   });
 
@@ -186,7 +186,7 @@ export function policyToContainerConfig(
     if (ctx.hooksDir) {
       mounts.push({
         hostPath: ctx.hooksDir,
-        containerPath: "/etc/bouncer/hooks",
+        containerPath: '/etc/bouncer/hooks',
         readOnly: true,
       });
     }
@@ -194,7 +194,7 @@ export function policyToContainerConfig(
     if (ctx.allowedRefsPath) {
       mounts.push({
         hostPath: ctx.allowedRefsPath,
-        containerPath: "/etc/bouncer/allowed-refs.txt",
+        containerPath: '/etc/bouncer/allowed-refs.txt',
         readOnly: true,
       });
     }
@@ -202,7 +202,7 @@ export function policyToContainerConfig(
     if (ctx.shimScriptPath) {
       mounts.push({
         hostPath: ctx.shimScriptPath,
-        containerPath: "/usr/local/bin/gh",
+        containerPath: '/usr/local/bin/gh',
         readOnly: true,
       });
     }
@@ -210,7 +210,7 @@ export function policyToContainerConfig(
     if (ctx.shimBundlePath) {
       mounts.push({
         hostPath: ctx.shimBundlePath,
-        containerPath: "/usr/local/lib/bouncer/gh-shim.js",
+        containerPath: '/usr/local/lib/bouncer/gh-shim.js',
         readOnly: true,
       });
     }
@@ -219,7 +219,7 @@ export function policyToContainerConfig(
       // Policy state is rw — the gh shim updates it (e.g. PR capture)
       mounts.push({
         hostPath: ctx.policyStatePath,
-        containerPath: "/etc/bouncer/github-policy.json",
+        containerPath: '/etc/bouncer/github-policy.json',
         readOnly: false,
       });
     }
@@ -227,7 +227,7 @@ export function policyToContainerConfig(
     if (ctx.gitconfigPath) {
       mounts.push({
         hostPath: ctx.gitconfigPath,
-        containerPath: "/etc/gitconfig",
+        containerPath: '/etc/gitconfig',
         readOnly: true,
       });
     }
@@ -235,7 +235,7 @@ export function policyToContainerConfig(
     if (ctx.credentialHelperPath) {
       mounts.push({
         hostPath: ctx.credentialHelperPath,
-        containerPath: "/usr/local/lib/bouncer/gh-credential-helper.js",
+        containerPath: '/usr/local/lib/bouncer/gh-credential-helper.js',
         readOnly: true,
       });
     }
@@ -249,7 +249,7 @@ export function policyToContainerConfig(
   if (ctx.userGitconfigPath) {
     mounts.push({
       hostPath: ctx.userGitconfigPath,
-      containerPath: "/home/agent/.gitconfig",
+      containerPath: '/home/agent/.gitconfig',
       readOnly: true,
     });
   }
@@ -257,9 +257,11 @@ export function policyToContainerConfig(
   // Claude Code config/state — the CLI reads and writes session state here.
   // The base image already has the claude binary; we only mount config dirs.
   if (ctx.claudeConfigDir) {
-    mounts.push(
-      { hostPath: ctx.claudeConfigDir, containerPath: "/home/agent/.claude", readOnly: false },
-    );
+    mounts.push({
+      hostPath: ctx.claudeConfigDir,
+      containerPath: '/home/agent/.claude',
+      readOnly: false,
+    });
   }
 
   // Credentials file extracted from macOS keychain — mounted into .claude dir
@@ -267,7 +269,7 @@ export function policyToContainerConfig(
   if (ctx.claudeCredentialsPath) {
     mounts.push({
       hostPath: ctx.claudeCredentialsPath,
-      containerPath: "/home/agent/.claude/.credentials.json",
+      containerPath: '/home/agent/.claude/.credentials.json',
       readOnly: true,
     });
   }
@@ -275,7 +277,7 @@ export function policyToContainerConfig(
   if (ctx.sshDir) {
     mounts.push({
       hostPath: ctx.sshDir,
-      containerPath: "/home/agent/.ssh",
+      containerPath: '/home/agent/.ssh',
       readOnly: true,
     });
   }
@@ -285,7 +287,7 @@ export function policyToContainerConfig(
   if (ctx.caCertPath) {
     mounts.push({
       hostPath: ctx.caCertPath,
-      containerPath: "/usr/local/share/ca-certificates/bouncer/bouncer-ca.crt",
+      containerPath: '/usr/local/share/ca-certificates/bouncer/bouncer-ca.crt',
       readOnly: true,
     });
   }
@@ -301,23 +303,23 @@ export function policyToContainerConfig(
   // --- Build env ---
 
   const containerEnv: Record<string, string> = {
-    NODE_PATH: "/usr/local/lib/agent/node_modules",
+    NODE_PATH: '/usr/local/lib/agent/node_modules',
     ...env,
   };
 
   if (template.github && ctx.policyStatePath) {
-    containerEnv.BOUNCER_GITHUB_POLICY = "/etc/bouncer/github-policy.json";
+    containerEnv.BOUNCER_GITHUB_POLICY = '/etc/bouncer/github-policy.json';
   }
 
   // --- Network mode ---
 
-  const networkMode = template.container?.networkMode ?? "bridge";
+  const networkMode = template.container?.networkMode ?? 'bridge';
 
   return {
     sessionId: ctx.sessionId,
     image: template.container?.image ?? imageTag,
     command,
-    workdir: "/workspace",
+    workdir: '/workspace',
     mounts,
     env: containerEnv,
     networkMode,

--- a/src/main/policy-event-parser.ts
+++ b/src/main/policy-event-parser.ts
@@ -14,13 +14,13 @@
  *   [bouncer:proxy] DENY POST /graphql — GraphQL endpoint is not allowed
  */
 
-import type { PolicyEvent } from "./types.js";
+import type { PolicyEvent } from './types.js';
 
 // Matches: [bouncer:<tool>] <ALLOW|DENY> <operation>[ — <reason>]
 const POLICY_LINE_RE = /^\[bouncer:(gh|git|proxy)\] (ALLOW|DENY) (.+)$/;
 
 // Splits "operation — reason" on the em-dash separator
-const REASON_SEPARATOR = " — ";
+const REASON_SEPARATOR = ' — ';
 
 /**
  * Attempt to parse a stderr line as a Bouncer policy event.
@@ -30,21 +30,21 @@ export function parsePolicyEvent(line: string): PolicyEvent | null {
   const match = line.trimEnd().match(POLICY_LINE_RE);
   if (!match) return null;
 
-  const tool = match[1] as "gh" | "git" | "proxy";
-  const decision = match[2] === "ALLOW" ? "allow" : "deny";
+  const tool = match[1] as 'gh' | 'git' | 'proxy';
+  const decision = match[2] === 'ALLOW' ? 'allow' : 'deny';
   const rest = match[3];
 
   let operation: string;
   let reason: string | undefined;
 
   const separatorIndex = rest.lastIndexOf(REASON_SEPARATOR);
-  if (decision === "deny" && separatorIndex !== -1) {
+  if (decision === 'deny' && separatorIndex !== -1) {
     operation = rest.substring(0, separatorIndex);
     reason = rest.substring(separatorIndex + REASON_SEPARATOR.length);
   } else {
     operation = rest;
     // Strip [unaudited] tag if present
-    operation = operation.replace(/ \[unaudited\]$/, "");
+    operation = operation.replace(/ \[unaudited\]$/, '');
   }
 
   return {

--- a/src/main/policy-registry.ts
+++ b/src/main/policy-registry.ts
@@ -1,9 +1,9 @@
-import type { PolicyTemplate, PolicyTemplateSummary } from "./types.js";
+import type { PolicyTemplate, PolicyTemplateSummary } from './types.js';
 import {
   standardPrTemplate,
   researchOnlyTemplate,
   permissiveTemplate,
-} from "./policy-templates.js";
+} from './policy-templates.js';
 
 const BUILT_IN_TEMPLATES: PolicyTemplate[] = [
   standardPrTemplate,

--- a/src/main/policy-sandbox.ts
+++ b/src/main/policy-sandbox.ts
@@ -1,7 +1,7 @@
-import { join } from "node:path";
-import type { PolicyTemplate } from "./types.js";
-import { POLICY_DIR, BASE_ENV_PASSTHROUGH } from "./sandbox.js";
-import type { SandboxConfig } from "./sandbox.js";
+import { join } from 'node:path';
+import type { PolicyTemplate } from './types.js';
+import { POLICY_DIR, BASE_ENV_PASSTHROUGH } from './sandbox.js';
+import type { SandboxConfig } from './sandbox.js';
 
 export interface SessionContext {
   sessionId: string;
@@ -9,7 +9,6 @@ export interface SessionContext {
   gitCommonDir?: string;
   readOnlyDirs?: string[];
 }
-
 
 export function policyToSandboxConfig(
   template: PolicyTemplate,
@@ -19,7 +18,7 @@ export function policyToSandboxConfig(
   const readOnlyDirs: string[] = [...(ctx.readOnlyDirs ?? [])];
 
   // Worktree access mode
-  if (template.filesystem.worktreeAccess === "read-write") {
+  if (template.filesystem.worktreeAccess === 'read-write') {
     writableDirs.push(ctx.worktreePath);
   } else {
     readOnlyDirs.push(ctx.worktreePath);
@@ -27,7 +26,7 @@ export function policyToSandboxConfig(
 
   // Git common dir follows worktree access mode
   if (ctx.gitCommonDir) {
-    if (template.filesystem.worktreeAccess === "read-write") {
+    if (template.filesystem.worktreeAccess === 'read-write') {
       writableDirs.push(ctx.gitCommonDir);
     } else {
       readOnlyDirs.push(ctx.gitCommonDir);
@@ -60,7 +59,7 @@ export function policyToSandboxConfig(
   }
 
   if (profileParts.length > 0) {
-    appendProfileContent = "(version 1)\n" + profileParts.join("\n") + "\n";
+    appendProfileContent = '(version 1)\n' + profileParts.join('\n') + '\n';
   }
 
   return {

--- a/src/main/policy-templates.ts
+++ b/src/main/policy-templates.ts
@@ -1,4 +1,4 @@
-import type { PolicyTemplate } from "./types.js";
+import type { PolicyTemplate } from './types.js';
 
 /**
  * Standard PR implementation: read-write worktree, filtered network via proxy.
@@ -7,46 +7,43 @@ import type { PolicyTemplate } from "./types.js";
  * GitHub API/git push enforcement.
  */
 export const standardPrTemplate: PolicyTemplate = {
-  id: "standard-pr",
-  name: "Standard PR",
-  description: "Read-write worktree, filtered network via proxy, GitHub policy enforcement",
+  id: 'standard-pr',
+  name: 'Standard PR',
+  description: 'Read-write worktree, filtered network via proxy, GitHub policy enforcement',
   filesystem: {
-    worktreeAccess: "read-write",
+    worktreeAccess: 'read-write',
     additionalWritableDirs: [],
     additionalReadOnlyDirs: [],
   },
   network: {
-    access: "filtered",
+    access: 'filtered',
     allowedDomains: [
       // Claude Code API backend — required for the agent to function
-      "api.anthropic.com",
+      'api.anthropic.com',
       // Claude Code OAuth — required for token refresh / re-authentication
-      "platform.claude.com",
+      'platform.claude.com',
       // GitHub (code hosting, API, uploads)
-      "github.com",
-      "api.github.com",
-      "uploads.github.com",
+      'github.com',
+      'api.github.com',
+      'uploads.github.com',
       // Package registries
-      "registry.npmjs.org",
-      "crates.io",
-      "static.crates.io",
-      "index.crates.io",
-      "pypi.org",
-      "files.pythonhosted.org",
+      'registry.npmjs.org',
+      'crates.io',
+      'static.crates.io',
+      'index.crates.io',
+      'pypi.org',
+      'files.pythonhosted.org',
     ],
-    inspectedDomains: [
-      "api.github.com",
-      "github.com",
-    ],
+    inspectedDomains: ['api.github.com', 'github.com'],
   },
   env: {
     additional: [],
     exclude: [],
   },
-  safehouseIntegrations: ["all-agents"],
+  safehouseIntegrations: ['all-agents'],
   github: {
-    repo: "",              // Populated per-session
-    allowedPushRefs: [],   // Populated per-session
+    repo: '', // Populated per-session
+    allowedPushRefs: [], // Populated per-session
     ownedPrNumber: null,
     canCreatePr: true,
   },
@@ -60,22 +57,22 @@ export const standardPrTemplate: PolicyTemplate = {
  * due to safehouse agent profiles. See findings.md for details.
  */
 export const researchOnlyTemplate: PolicyTemplate = {
-  id: "research-only",
-  name: "Research Only",
-  description: "Read-write worktree, full network, no access outside sandbox",
+  id: 'research-only',
+  name: 'Research Only',
+  description: 'Read-write worktree, full network, no access outside sandbox',
   filesystem: {
-    worktreeAccess: "read-write",
+    worktreeAccess: 'read-write',
     additionalWritableDirs: [],
     additionalReadOnlyDirs: [],
   },
   network: {
-    access: "full",
+    access: 'full',
   },
   env: {
     additional: [],
     exclude: [],
   },
-  safehouseIntegrations: ["all-agents"],
+  safehouseIntegrations: ['all-agents'],
 };
 
 /**
@@ -84,20 +81,20 @@ export const researchOnlyTemplate: PolicyTemplate = {
  * Equivalent to the M2 default safehouse configuration.
  */
 export const permissiveTemplate: PolicyTemplate = {
-  id: "permissive",
-  name: "Permissive",
-  description: "Read-write worktree, toolchains, full network access",
+  id: 'permissive',
+  name: 'Permissive',
+  description: 'Read-write worktree, toolchains, full network access',
   filesystem: {
-    worktreeAccess: "read-write",
+    worktreeAccess: 'read-write',
     additionalWritableDirs: [],
     additionalReadOnlyDirs: [],
   },
   network: {
-    access: "full",
+    access: 'full',
   },
   env: {
     additional: [],
     exclude: [],
   },
-  safehouseIntegrations: ["all-agents"],
+  safehouseIntegrations: ['all-agents'],
 };

--- a/src/main/preferences-store.ts
+++ b/src/main/preferences-store.ts
@@ -1,6 +1,6 @@
-import { join } from "node:path";
-import { homedir } from "node:os";
-import { readFile, writeFile, mkdir, rename } from "node:fs/promises";
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { readFile, writeFile, mkdir, rename } from 'node:fs/promises';
 
 interface Preferences {
   focusedRepoId?: string;
@@ -11,16 +11,16 @@ export class PreferencesStore {
   private configPath: string;
 
   constructor(configDir?: string) {
-    const dir = configDir ?? join(homedir(), ".config", "bouncer");
-    this.configPath = join(dir, "preferences.json");
+    const dir = configDir ?? join(homedir(), '.config', 'bouncer');
+    this.configPath = join(dir, 'preferences.json');
   }
 
   async load(): Promise<void> {
     try {
-      const raw = await readFile(this.configPath, "utf-8");
+      const raw = await readFile(this.configPath, 'utf-8');
       this.prefs = JSON.parse(raw);
     } catch (err: unknown) {
-      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
         this.prefs = {};
       } else {
         throw err;
@@ -29,11 +29,11 @@ export class PreferencesStore {
   }
 
   private async save(): Promise<void> {
-    const dir = join(this.configPath, "..");
+    const dir = join(this.configPath, '..');
     await mkdir(dir, { recursive: true });
-    const json = JSON.stringify(this.prefs, null, 2) + "\n";
-    const tmpPath = this.configPath + ".tmp";
-    await writeFile(tmpPath, json, "utf-8");
+    const json = JSON.stringify(this.prefs, null, 2) + '\n';
+    const tmpPath = this.configPath + '.tmp';
+    await writeFile(tmpPath, json, 'utf-8');
     await rename(tmpPath, this.configPath);
   }
 

--- a/src/main/proxy-github.ts
+++ b/src/main/proxy-github.ts
@@ -5,14 +5,14 @@
 // to enforce REST API policy and capture PR numbers from POST /pulls responses.
 // Also enforces git push ref restrictions on github.com smart HTTP transport.
 
-import http from "node:http";
-import https from "node:https";
+import http from 'node:http';
+import https from 'node:https';
 import {
   evaluateGitHubRequest,
   parseGitReceivePack,
   evaluateGitPush,
-} from "./github-policy-engine.js";
-import type { ProxyConfig, MitmRequestHandler } from "./proxy.js";
+} from './github-policy-engine.js';
+import type { ProxyConfig, MitmRequestHandler } from './proxy.js';
 
 // ---------------------------------------------------------------------------
 // createGitHubMitmHandler()
@@ -29,8 +29,8 @@ import type { ProxyConfig, MitmRequestHandler } from "./proxy.js";
  */
 export function createGitHubMitmHandler(
   config: ProxyConfig,
-  apiHostname: string = "api.github.com",
-  gitHostname: string = "github.com",
+  apiHostname: string = 'api.github.com',
+  gitHostname: string = 'github.com',
 ): MitmRequestHandler {
   const apiNorm = normalizeHost(apiHostname);
   const gitNorm = normalizeHost(gitHostname);
@@ -49,7 +49,7 @@ export function createGitHubMitmHandler(
 
 function normalizeHost(h: string): string {
   const lower = h.toLowerCase();
-  return lower.endsWith(".") ? lower.slice(0, -1) : lower;
+  return lower.endsWith('.') ? lower.slice(0, -1) : lower;
 }
 
 // ---------------------------------------------------------------------------
@@ -64,8 +64,8 @@ function handleGitHubApiRequest(
   config: ProxyConfig,
   upstream: (req: http.IncomingMessage, res: http.ServerResponse) => void,
 ): void {
-  const method = req.method ?? "GET";
-  const path = req.url ?? "/";
+  const method = req.method ?? 'GET';
+  const path = req.url ?? '/';
   const policy = config.githubPolicy!;
 
   const decision = evaluateGitHubRequest(method, path, policy);
@@ -73,19 +73,19 @@ function handleGitHubApiRequest(
   // Log the policy event
   config.onPolicyEvent({
     timestamp: Date.now(),
-    tool: "proxy",
+    tool: 'proxy',
     operation: `${method} ${path}`,
-    decision: decision.action === "deny" ? "deny" : "allow",
-    reason: decision.action === "deny" ? decision.reason : undefined,
+    decision: decision.action === 'deny' ? 'deny' : 'allow',
+    reason: decision.action === 'deny' ? decision.reason : undefined,
   });
 
-  if (decision.action === "deny") {
-    res.writeHead(403, { "Content-Type": "text/plain" });
+  if (decision.action === 'deny') {
+    res.writeHead(403, { 'Content-Type': 'text/plain' });
     res.end(`[bouncer:proxy] DENY ${method} ${path} — ${decision.reason}\n`);
     return;
   }
 
-  if (decision.action === "allow-and-capture-pr") {
+  if (decision.action === 'allow-and-capture-pr') {
     // Eagerly reserve PR creation to prevent concurrent requests from
     // seeing canCreatePr=true before the first response is captured.
     policy.canCreatePr = false;
@@ -113,16 +113,16 @@ function handleGitSmartHttp(
   config: ProxyConfig,
   upstream: (req: http.IncomingMessage, res: http.ServerResponse) => void,
 ): void {
-  const method = req.method ?? "GET";
-  const rawPath = req.url ?? "/";
+  const method = req.method ?? 'GET';
+  const rawPath = req.url ?? '/';
   const policy = config.githubPolicy!;
 
   // Strip query string before matching to prevent bypass via ?x=y
-  const path = rawPath.split("?")[0];
+  const path = rawPath.split('?')[0];
 
   // Only inspect git-receive-pack (push) requests
   const pushMatch = path.match(GIT_RECEIVE_PACK_RE);
-  if (method !== "POST" || !pushMatch) {
+  if (method !== 'POST' || !pushMatch) {
     // Non-push requests (ref advertisement, clone, fetch) — forward directly
     upstream(req, res);
     return;
@@ -134,13 +134,13 @@ function handleGitSmartHttp(
   if (repo !== policy.repo) {
     config.onPolicyEvent({
       timestamp: Date.now(),
-      tool: "proxy",
+      tool: 'proxy',
       operation: `git push to ${repo}`,
-      decision: "deny",
+      decision: 'deny',
       reason: `cross-repo push denied (session repo: ${policy.repo})`,
     });
     req.resume(); // drain the request body to avoid tying up the connection
-    res.writeHead(403, { "Content-Type": "text/plain" });
+    res.writeHead(403, { 'Content-Type': 'text/plain' });
     res.end(`[bouncer:proxy] DENY push to ${repo} — cross-repo access denied\n`);
     return;
   }
@@ -155,18 +155,18 @@ function handleGitSmartHttp(
   let headerSize = 0;
   let decided = false;
 
-  req.on("data", (chunk: Buffer) => {
+  req.on('data', (chunk: Buffer) => {
     if (decided) return;
     headerChunks.push(chunk);
     headerSize += chunk.length;
 
     if (headerSize > MAX_HEADER_BYTES) {
       decided = true;
-      denyPush(req, res, config, "git push", "pkt-line header exceeded size limit");
+      denyPush(req, res, config, 'git push', 'pkt-line header exceeded size limit');
     }
   });
 
-  req.on("end", () => {
+  req.on('end', () => {
     if (decided) return;
     decided = true;
 
@@ -176,21 +176,21 @@ function handleGitSmartHttp(
 
     if (!result.allowed) {
       const reason = result.reason ?? `ref ${result.deniedRef} not in allowed list`;
-      denyPush(req, res, config, `git push ${result.deniedRef ?? "unknown"}`, reason);
+      denyPush(req, res, config, `git push ${result.deniedRef ?? 'unknown'}`, reason);
       return;
     }
 
     if (parseResult.refs.length === 0) {
-      denyPush(req, res, config, "git push (no refs)", "push contained no ref updates");
+      denyPush(req, res, config, 'git push (no refs)', 'push contained no ref updates');
       return;
     }
 
     // Push allowed — log and forward the buffered body
     config.onPolicyEvent({
       timestamp: Date.now(),
-      tool: "proxy",
-      operation: `git push (${parseResult.refs.map((r) => r.refName).join(", ")})`,
-      decision: "allow",
+      tool: 'proxy',
+      operation: `git push (${parseResult.refs.map((r) => r.refName).join(', ')})`,
+      decision: 'allow',
     });
     forwardWithBody(req, res, hostname, upstreamPort, config, body);
   });
@@ -205,14 +205,14 @@ function denyPush(
 ): void {
   config.onPolicyEvent({
     timestamp: Date.now(),
-    tool: "proxy",
+    tool: 'proxy',
     operation,
-    decision: "deny",
+    decision: 'deny',
     reason,
   });
   req.resume(); // drain remaining body
-  res.writeHead(403, { "Content-Type": "text/plain" });
-  res.end(`[bouncer:proxy] DENY push to ${operation.replace("git push ", "")} — ${reason}\n`);
+  res.writeHead(403, { 'Content-Type': 'text/plain' });
+  res.end(`[bouncer:proxy] DENY push to ${operation.replace('git push ', '')} — ${reason}\n`);
 }
 
 /**
@@ -227,7 +227,7 @@ function forwardWithBody(
   config: ProxyConfig,
   body: Buffer,
 ): void {
-  const { "transfer-encoding": _te, ...forwardHeaders } = clientReq.headers;
+  const { 'transfer-encoding': _te, ...forwardHeaders } = clientReq.headers;
   const options: https.RequestOptions = {
     hostname,
     port,
@@ -236,7 +236,7 @@ function forwardWithBody(
     headers: {
       ...forwardHeaders,
       host: hostname,
-      "content-length": String(body.length),
+      'content-length': String(body.length),
     },
     ...(config.insecureUpstreamTls ? { rejectUnauthorized: false } : {}),
   };
@@ -246,9 +246,9 @@ function forwardWithBody(
     proxyRes.pipe(clientRes);
   });
 
-  proxyReq.on("error", () => {
+  proxyReq.on('error', () => {
     clientRes.writeHead(502);
-    clientRes.end("Bad Gateway\n");
+    clientRes.end('Bad Gateway\n');
   });
 
   proxyReq.end(body);
@@ -284,14 +284,14 @@ function forwardWithCapture(
     let totalBytes = 0;
     let captureLimitExceeded = false;
 
-    proxyRes.on("data", (chunk: Buffer) => {
+    proxyRes.on('data', (chunk: Buffer) => {
       chunks.push(chunk);
       totalBytes += chunk.length;
       if (totalBytes > MAX_CAPTURE_BYTES) {
         captureLimitExceeded = true;
       }
     });
-    proxyRes.on("end", () => {
+    proxyRes.on('end', () => {
       const bodyBuffer = Buffer.concat(chunks);
 
       // Relay the raw bytes to the client (preserves encoding, binary safety)
@@ -305,10 +305,10 @@ function forwardWithCapture(
         proxyRes.statusCode >= 200 &&
         proxyRes.statusCode < 300
       ) {
-        const encoding = proxyRes.headers["content-encoding"];
-        if (!encoding || encoding === "identity") {
+        const encoding = proxyRes.headers['content-encoding'];
+        if (!encoding || encoding === 'identity') {
           try {
-            capturePrFromResponse(bodyBuffer.toString("utf-8"), config);
+            capturePrFromResponse(bodyBuffer.toString('utf-8'), config);
           } catch {
             // Decode failed — skip capture
           }
@@ -317,9 +317,9 @@ function forwardWithCapture(
     });
   });
 
-  proxyReq.on("error", () => {
+  proxyReq.on('error', () => {
     clientRes.writeHead(502);
-    clientRes.end("Bad Gateway\n");
+    clientRes.end('Bad Gateway\n');
   });
 
   clientReq.pipe(proxyReq);
@@ -332,14 +332,14 @@ function forwardWithCapture(
 function capturePrFromResponse(body: string, config: ProxyConfig): void {
   try {
     const data = JSON.parse(body);
-    if (typeof data.number === "number" && config.githubPolicy) {
+    if (typeof data.number === 'number' && config.githubPolicy) {
       config.githubPolicy.canCreatePr = false;
       config.githubPolicy.ownedPrNumber = data.number;
       config.onPolicyEvent({
         timestamp: Date.now(),
-        tool: "proxy",
+        tool: 'proxy',
         operation: `captured PR #${data.number}`,
-        decision: "allow",
+        decision: 'allow',
       });
     }
   } catch {

--- a/src/main/proxy-network.ts
+++ b/src/main/proxy-network.ts
@@ -5,12 +5,12 @@
 // with HTTP_PROXY/HTTPS_PROXY env vars pointing to the host proxy, which enforces
 // domain allowlists. Note: this is env-var-based routing, not network-level enforcement.
 
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 
-const NETWORK_PREFIX = "bouncer-net";
+const NETWORK_PREFIX = 'bouncer-net';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -33,30 +33,28 @@ export interface SessionNetwork {
  * making host.docker.internal unreachable. The proxy is the enforcement
  * layer — it blocks disallowed domains.
  */
-export async function createSessionNetwork(
-  sessionId: string,
-): Promise<SessionNetwork> {
+export async function createSessionNetwork(sessionId: string): Promise<SessionNetwork> {
   const networkName = `${NETWORK_PREFIX}-${sessionId}`;
 
   // Check if the network already exists (e.g., left over from a crash)
   try {
-    await execFileAsync("docker", ["network", "inspect", networkName], {
+    await execFileAsync('docker', ['network', 'inspect', networkName], {
       timeout: 10_000,
     });
     // Network exists — reuse it
   } catch {
     // Network doesn't exist — create it
     await execFileAsync(
-      "docker",
+      'docker',
       [
-        "network",
-        "create",
+        'network',
+        'create',
         networkName,
-        "--driver",
-        "bridge",
-        "--label",
-        "bouncer.managed=true",
-        "--label",
+        '--driver',
+        'bridge',
+        '--label',
+        'bouncer.managed=true',
+        '--label',
         `bouncer.sessionId=${sessionId}`,
       ],
       { timeout: 10_000 },
@@ -66,9 +64,7 @@ export async function createSessionNetwork(
   return {
     networkName,
     async cleanup() {
-      await execFileAsync("docker", ["network", "rm", networkName]).catch(
-        () => {},
-      ); // idempotent
+      await execFileAsync('docker', ['network', 'rm', networkName]).catch(() => {}); // idempotent
     },
   };
 }
@@ -81,21 +77,12 @@ export async function createSessionNetwork(
  * Remove any bouncer networks that don't belong to active sessions.
  * Called at startup to clean up after crashes.
  */
-export async function cleanupOrphanNetworks(
-  activeSessionIds: Set<string>,
-): Promise<void> {
+export async function cleanupOrphanNetworks(activeSessionIds: Set<string>): Promise<void> {
   let stdout: string;
   try {
     const result = await execFileAsync(
-      "docker",
-      [
-        "network",
-        "ls",
-        "--filter",
-        "label=bouncer.managed=true",
-        "--format",
-        "{{.Name}}",
-      ],
+      'docker',
+      ['network', 'ls', '--filter', 'label=bouncer.managed=true', '--format', '{{.Name}}'],
       { timeout: 10_000 },
     );
     stdout = result.stdout;
@@ -103,7 +90,7 @@ export async function cleanupOrphanNetworks(
     return; // Docker not available or error — nothing to clean up
   }
 
-  const names = stdout.trim().split("\n").filter(Boolean);
+  const names = stdout.trim().split('\n').filter(Boolean);
   for (const name of names) {
     // Extract session ID from network name: bouncer-net-{sessionId}
     const sessionId = name.startsWith(`${NETWORK_PREFIX}-`)
@@ -112,13 +99,11 @@ export async function cleanupOrphanNetworks(
     if (sessionId && !activeSessionIds.has(sessionId)) {
       console.log(`[proxy-network] Removing orphan network: ${name}`);
       try {
-        await execFileAsync("docker", ["network", "rm", name], {
+        await execFileAsync('docker', ['network', 'rm', name], {
           timeout: 10_000,
         });
       } catch {
-        console.warn(
-          `[proxy-network] Failed to remove orphan network: ${name}`,
-        );
+        console.warn(`[proxy-network] Failed to remove orphan network: ${name}`);
       }
     }
   }

--- a/src/main/proxy-tls.ts
+++ b/src/main/proxy-tls.ts
@@ -2,9 +2,9 @@
 //
 // TLS primitives for Bouncer's MITM proxy: CA generation and per-host certificate minting.
 
-import { join } from "node:path";
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
-import forge from "node-forge";
+import { join } from 'node:path';
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import forge from 'node-forge';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -37,42 +37,37 @@ const hostCertCache = new Map<string, CachedHostCert>();
  * Lazily imports `electron` so this module can be loaded outside Electron for testing.
  */
 export async function defaultCADir(): Promise<string> {
-  const { app } = await import("electron");
-  return join(app.getPath("userData"), "bouncer-ca");
+  const { app } = await import('electron');
+  return join(app.getPath('userData'), 'bouncer-ca');
 }
 
 /**
  * Load the Bouncer CA from disk, or generate a new one if it doesn't exist.
  * @param caDir - Directory to store the CA. Defaults to `{userData}/bouncer-ca/`.
  */
-export async function ensureCA(
-  caDir?: string,
-): Promise<BouncerCA> {
+export async function ensureCA(caDir?: string): Promise<BouncerCA> {
   caDir ??= await defaultCADir();
-  const certPath = join(caDir, "bouncer-ca.crt");
-  const keyPath = join(caDir, "bouncer-ca.key");
+  const certPath = join(caDir, 'bouncer-ca.crt');
+  const keyPath = join(caDir, 'bouncer-ca.key');
 
   // Load existing CA if present
   if (existsSync(certPath) && existsSync(keyPath)) {
     return {
-      cert: readFileSync(certPath, "utf-8"),
-      key: readFileSync(keyPath, "utf-8"),
+      cert: readFileSync(certPath, 'utf-8'),
+      key: readFileSync(keyPath, 'utf-8'),
       certPath,
     };
   }
 
   // Generate new CA (async to avoid blocking the event loop)
   const keys = await new Promise<forge.pki.rsa.KeyPair>((resolve, reject) => {
-    forge.pki.rsa.generateKeyPair(
-      { bits: 2048, workers: -1 },
-      (err, keypair) => {
-        if (err || !keypair) {
-          reject(err ?? new Error("Failed to generate RSA key pair"));
-          return;
-        }
-        resolve(keypair);
-      },
-    );
+    forge.pki.rsa.generateKeyPair({ bits: 2048, workers: -1 }, (err, keypair) => {
+      if (err || !keypair) {
+        reject(err ?? new Error('Failed to generate RSA key pair'));
+        return;
+      }
+      resolve(keypair);
+    });
   });
   const cert = forge.pki.createCertificate();
 
@@ -80,21 +75,19 @@ export async function ensureCA(
   cert.serialNumber = generateSerialNumber();
   cert.validity.notBefore = new Date();
   cert.validity.notAfter = new Date();
-  cert.validity.notAfter.setFullYear(
-    cert.validity.notBefore.getFullYear() + 10,
-  );
+  cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 10);
 
   const attrs = [
-    { name: "commonName", value: "Bouncer Proxy CA" },
-    { name: "organizationName", value: "Bouncer" },
+    { name: 'commonName', value: 'Bouncer Proxy CA' },
+    { name: 'organizationName', value: 'Bouncer' },
   ];
   cert.setSubject(attrs);
   cert.setIssuer(attrs);
 
   cert.setExtensions([
-    { name: "basicConstraints", cA: true, critical: true },
+    { name: 'basicConstraints', cA: true, critical: true },
     {
-      name: "keyUsage",
+      name: 'keyUsage',
       keyCertSign: true,
       cRLSign: true,
       critical: true,
@@ -122,10 +115,7 @@ export async function ensureCA(
  * Generate (or return cached) a TLS certificate for `hostname`, signed by `ca`.
  * Certificates are cached in memory with a 24-hour TTL.
  */
-export function generateHostCert(
-  hostname: string,
-  ca: BouncerCA,
-): { cert: string; key: string } {
+export function generateHostCert(hostname: string, ca: BouncerCA): { cert: string; key: string } {
   const now = Date.now();
   const cached = hostCertCache.get(hostname);
   if (cached) {
@@ -144,16 +134,14 @@ export function generateHostCert(
   cert.serialNumber = generateSerialNumber();
   cert.validity.notBefore = new Date();
   cert.validity.notAfter = new Date();
-  cert.validity.notAfter.setTime(
-    cert.validity.notBefore.getTime() + 24 * 60 * 60 * 1000,
-  );
+  cert.validity.notAfter.setTime(cert.validity.notBefore.getTime() + 24 * 60 * 60 * 1000);
 
-  cert.setSubject([{ name: "commonName", value: hostname }]);
+  cert.setSubject([{ name: 'commonName', value: hostname }]);
   cert.setIssuer(caCert.subject.attributes);
 
   cert.setExtensions([
     {
-      name: "subjectAltName",
+      name: 'subjectAltName',
       altNames: [{ type: 2 /* DNS */, value: hostname }],
     },
   ]);

--- a/src/main/proxy.ts
+++ b/src/main/proxy.ts
@@ -3,14 +3,14 @@
 // HTTP proxy server with domain filtering and selective TLS MITM.
 // One instance per session — started by the session manager.
 
-import http from "node:http";
-import https from "node:https";
-import net from "node:net";
-import tls from "node:tls";
-import { Duplex } from "node:stream";
-import { generateHostCert } from "./proxy-tls.js";
-import type { BouncerCA } from "./proxy-tls.js";
-import type { GitHubPolicy, PolicyEvent } from "./types.js";
+import http from 'node:http';
+import https from 'node:https';
+import net from 'node:net';
+import tls from 'node:tls';
+import { Duplex } from 'node:stream';
+import { generateHostCert } from './proxy-tls.js';
+import type { BouncerCA } from './proxy-tls.js';
+import type { GitHubPolicy, PolicyEvent } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -43,10 +43,7 @@ export type MitmRequestHandler = (
   req: http.IncomingMessage,
   res: http.ServerResponse,
   hostname: string,
-  upstream: (
-    req: http.IncomingMessage,
-    res: http.ServerResponse,
-  ) => void,
+  upstream: (req: http.IncomingMessage, res: http.ServerResponse) => void,
   /** The upstream port from the original CONNECT request */
   upstreamPort: number,
 ) => void;
@@ -66,7 +63,7 @@ export interface ProxyHandle {
 
 function normalize(s: string): string {
   const lower = s.toLowerCase();
-  return lower.endsWith(".") ? lower.slice(0, -1) : lower;
+  return lower.endsWith('.') ? lower.slice(0, -1) : lower;
 }
 
 /**
@@ -78,10 +75,10 @@ function normalize(s: string): string {
  * Matching is case-insensitive and ignores trailing dots.
  */
 export function domainMatches(hostname: string, pattern: string): boolean {
-  if (pattern === "*") return true;
+  if (pattern === '*') return true;
   const h = normalize(hostname);
   const p = normalize(pattern);
-  if (p.startsWith("*.")) {
+  if (p.startsWith('*.')) {
     const suffix = p.slice(1); // ".example.com"
     return h.endsWith(suffix) && h.length > suffix.length;
   }
@@ -92,10 +89,7 @@ function domainAllowed(hostname: string, allowedDomains: string[]): boolean {
   return allowedDomains.some((p) => domainMatches(hostname, p));
 }
 
-function domainInspected(
-  hostname: string,
-  inspectedDomains: string[],
-): boolean {
+function domainInspected(hostname: string, inspectedDomains: string[]): boolean {
   return inspectedDomains.some((p) => domainMatches(hostname, p));
 }
 
@@ -108,19 +102,19 @@ export async function startProxy(config: ProxyConfig): Promise<ProxyHandle> {
 
   function trackSocket(socket: net.Socket | Duplex): void {
     openSockets.add(socket);
-    socket.on("close", () => openSockets.delete(socket));
+    socket.on('close', () => openSockets.delete(socket));
   }
 
   const server = http.createServer();
 
   // Track all incoming connections for clean shutdown
-  server.on("connection", trackSocket);
+  server.on('connection', trackSocket);
 
   // --- Plain HTTP requests ---
-  server.on("request", (req, res) => {
+  server.on('request', (req, res) => {
     if (!req.url) {
       res.writeHead(400);
-      res.end("Bad request\n");
+      res.end('Bad request\n');
       return;
     }
 
@@ -128,11 +122,11 @@ export async function startProxy(config: ProxyConfig): Promise<ProxyHandle> {
     try {
       // Proxy clients typically send absolute URLs (http://host/path).
       // Some may send origin-form (/path) with a Host header instead.
-      if (req.url.startsWith("/")) {
+      if (req.url.startsWith('/')) {
         const host = req.headers.host;
         if (!host) {
           res.writeHead(400);
-          res.end("Bad request: origin-form URL without Host header\n");
+          res.end('Bad request: origin-form URL without Host header\n');
           return;
         }
         url = new URL(req.url, `http://${host}`);
@@ -141,7 +135,7 @@ export async function startProxy(config: ProxyConfig): Promise<ProxyHandle> {
       }
     } catch {
       res.writeHead(400);
-      res.end("Bad request URL\n");
+      res.end('Bad request URL\n');
       return;
     }
 
@@ -156,17 +150,14 @@ export async function startProxy(config: ProxyConfig): Promise<ProxyHandle> {
   });
 
   // --- CONNECT requests (HTTPS tunneling) ---
-  server.on("connect", (req, clientSocket, head) => {
+  server.on('connect', (req, clientSocket, head) => {
     trackSocket(clientSocket);
-    const [host, portStr] = (req.url ?? "").split(":");
+    const [host, portStr] = (req.url ?? '').split(':');
     const port = parseInt(portStr) || 443;
 
     if (!host || !domainAllowed(host, config.allowedDomains)) {
-      emitDenyEvent(config, host ?? "unknown", `CONNECT ${req.url}`);
-      clientSocket.end(
-        "HTTP/1.1 403 Forbidden\r\n\r\n" +
-          formatDenyMessage(host ?? "unknown"),
-      );
+      emitDenyEvent(config, host ?? 'unknown', `CONNECT ${req.url}`);
+      clientSocket.end('HTTP/1.1 403 Forbidden\r\n\r\n' + formatDenyMessage(host ?? 'unknown'));
       return;
     }
 
@@ -177,19 +168,19 @@ export async function startProxy(config: ProxyConfig): Promise<ProxyHandle> {
 
     // Tunnel: connect directly to upstream
     const upstream = net.connect(port, host, () => {
-      clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+      clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
       if (head.length > 0) upstream.write(head);
       upstream.pipe(clientSocket);
       clientSocket.pipe(upstream);
     });
     trackSocket(upstream);
-    upstream.on("error", () => clientSocket.destroy());
-    clientSocket.on("error", () => upstream.destroy());
+    upstream.on('error', () => clientSocket.destroy());
+    clientSocket.on('error', () => upstream.destroy());
   });
 
   // Start listening
   await new Promise<void>((resolve) => {
-    server.listen(config.port, config.listenHost ?? "0.0.0.0", resolve);
+    server.listen(config.port, config.listenHost ?? '0.0.0.0', resolve);
   });
 
   const addr = server.address() as net.AddressInfo;
@@ -222,9 +213,7 @@ function handleMitm(
   const hostCert = generateHostCert(hostname, config.ca);
 
   // Tell the client the tunnel is established
-  (clientSocket as net.Socket).write(
-    "HTTP/1.1 200 Connection Established\r\n\r\n",
-  );
+  (clientSocket as net.Socket).write('HTTP/1.1 200 Connection Established\r\n\r\n');
 
   // Wrap the client socket in TLS (we are the server to the client)
   const tlsSocket = new tls.TLSSocket(clientSocket, {
@@ -236,10 +225,7 @@ function handleMitm(
 
   // Create an HTTP server to parse requests from the decrypted stream
   const mitmServer = http.createServer((req, res) => {
-    const doUpstreamForward = (
-      inReq: http.IncomingMessage,
-      inRes: http.ServerResponse,
-    ) => {
+    const doUpstreamForward = (inReq: http.IncomingMessage, inRes: http.ServerResponse) => {
       forwardToUpstream(hostname, port, inReq, inRes, config.insecureUpstreamTls);
     };
 
@@ -252,19 +238,19 @@ function handleMitm(
   });
 
   // Feed the TLS socket into the HTTP server
-  mitmServer.emit("connection", tlsSocket);
+  mitmServer.emit('connection', tlsSocket);
   if (head.length > 0) {
     tlsSocket.unshift(head);
   }
 
   // Clean up the per-connection MITM server when the socket closes
   const closeMitm = () => mitmServer.close();
-  tlsSocket.on("close", closeMitm);
+  tlsSocket.on('close', closeMitm);
 
-  tlsSocket.on("error", () => {
+  tlsSocket.on('error', () => {
     clientSocket.destroy();
   });
-  clientSocket.on("error", () => {
+  clientSocket.on('error', () => {
     tlsSocket.destroy();
   });
 }
@@ -291,9 +277,9 @@ function forwardHttpRequest(
     proxyRes.pipe(clientRes);
   });
 
-  proxyReq.on("error", () => {
+  proxyReq.on('error', () => {
     clientRes.writeHead(502);
-    clientRes.end("Bad Gateway\n");
+    clientRes.end('Bad Gateway\n');
   });
 
   clientReq.pipe(proxyReq);
@@ -320,9 +306,9 @@ function forwardToUpstream(
     proxyRes.pipe(clientRes);
   });
 
-  proxyReq.on("error", () => {
+  proxyReq.on('error', () => {
     clientRes.writeHead(502);
-    clientRes.end("Bad Gateway\n");
+    clientRes.end('Bad Gateway\n');
   });
 
   clientReq.pipe(proxyReq);
@@ -336,16 +322,12 @@ function formatDenyMessage(hostname: string): string {
   return `Bouncer: domain "${hostname}" is not in the allowed domain list.\n`;
 }
 
-function emitDenyEvent(
-  config: ProxyConfig,
-  hostname: string,
-  operation: string,
-): void {
+function emitDenyEvent(config: ProxyConfig, hostname: string, operation: string): void {
   config.onPolicyEvent({
     timestamp: Date.now(),
-    tool: "proxy",
+    tool: 'proxy',
     operation,
-    decision: "deny",
+    decision: 'deny',
     reason: `Domain "${hostname}" not in allowedDomains`,
   });
 }

--- a/src/main/replay-scaffold.ts
+++ b/src/main/replay-scaffold.ts
@@ -1,6 +1,6 @@
-import { mkdir, writeFile } from "node:fs/promises";
-import { basename, dirname, extname, join, relative, isAbsolute } from "node:path";
-import type { ReplayToolCall } from "./types.js";
+import { mkdir, writeFile } from 'node:fs/promises';
+import { basename, dirname, extname, join, relative, isAbsolute } from 'node:path';
+import type { ReplayToolCall } from './types.js';
 
 export interface ScaffoldPlan {
   /** Relative path → file content */
@@ -18,16 +18,16 @@ function looksLikeFile(path: string): boolean {
   const ext = extname(base);
   // extname(".github") returns ".github" — the whole name is the "extension"
   // A real file extension means the name has content before the dot
-  return ext !== "" && base !== ext;
+  return ext !== '' && base !== ext;
 }
 
 /**
  * Returns true if the raw (pre-deanonymized) path should be skipped for scaffolding.
  */
 function shouldSkipPath(raw: string): boolean {
-  if (raw.includes("{project-name}")) return true;
-  if (raw.includes(".claude/")) return true;
-  if (raw.includes("{home}")) return true;
+  if (raw.includes('{project-name}')) return true;
+  if (raw.includes('.claude/')) return true;
+  if (raw.includes('{home}')) return true;
   return false;
 }
 
@@ -39,7 +39,7 @@ function toRelativePath(absPath: string, worktreePath: string): string | null {
   if (!isAbsolute(absPath)) return null;
   const rel = relative(worktreePath, absPath);
   // Reject paths outside the worktree (../ or absolute)
-  if (rel.startsWith("..") || isAbsolute(rel)) return null;
+  if (rel.startsWith('..') || isAbsolute(rel)) return null;
   return rel;
 }
 
@@ -69,16 +69,16 @@ export function buildScaffoldPlan(
     const rel = toRelativePath(abs, worktreePath);
     if (!rel) return;
 
-    if (content != null && content !== "// stub\n") {
+    if (content != null && content !== '// stub\n') {
       // Meaningful content (e.g. old_string from Edit) — append if file already has content
       const existing = files.get(rel);
-      if (existing && existing !== "// stub\n") {
-        files.set(rel, existing + "\n" + content);
+      if (existing && existing !== '// stub\n') {
+        files.set(rel, existing + '\n' + content);
       } else {
         files.set(rel, content);
       }
     } else if (!files.has(rel)) {
-      files.set(rel, "// stub\n");
+      files.set(rel, '// stub\n');
     }
   }
 
@@ -93,12 +93,12 @@ export function buildScaffoldPlan(
   for (const call of toolCalls) {
     const input = call.input;
     switch (call.tool) {
-      case "Read": {
+      case 'Read': {
         const filePath = input.file_path as string | undefined;
-        if (filePath) addFile(filePath, "// stub\n");
+        if (filePath) addFile(filePath, '// stub\n');
         break;
       }
-      case "Write": {
+      case 'Write': {
         const filePath = input.file_path as string | undefined;
         if (filePath) {
           // Only create parent directory — Write creates the file itself
@@ -107,42 +107,42 @@ export function buildScaffoldPlan(
             const rel = toRelativePath(abs, worktreePath);
             if (rel) {
               const dir = dirname(rel);
-              if (dir !== ".") directories.add(dir);
+              if (dir !== '.') directories.add(dir);
             }
           }
         }
         break;
       }
-      case "Edit": {
+      case 'Edit': {
         const filePath = input.file_path as string | undefined;
         if (filePath) {
           const oldString = input.old_string as string | undefined;
-          addFile(filePath, oldString ?? "// stub\n");
+          addFile(filePath, oldString ?? '// stub\n');
         }
         break;
       }
-      case "Grep": {
+      case 'Grep': {
         const path = input.path as string | undefined;
         if (path) {
           if (looksLikeFile(path)) {
-            addFile(path, "// stub\n");
+            addFile(path, '// stub\n');
           } else {
             addDirectory(path);
           }
         }
         break;
       }
-      case "Glob": {
+      case 'Glob': {
         const path = input.path as string | undefined;
         if (path) addDirectory(path);
         break;
       }
-      case "Bash": {
+      case 'Bash': {
         const command = input.command as string | undefined;
         if (command) {
           for (const raw of extractProjectPaths(command)) {
             if (looksLikeFile(raw)) {
-              addFile(raw, "// stub\n");
+              addFile(raw, '// stub\n');
             } else {
               addDirectory(raw);
             }
@@ -160,10 +160,7 @@ export function buildScaffoldPlan(
  * Apply a scaffold plan to a worktree directory.
  * Returns the number of files created.
  */
-export async function applyScaffold(
-  worktreePath: string,
-  plan: ScaffoldPlan,
-): Promise<number> {
+export async function applyScaffold(worktreePath: string, plan: ScaffoldPlan): Promise<number> {
   // Create directories first
   for (const dir of plan.directories) {
     await mkdir(join(worktreePath, dir), { recursive: true });
@@ -174,10 +171,10 @@ export async function applyScaffold(
     const absPath = join(worktreePath, relPath);
     await mkdir(dirname(absPath), { recursive: true });
     try {
-      await writeFile(absPath, content, { encoding: "utf-8", flag: "wx" });
+      await writeFile(absPath, content, { encoding: 'utf-8', flag: 'wx' });
       created++;
     } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === "EEXIST") continue;
+      if ((err as NodeJS.ErrnoException).code === 'EEXIST') continue;
       throw err;
     }
   }

--- a/src/main/repository-store.ts
+++ b/src/main/repository-store.ts
@@ -1,10 +1,10 @@
-import { randomUUID } from "node:crypto";
-import { join } from "node:path";
-import { homedir } from "node:os";
-import { readFile, writeFile, mkdir, rename, unlink } from "node:fs/promises";
-import { execFile as execFileCb } from "node:child_process";
-import { promisify } from "node:util";
-import type { AgentType, Repository } from "./types.js";
+import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { readFile, writeFile, mkdir, rename, unlink } from 'node:fs/promises';
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { AgentType, Repository } from './types.js';
 
 const execFile = promisify(execFileCb);
 
@@ -13,19 +13,19 @@ export class RepositoryStore {
   private configPath: string;
 
   constructor(configDir?: string) {
-    const dir = configDir ?? join(homedir(), ".config", "bouncer");
-    this.configPath = join(dir, "repositories.json");
+    const dir = configDir ?? join(homedir(), '.config', 'bouncer');
+    this.configPath = join(dir, 'repositories.json');
   }
 
   async load(): Promise<void> {
     try {
-      const raw = await readFile(this.configPath, "utf-8");
+      const raw = await readFile(this.configPath, 'utf-8');
       const parsed = JSON.parse(raw);
       if (Array.isArray(parsed)) {
         this.repos = parsed;
       }
     } catch (err: unknown) {
-      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
         // First run — no config file yet
         this.repos = [];
       } else {
@@ -35,12 +35,12 @@ export class RepositoryStore {
   }
 
   private async save(): Promise<void> {
-    const dir = join(this.configPath, "..");
+    const dir = join(this.configPath, '..');
     await mkdir(dir, { recursive: true });
-    const json = JSON.stringify(this.repos, null, 2) + "\n";
+    const json = JSON.stringify(this.repos, null, 2) + '\n';
     // Atomic write: write to temp file then rename
-    const tmpPath = this.configPath + ".tmp";
-    await writeFile(tmpPath, json, "utf-8");
+    const tmpPath = this.configPath + '.tmp';
+    await writeFile(tmpPath, json, 'utf-8');
     await rename(tmpPath, this.configPath);
   }
 
@@ -55,7 +55,7 @@ export class RepositoryStore {
   async add(localPath: string): Promise<Repository> {
     // Validate: must be a git repo
     try {
-      await execFile("git", ["-C", localPath, "rev-parse", "--git-dir"]);
+      await execFile('git', ['-C', localPath, 'rev-parse', '--git-dir']);
     } catch {
       throw new Error(`Not a git repository: ${localPath}`);
     }
@@ -66,12 +66,12 @@ export class RepositoryStore {
     }
 
     // Auto-detect name from directory basename
-    const name = localPath.split("/").pop() ?? localPath;
+    const name = localPath.split('/').pop() ?? localPath;
 
     // Auto-detect GitHub repo from origin remote
     let githubRepo: string | null = null;
     try {
-      const { stdout } = await execFile("git", ["-C", localPath, "remote", "get-url", "origin"]);
+      const { stdout } = await execFile('git', ['-C', localPath, 'remote', 'get-url', 'origin']);
       githubRepo = parseGitHubRepo(stdout.trim());
     } catch {
       // No origin remote or not a GitHub repo — that's fine
@@ -82,8 +82,8 @@ export class RepositoryStore {
       name,
       localPath,
       githubRepo,
-      defaultPolicyId: "standard-pr",
-      defaultAgentType: "claude-code" as AgentType,
+      defaultPolicyId: 'standard-pr',
+      defaultAgentType: 'claude-code' as AgentType,
       createdAt: Date.now(),
     };
 
@@ -92,7 +92,7 @@ export class RepositoryStore {
     return repo;
   }
 
-  async update(id: string, changes: Partial<Omit<Repository, "id" | "createdAt">>): Promise<void> {
+  async update(id: string, changes: Partial<Omit<Repository, 'id' | 'createdAt'>>): Promise<void> {
     const idx = this.repos.findIndex((r) => r.id === id);
     if (idx < 0) {
       throw new Error(`Repository not found: ${id}`);
@@ -123,9 +123,9 @@ export function parseGitHubRepo(url: string): string | null {
   // HTTPS format: https://github.com/owner/repo.git
   try {
     const parsed = new URL(url);
-    if (parsed.hostname === "github.com") {
-      const path = parsed.pathname.replace(/^\//, "").replace(/\.git$/, "");
-      if (path.includes("/")) return path;
+    if (parsed.hostname === 'github.com') {
+      const path = parsed.pathname.replace(/^\//, '').replace(/\.git$/, '');
+      if (path.includes('/')) return path;
     }
   } catch {
     // Not a valid URL

--- a/src/main/sandbox-monitor.ts
+++ b/src/main/sandbox-monitor.ts
@@ -1,7 +1,7 @@
-import { spawn, execFile, type ChildProcess } from "node:child_process";
-import { promisify } from "node:util";
-import { EventEmitter } from "node:events";
-import { createInterface } from "node:readline";
+import { spawn, execFile, type ChildProcess } from 'node:child_process';
+import { promisify } from 'node:util';
+import { EventEmitter } from 'node:events';
+import { createInterface } from 'node:readline';
 
 const execFileAsync = promisify(execFile);
 
@@ -54,13 +54,13 @@ export class SandboxMonitor extends EventEmitter<SandboxMonitorEvents> {
     const WARMUP_MS = 5000;
 
     this.logProcess = spawn(
-      "log",
-      ["stream", "--style", "ndjson", "--predicate", 'sender=="Sandbox"'],
-      { stdio: ["ignore", "pipe", "ignore"] }
+      'log',
+      ['stream', '--style', 'ndjson', '--predicate', 'sender=="Sandbox"'],
+      { stdio: ['ignore', 'pipe', 'ignore'] },
     );
 
     const rl = createInterface({ input: this.logProcess.stdout! });
-    rl.on("line", (line) => {
+    rl.on('line', (line) => {
       const violation = this.parseLine(line);
       if (!violation) return;
 
@@ -68,18 +68,18 @@ export class SandboxMonitor extends EventEmitter<SandboxMonitorEvents> {
       if (inWarmup || this.knownPids.has(violation.pid)) {
         // During warmup, add discovered PIDs to the known set
         if (inWarmup) this.knownPids.add(violation.pid);
-        this.emit("violation", violation);
+        this.emit('violation', violation);
       }
     });
 
-    this.logProcess.on("exit", (code) => {
+    this.logProcess.on('exit', (code) => {
       if (code !== null && code !== 0) {
         console.warn(`Sandbox monitor log stream exited with code ${code}`);
       }
     });
 
-    this.logProcess.on("error", (err) => {
-      console.warn("Sandbox monitor log stream error:", err.message);
+    this.logProcess.on('error', (err) => {
+      console.warn('Sandbox monitor log stream error:', err.message);
     });
 
     // Refresh PID tree periodically
@@ -110,11 +110,9 @@ export class SandboxMonitor extends EventEmitter<SandboxMonitorEvents> {
   private parseLine(line: string): SandboxViolation | null {
     try {
       const entry = JSON.parse(line);
-      const msg: string = entry.eventMessage ?? "";
+      const msg: string = entry.eventMessage ?? '';
 
-      const match = msg.match(
-        /Sandbox:\s+(\S+)\((\d+)\)\s+deny\(\d+\)\s+([\w*-]+)\s*(.*)/
-      );
+      const match = msg.match(/Sandbox:\s+(\S+)\((\d+)\)\s+deny\(\d+\)\s+([\w*-]+)\s*(.*)/);
       if (!match) return null;
 
       const [, processName, pidStr, operation, path] = match;
@@ -138,11 +136,11 @@ export class SandboxMonitor extends EventEmitter<SandboxMonitorEvents> {
   }
 
   private discoverDescendants(parentPid: number): void {
-    execFileAsync("pgrep", ["-P", String(parentPid)])
+    execFileAsync('pgrep', ['-P', String(parentPid)])
       .then(({ stdout }) => {
         const pids = stdout
           .trim()
-          .split("\n")
+          .split('\n')
           .filter(Boolean)
           .map(Number)
           .filter((n) => !isNaN(n));
@@ -156,11 +154,8 @@ export class SandboxMonitor extends EventEmitter<SandboxMonitorEvents> {
       .catch((error: unknown) => {
         // pgrep returns exit code 1 when no children found — expected
         const err = error as { code?: number | string | null; message?: string };
-        if (err?.code === 1 || err?.code === "1") return;
-        console.warn(
-          `SandboxMonitor: pgrep failed for PID ${parentPid}:`,
-          err?.message ?? error
-        );
+        if (err?.code === 1 || err?.code === '1') return;
+        console.warn(`SandboxMonitor: pgrep failed for PID ${parentPid}:`, err?.message ?? error);
       });
   }
 }

--- a/src/main/sandbox.ts
+++ b/src/main/sandbox.ts
@@ -18,26 +18,26 @@
  *   - Policy file lifecycle management
  */
 
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 
 const execFileAsync = promisify(execFile);
 
-export const POLICY_DIR = join(tmpdir(), "bouncer-sandbox");
+export const POLICY_DIR = join(tmpdir(), 'bouncer-sandbox');
 
 export const BASE_ENV_PASSTHROUGH = [
-  "ANTHROPIC_API_KEY",
-  "NODE_OPTIONS",
-  "NODE_PATH",
-  "EDITOR",
-  "VISUAL",
-  "GIT_AUTHOR_NAME",
-  "GIT_AUTHOR_EMAIL",
-  "GIT_COMMITTER_NAME",
-  "GIT_COMMITTER_EMAIL",
+  'ANTHROPIC_API_KEY',
+  'NODE_OPTIONS',
+  'NODE_PATH',
+  'EDITOR',
+  'VISUAL',
+  'GIT_AUTHOR_NAME',
+  'GIT_AUTHOR_EMAIL',
+  'GIT_COMMITTER_NAME',
+  'GIT_COMMITTER_EMAIL',
 ];
 
 export interface SandboxConfig {
@@ -63,10 +63,7 @@ export interface SandboxConfig {
  *
  * When safehouse is unavailable, falls back to unsandboxed execution.
  */
-export function buildSafehouseArgs(
-  config: SandboxConfig,
-  command: string[]
-): string[] {
+export function buildSafehouseArgs(config: SandboxConfig, command: string[]): string[] {
   const args: string[] = [];
 
   // Persist the policy file so we control its lifecycle
@@ -76,34 +73,34 @@ export function buildSafehouseArgs(
   // basename, but we spawn "node <agent-bin>" so it can't detect that
   // the wrapped process is Claude Code. --enable=all-agents loads all
   // agent-specific grants (Claude Code state dirs, etc.).
-  args.push("--enable=all-agents");
+  args.push('--enable=all-agents');
 
   // Set the working directory for git root detection
   args.push(`--workdir=${config.workdir}`);
 
   // Writable directories
   if (config.writableDirs.length > 0) {
-    args.push(`--add-dirs=${config.writableDirs.join(":")}`);
+    args.push(`--add-dirs=${config.writableDirs.join(':')}`);
   }
 
   // Read-only directories
   if (config.readOnlyDirs.length > 0) {
-    args.push(`--add-dirs-ro=${config.readOnlyDirs.join(":")}`);
+    args.push(`--add-dirs-ro=${config.readOnlyDirs.join(':')}`);
   }
 
   // Environment passthrough
   if (config.envPassthrough.length > 0) {
-    args.push(`--env-pass=${config.envPassthrough.join(",")}`);
+    args.push(`--env-pass=${config.envPassthrough.join(',')}`);
   }
 
   // Append profile overlay for policy-specific SBPL rules
   if (config.appendProfileContent) {
-    const appendPath = config.policyOutputPath.replace(/\.sb$/, "-append.sb");
+    const appendPath = config.policyOutputPath.replace(/\.sb$/, '-append.sb');
     args.push(`--append-profile=${appendPath}`);
   }
 
   // Separator and command
-  args.push("--");
+  args.push('--');
   args.push(...command);
 
   return args;
@@ -151,7 +148,7 @@ let _safehouseAvailable: boolean | null = null;
 export async function isSafehouseAvailable(): Promise<boolean> {
   if (_safehouseAvailable !== null) return _safehouseAvailable;
   try {
-    await execFileAsync("safehouse", ["--version"]);
+    await execFileAsync('safehouse', ['--version']);
     _safehouseAvailable = true;
   } catch {
     _safehouseAvailable = false;
@@ -172,15 +169,15 @@ export async function ensurePolicyDir(): Promise<void> {
  */
 export async function writeAppendProfile(config: SandboxConfig): Promise<void> {
   if (!config.appendProfileContent) return;
-  const appendPath = config.policyOutputPath.replace(/\.sb$/, "-append.sb");
-  await writeFile(appendPath, config.appendProfileContent, "utf-8");
+  const appendPath = config.policyOutputPath.replace(/\.sb$/, '-append.sb');
+  await writeFile(appendPath, config.appendProfileContent, 'utf-8');
 }
 
 /**
  * Clean up a session's policy file(s), including any append profile.
  */
 export async function cleanupPolicy(policyPath: string): Promise<void> {
-  const appendPath = policyPath.replace(/\.sb$/, "-append.sb");
+  const appendPath = policyPath.replace(/\.sb$/, '-append.sb');
   await rm(policyPath, { force: true }).catch(() => {});
   await rm(appendPath, { force: true }).catch(() => {});
 }
@@ -188,16 +185,14 @@ export async function cleanupPolicy(policyPath: string): Promise<void> {
 /**
  * Clean up orphan policy files from previous sessions.
  */
-export async function cleanupOrphanPolicies(
-  activeSessionIds: Set<string>
-): Promise<void> {
-  const { readdir } = await import("node:fs/promises");
+export async function cleanupOrphanPolicies(activeSessionIds: Set<string>): Promise<void> {
+  const { readdir } = await import('node:fs/promises');
   try {
     const entries = await readdir(POLICY_DIR);
     for (const entry of entries) {
-      if (entry.endsWith(".sb")) {
+      if (entry.endsWith('.sb')) {
         // Extract session ID from both "uuid.sb" and "uuid-append.sb"
-        const sessionId = entry.replace(/-append\.sb$/, "").replace(/\.sb$/, "");
+        const sessionId = entry.replace(/-append\.sb$/, '').replace(/\.sb$/, '');
         if (!activeSessionIds.has(sessionId)) {
           await rm(join(POLICY_DIR, entry), { force: true });
         }

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -1,4 +1,4 @@
-export type AgentType = "echo" | "claude-code" | "replay";
+export type AgentType = 'echo' | 'claude-code' | 'replay';
 
 // --- Repository Types (M8) ---
 
@@ -12,13 +12,11 @@ export interface Repository {
   createdAt: number;
 }
 
-export type MessagePart =
-  | { type: "text"; index: number }
-  | { type: "tool"; toolCallId: string };
+export type MessagePart = { type: 'text'; index: number } | { type: 'tool'; toolCallId: string };
 
 export interface Message {
   id: string;
-  role: "user" | "agent";
+  role: 'user' | 'agent';
   text: string;
   timestamp: number;
   streaming?: boolean;
@@ -30,19 +28,19 @@ export interface Message {
 export interface ToolCallInfo {
   id: string;
   name: string;
-  status: "pending" | "in_progress" | "completed" | "failed";
+  status: 'pending' | 'in_progress' | 'completed' | 'failed';
   title?: string;
   description?: string;
   input?: Record<string, unknown>;
   output?: string;
 }
 
-export type SandboxBackend = "safehouse" | "container" | "none";
+export type SandboxBackend = 'safehouse' | 'container' | 'none';
 
 export interface WorkspaceSummary {
   id: string;
   repositoryId: string | null;
-  status: "initializing" | "ready" | "error" | "closed";
+  status: 'initializing' | 'ready' | 'error' | 'closed';
   messageCount: number;
   agentType: AgentType;
   projectDir: string;
@@ -53,7 +51,7 @@ export interface WorkspaceSummary {
   policyName: string | null;
   githubRepo: string | null;
   ownedPrNumber: number | null;
-  networkAccess: "full" | "none" | "filtered" | null;
+  networkAccess: 'full' | 'none' | 'filtered' | null;
 }
 
 // --- GitHub Application-Layer Policy Types (M5) ---
@@ -69,9 +67,9 @@ export interface GitHubPolicy {
 /** Logged when the gh shim, git hook, or proxy allows/denies an operation. */
 export interface PolicyEvent {
   timestamp: number;
-  tool: "gh" | "git" | "proxy";
+  tool: 'gh' | 'git' | 'proxy';
   operation: string;
-  decision: "allow" | "deny";
+  decision: 'allow' | 'deny';
   reason?: string;
 }
 
@@ -80,7 +78,7 @@ export interface PolicyEvent {
 export interface ContainerPolicy {
   image?: string;
   additionalMounts?: Array<{ hostPath: string; containerPath: string; readOnly: boolean }>;
-  networkMode?: "none" | "bridge" | "proxy";
+  networkMode?: 'none' | 'bridge' | 'proxy';
 }
 
 export interface PolicyTemplate {
@@ -97,15 +95,15 @@ export interface PolicyTemplate {
 }
 
 export interface FilesystemPolicy {
-  worktreeAccess: "read-write" | "read-only";
+  worktreeAccess: 'read-write' | 'read-only';
   additionalWritableDirs: string[];
   additionalReadOnlyDirs: string[];
 }
 
 export type NetworkPolicy =
-  | { access: "full" }
-  | { access: "none" }
-  | { access: "filtered"; allowedDomains: string[]; inspectedDomains: string[] };
+  | { access: 'full' }
+  | { access: 'none' }
+  | { access: 'filtered'; allowedDomains: string[]; inspectedDomains: string[] };
 
 export interface EnvPolicy {
   additional: string[];
@@ -137,16 +135,35 @@ export interface ReplayToolCall {
 export interface ReplayResult {
   id: number;
   tool: string;
-  replay_outcome: "allowed" | "blocked" | "skipped" | "error";
+  replay_outcome: 'allowed' | 'blocked' | 'skipped' | 'error';
   error_message?: string;
   original_outcome: string;
 }
 
 export type WorkspaceUpdate =
-  | { workspaceId: string; type: "status-change"; status: WorkspaceSummary["status"]; error?: string; errorKind?: "auth"; summary?: WorkspaceSummary }
-  | { workspaceId: string; type: "message"; message: Message }
-  | { workspaceId: string; type: "stream-chunk"; messageId: string; text: string; segmentIndex: number }
-  | { workspaceId: string; type: "stream-end"; messageId: string; textSegments: string[]; parts: MessagePart[] }
-  | { workspaceId: string; type: "tool-call"; messageId: string; toolCall: ToolCallInfo }
-  | { workspaceId: string; type: "sandbox-violation"; violation: SandboxViolationInfo }
-  | { workspaceId: string; type: "policy-event"; event: PolicyEvent };
+  | {
+      workspaceId: string;
+      type: 'status-change';
+      status: WorkspaceSummary['status'];
+      error?: string;
+      errorKind?: 'auth';
+      summary?: WorkspaceSummary;
+    }
+  | { workspaceId: string; type: 'message'; message: Message }
+  | {
+      workspaceId: string;
+      type: 'stream-chunk';
+      messageId: string;
+      text: string;
+      segmentIndex: number;
+    }
+  | {
+      workspaceId: string;
+      type: 'stream-end';
+      messageId: string;
+      textSegments: string[];
+      parts: MessagePart[];
+    }
+  | { workspaceId: string; type: 'tool-call'; messageId: string; toolCall: ToolCallInfo }
+  | { workspaceId: string; type: 'sandbox-violation'; violation: SandboxViolationInfo }
+  | { workspaceId: string; type: 'policy-event'; event: PolicyEvent };

--- a/src/main/workspace-manager.ts
+++ b/src/main/workspace-manager.ts
@@ -1,12 +1,12 @@
-import { spawn, type ChildProcess } from "node:child_process";
-import { createRequire } from "node:module";
-import { randomUUID } from "node:crypto";
-import { join } from "node:path";
-import { StringDecoder } from "node:string_decoder";
-import { Writable, Readable } from "node:stream";
-import * as acp from "@agentclientprotocol/sdk";
-import { app } from "electron";
-import { WorktreeManager, type WorktreeInfo } from "./worktree-manager.js";
+import { spawn, type ChildProcess } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
+import { StringDecoder } from 'node:string_decoder';
+import { Writable, Readable } from 'node:stream';
+import * as acp from '@agentclientprotocol/sdk';
+import { app } from 'electron';
+import { WorktreeManager, type WorktreeInfo } from './worktree-manager.js';
 import {
   type SandboxConfig,
   buildSafehouseArgs,
@@ -15,12 +15,12 @@ import {
   cleanupPolicy,
   cleanupOrphanPolicies,
   writeAppendProfile,
-} from "./sandbox.js";
-import { SandboxMonitor } from "./sandbox-monitor.js";
-import { ContainerMonitor } from "./container-monitor.js";
-import { PolicyTemplateRegistry } from "./policy-registry.js";
-import { policyToSandboxConfig } from "./policy-sandbox.js";
-import { parsePolicyEvent } from "./policy-event-parser.js";
+} from './sandbox.js';
+import { SandboxMonitor } from './sandbox-monitor.js';
+import { ContainerMonitor } from './container-monitor.js';
+import { PolicyTemplateRegistry } from './policy-registry.js';
+import { policyToSandboxConfig } from './policy-sandbox.js';
+import { parsePolicyEvent } from './policy-event-parser.js';
 import {
   detectGitHubRepo,
   buildSessionPolicy,
@@ -32,11 +32,20 @@ import {
   cleanupGhShim,
   findRealGh,
   cleanupOrphanGitHubArtifacts,
-} from "./github-policy.js";
-import { installHooks, cleanupHooks, generatePrePushHookForContainer, allowedRefsPath } from "./hooks.js";
-import { policyToContainerConfig, generateGitconfig, type ContainerSessionContext } from "./policy-container.js";
-import { writeFile, mkdir, rm, chmod } from "node:fs/promises";
-import { POLICY_DIR } from "./sandbox.js";
+} from './github-policy.js';
+import {
+  installHooks,
+  cleanupHooks,
+  generatePrePushHookForContainer,
+  allowedRefsPath,
+} from './hooks.js';
+import {
+  policyToContainerConfig,
+  generateGitconfig,
+  type ContainerSessionContext,
+} from './policy-container.js';
+import { writeFile, mkdir, rm, chmod } from 'node:fs/promises';
+import { POLICY_DIR } from './sandbox.js';
 import type {
   AgentType,
   GitHubPolicy,
@@ -48,8 +57,8 @@ import type {
   WorkspaceSummary,
   WorkspaceUpdate,
   ToolCallInfo,
-} from "./types.js";
-import type { RepositoryStore } from "./repository-store.js";
+} from './types.js';
+import type { RepositoryStore } from './repository-store.js';
 import {
   isDockerAvailable,
   ensureAgentImage,
@@ -58,11 +67,15 @@ import {
   cleanupOrphanContainers,
   type ContainerConfig,
   type ContainerHandle,
-} from "./container.js";
-import { ensureCA } from "./proxy-tls.js";
-import { startProxy, type ProxyConfig, type ProxyHandle } from "./proxy.js";
-import { createGitHubMitmHandler } from "./proxy-github.js";
-import { createSessionNetwork, cleanupOrphanNetworks, type SessionNetwork } from "./proxy-network.js";
+} from './container.js';
+import { ensureCA } from './proxy-tls.js';
+import { startProxy, type ProxyConfig, type ProxyHandle } from './proxy.js';
+import { createGitHubMitmHandler } from './proxy-github.js';
+import {
+  createSessionNetwork,
+  cleanupOrphanNetworks,
+  type SessionNetwork,
+} from './proxy-network.js';
 
 interface SpawnConfig {
   cmd: string;
@@ -74,44 +87,39 @@ interface SpawnConfig {
 function resolveEchoAgentCommand(): SpawnConfig {
   const isDev = !app.isPackaged;
   if (isDev) {
-    const require = createRequire(app.getAppPath() + "/");
-    const tsxBin = require.resolve("tsx/cli");
-    const agentScript = join(app.getAppPath(), "src", "agents", "echo-agent.ts");
+    const require = createRequire(app.getAppPath() + '/');
+    const tsxBin = require.resolve('tsx/cli');
+    const agentScript = join(app.getAppPath(), 'src', 'agents', 'echo-agent.ts');
     return {
       cmd: process.execPath,
       args: [tsxBin, agentScript],
-      env: { ELECTRON_RUN_AS_NODE: "1" },
+      env: { ELECTRON_RUN_AS_NODE: '1' },
     };
   } else {
-    const agentScript = join(__dirname, "..", "agents", "echo-agent.js");
+    const agentScript = join(__dirname, '..', 'agents', 'echo-agent.js');
     return {
       cmd: process.execPath,
       args: [agentScript],
-      env: { ELECTRON_RUN_AS_NODE: "1" },
+      env: { ELECTRON_RUN_AS_NODE: '1' },
     };
   }
 }
 
-function resolveClaudeCodeCommand(
-  cwd: string,
-  sandboxConfig: SandboxConfig | null,
-): SpawnConfig {
-  const require = createRequire(app.getAppPath() + "/");
-  const binPath = require.resolve(
-    "@zed-industries/claude-agent-acp/dist/index.js"
-  );
+function resolveClaudeCodeCommand(cwd: string, sandboxConfig: SandboxConfig | null): SpawnConfig {
+  const require = createRequire(app.getAppPath() + '/');
+  const binPath = require.resolve('@zed-industries/claude-agent-acp/dist/index.js');
 
   // When safehouse is available, wrap in sandbox
   if (sandboxConfig) {
-    const args = buildSafehouseArgs(sandboxConfig, ["node", binPath]);
-    return { cmd: "safehouse", args, cwd };
+    const args = buildSafehouseArgs(sandboxConfig, ['node', binPath]);
+    return { cmd: 'safehouse', args, cwd };
   }
 
   // Unsandboxed fallback — use node binary rather than process.execPath
   // (Electron) to avoid spawning a second Electron instance with its own
   // Dock icon on macOS.
   return {
-    cmd: "node",
+    cmd: 'node',
     args: [binPath],
     cwd,
   };
@@ -123,18 +131,18 @@ function resolveReplayAgentCommand(
   worktreePath: string,
 ): SpawnConfig {
   const isDev = !app.isPackaged;
-  const require = createRequire(app.getAppPath() + "/");
+  const require = createRequire(app.getAppPath() + '/');
 
   let cmd: string;
   let args: string[];
 
   let agentArgs: string[];
   if (isDev) {
-    const tsxBin = require.resolve("tsx/cli");
-    const agentScript = join(app.getAppPath(), "src", "agents", "replay-agent.ts");
+    const tsxBin = require.resolve('tsx/cli');
+    const agentScript = join(app.getAppPath(), 'src', 'agents', 'replay-agent.ts');
     agentArgs = [tsxBin, agentScript];
   } else {
-    const agentScript = join(__dirname, "..", "agents", "replay-agent.js");
+    const agentScript = join(__dirname, '..', 'agents', 'replay-agent.js');
     agentArgs = [agentScript];
   }
 
@@ -147,13 +155,13 @@ function resolveReplayAgentCommand(
   // takes effect). Without safehouse, use process.execPath with
   // ELECTRON_RUN_AS_NODE so we don't depend on node being on PATH.
   if (sandboxConfig) {
-    const safehouseArgs = buildSafehouseArgs(sandboxConfig, ["node", ...agentArgs]);
-    return { cmd: "safehouse", args: safehouseArgs, cwd, env };
+    const safehouseArgs = buildSafehouseArgs(sandboxConfig, ['node', ...agentArgs]);
+    return { cmd: 'safehouse', args: safehouseArgs, cwd, env };
   }
 
   cmd = process.execPath;
   args = agentArgs;
-  env.ELECTRON_RUN_AS_NODE = "1";
+  env.ELECTRON_RUN_AS_NODE = '1';
   return { cmd, args, env, cwd };
 }
 
@@ -165,10 +173,10 @@ function resolveAgentCommand(
   sandboxConfig: SandboxConfig | null,
   worktreePath?: string,
 ): SpawnConfig {
-  if (agentType === "echo") {
+  if (agentType === 'echo') {
     return resolveEchoAgentCommand();
   }
-  if (agentType === "replay") {
+  if (agentType === 'replay') {
     return resolveReplayAgentCommand(cwd, sandboxConfig, worktreePath ?? cwd);
   }
   return resolveClaudeCodeCommand(cwd, sandboxConfig);
@@ -177,11 +185,16 @@ function resolveAgentCommand(
 /** Heuristic: does the error look like an authentication/token failure? */
 function isAuthError(err: unknown): boolean {
   // Extract message from Error objects, JSON-RPC error objects, or plain strings
-  const raw = typeof err === "string" ? err
-    : err && typeof err === "object" && "message" in err ? String((err as { message: unknown }).message)
-    : String(err);
+  const raw =
+    typeof err === 'string'
+      ? err
+      : err && typeof err === 'object' && 'message' in err
+        ? String((err as { message: unknown }).message)
+        : String(err);
   const msg = raw.toLowerCase();
-  return /\b(401|unauthorized|authentication.*(failed|error|required|expired)|token.*expired|invalid[._ -]?token|unauthenticated)\b/.test(msg);
+  return /\b(401|unauthorized|authentication.*(failed|error|required|expired)|token.*expired|invalid[._ -]?token|unauthenticated)\b/.test(
+    msg,
+  );
 }
 
 interface WorkspaceState {
@@ -191,9 +204,9 @@ interface WorkspaceState {
   agentProcess: ChildProcess;
   connection: acp.ClientSideConnection;
   messages: Message[];
-  status: "initializing" | "ready" | "error" | "closed";
+  status: 'initializing' | 'ready' | 'error' | 'closed';
   errorMessage?: string;
-  errorKind?: "auth";
+  errorKind?: 'auth';
   agentType: AgentType;
   projectDir: string;
   worktree: WorktreeInfo | null;
@@ -233,12 +246,17 @@ export class WorkspaceManager {
     if (!repo) {
       throw new Error(`Repository not found: ${repositoryId}`);
     }
-    return this.createWorkspace(repo.localPath, repo.defaultAgentType, repo.defaultPolicyId, repositoryId);
+    return this.createWorkspace(
+      repo.localPath,
+      repo.defaultAgentType,
+      repo.defaultPolicyId,
+      repositoryId,
+    );
   }
 
   async createWorkspace(
     projectDir: string,
-    agentType: AgentType = "claude-code",
+    agentType: AgentType = 'claude-code',
     policyId?: string,
     repositoryId?: string,
   ): Promise<WorkspaceSummary> {
@@ -246,16 +264,14 @@ export class WorkspaceManager {
     let worktree: WorktreeInfo | null = null;
 
     // Resolve policy template — replay agents also get sandboxed
-    const resolvedPolicyId = (agentType === "claude-code" || agentType === "replay")
-      ? (policyId ?? this.policyRegistry.defaultId)
-      : null;
-    const template = resolvedPolicyId
-      ? this.policyRegistry.get(resolvedPolicyId)
-      : null;
+    const resolvedPolicyId =
+      agentType === 'claude-code' || agentType === 'replay'
+        ? (policyId ?? this.policyRegistry.defaultId)
+        : null;
+    const template = resolvedPolicyId ? this.policyRegistry.get(resolvedPolicyId) : null;
 
     // Create worktree for Claude Code and replay sessions
-    if (agentType === "claude-code" || agentType === "replay") {
-
+    if (agentType === 'claude-code' || agentType === 'replay') {
       const isGitRepo = await this.worktreeManager.validateGitRepo(projectDir);
       if (!isGitRepo) {
         throw new Error(`Not a git repository: ${projectDir}`);
@@ -270,15 +286,15 @@ export class WorkspaceManager {
     const workspace: WorkspaceState = {
       id,
       repositoryId: repositoryId ?? null,
-      acpSessionId: "",
+      acpSessionId: '',
       agentProcess: null!,
       connection: null!,
       messages: [],
-      status: "initializing",
+      status: 'initializing',
       agentType,
       projectDir,
       worktree,
-      sandboxBackend: "none",
+      sandboxBackend: 'none',
       sandboxConfig,
       sandboxMonitor: null,
       containerMonitor: null,
@@ -293,15 +309,24 @@ export class WorkspaceManager {
       pendingMessage: null,
     };
     this.workspaces.set(id, workspace);
-    this.emit("workspace-update", {
+    this.emit('workspace-update', {
       workspaceId: id,
-      type: "status-change",
-      status: "initializing",
+      type: 'status-change',
+      status: 'initializing',
     });
 
     // Return summary immediately; initialization continues in the background
     const summary = await this.summarize(workspace);
-    this.initializeWorkspace(workspace, id, worktree, sandboxConfig, workingDir, agentType, template, repositoryId).catch(() => {
+    this.initializeWorkspace(
+      workspace,
+      id,
+      worktree,
+      sandboxConfig,
+      workingDir,
+      agentType,
+      template,
+      repositoryId,
+    ).catch(() => {
       // Errors are handled inside initializeWorkspace via status-change events
     });
     return summary;
@@ -320,11 +345,9 @@ export class WorkspaceManager {
     try {
       // Build sandbox config from policy template
       const safehouseAvailable = await isSafehouseAvailable();
-      if ((agentType === "claude-code" || agentType === "replay") && !safehouseAvailable) {
+      if ((agentType === 'claude-code' || agentType === 'replay') && !safehouseAvailable) {
         if (!this.safehouseWarningLogged) {
-          console.warn(
-            "safehouse not available — agent will run without OS-level sandboxing"
-          );
+          console.warn('safehouse not available — agent will run without OS-level sandboxing');
           this.safehouseWarningLogged = true;
         }
       }
@@ -336,13 +359,13 @@ export class WorkspaceManager {
         // but ESM bare-specifier resolution walks up to the parent node_modules
         // to find peer dependencies (e.g. @agentclientprotocol/sdk). Granting
         // only the agent package dir is insufficient.
-        const appNodeModules = join(app.getAppPath(), "node_modules");
+        const appNodeModules = join(app.getAppPath(), 'node_modules');
 
         // The replay agent entrypoint lives in src/agents/ (dev) or
         // dist/agents/ (prod), outside node_modules. Grant read-only
         // access to the app root so the sandbox can read the script.
         const readOnlyDirs = [appNodeModules];
-        if (agentType === "replay") {
+        if (agentType === 'replay') {
           readOnlyDirs.push(app.getAppPath());
         }
 
@@ -371,11 +394,13 @@ export class WorkspaceManager {
           // Configure the worktree for HTTPS push with gh credential helper.
           // SSH push fails in the sandbox (SSH_AUTH_SOCK socket is blocked),
           // so switch the remote to HTTPS and configure git to use gh for auth.
-          const { execFile: execFileCb } = await import("node:child_process");
-          const { promisify: pfy } = await import("node:util");
+          const { execFile: execFileCb } = await import('node:child_process');
+          const { promisify: pfy } = await import('node:util');
           const execFileP = pfy(execFileCb);
           const httpsUrl = `https://github.com/${repo}.git`;
-          await execFileP("git", ["-C", workingDir, "remote", "set-url", "origin", httpsUrl]).catch(() => {});
+          await execFileP('git', ['-C', workingDir, 'remote', 'set-url', 'origin', httpsUrl]).catch(
+            () => {},
+          );
 
           // Install gh shim and set up environment (only if gh is available).
           // Also configure git credential helper to use the real gh binary
@@ -383,26 +408,31 @@ export class WorkspaceManager {
           const realGhPath = await findRealGh();
           if (realGhPath) {
             const ghShimPath = app.isPackaged
-              ? join(app.getAppPath(), "dist", "main", "gh-shim.js")
-              : join(app.getAppPath(), "src", "main", "gh-shim.ts");
-            const shimDir = await installGhShim(id, ghShimPath, "node");
+              ? join(app.getAppPath(), 'dist', 'main', 'gh-shim.js')
+              : join(app.getAppPath(), 'src', 'main', 'gh-shim.ts');
+            const shimDir = await installGhShim(id, ghShimPath, 'node');
 
             // Resolve GH_TOKEN — gh uses keyring auth which the sandbox blocks.
-            let ghToken = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN ?? "";
+            let ghToken = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN ?? '';
             if (!ghToken) {
               try {
-                const { stdout } = await execFileP("gh", ["auth", "token"]);
+                const { stdout } = await execFileP('gh', ['auth', 'token']);
                 ghToken = stdout.trim();
               } catch {
-                console.warn("Could not resolve gh auth token — gh commands may fail in sandbox");
+                console.warn('Could not resolve gh auth token — gh commands may fail in sandbox');
               }
             }
 
             // Configure git credential helper so git push HTTPS uses the token.
             // Point to the *real* gh (not the shim) for credential operations.
             if (ghToken) {
-              await execFileP("git", ["-C", workingDir, "config", "credential.helper", ""]).catch(() => {});
-              await execFileP("git", ["-C", workingDir, "config",
+              await execFileP('git', ['-C', workingDir, 'config', 'credential.helper', '']).catch(
+                () => {},
+              );
+              await execFileP('git', [
+                '-C',
+                workingDir,
+                'config',
                 `credential.https://github.com.helper`,
                 `!${realGhPath} auth git-credential`,
               ]).catch(() => {});
@@ -411,29 +441,29 @@ export class WorkspaceManager {
             shimEnv = {
               BOUNCER_GITHUB_POLICY: policyStatePath(id),
               BOUNCER_REAL_GH: realGhPath,
-              PATH: `${shimDir}:${process.env.PATH ?? ""}`,
+              PATH: `${shimDir}:${process.env.PATH ?? ''}`,
               ...(ghToken ? { GH_TOKEN: ghToken } : {}),
             };
             // Ensure safehouse forwards the shim env vars and GitHub
             // auth/network vars to the agent
             if (sandboxConfig) {
               sandboxConfig.envPassthrough.push(
-                "BOUNCER_GITHUB_POLICY",
-                "BOUNCER_REAL_GH",
-                "PATH",
+                'BOUNCER_GITHUB_POLICY',
+                'BOUNCER_REAL_GH',
+                'PATH',
                 // Git push via SSH needs the auth socket
-                "SSH_AUTH_SOCK",
-                "GIT_SSH_COMMAND",
+                'SSH_AUTH_SOCK',
+                'GIT_SSH_COMMAND',
                 // gh CLI auth
-                "GH_TOKEN",
-                "GITHUB_TOKEN",
+                'GH_TOKEN',
+                'GITHUB_TOKEN',
               );
             }
           } else {
-            console.warn("gh CLI not found — gh shim will not be installed");
+            console.warn('gh CLI not found — gh shim will not be installed');
           }
         } else {
-          console.warn("No GitHub remote detected — skipping application-layer policy");
+          console.warn('No GitHub remote detected — skipping application-layer policy');
         }
       }
 
@@ -444,40 +474,43 @@ export class WorkspaceManager {
       if (dockerAvailable) {
         const imageTag = await ensureAgentImage();
 
-        if (agentType === "echo") {
+        if (agentType === 'echo') {
           // Echo agent: simple container with agent script mounted
-          const appNodeModules = join(app.getAppPath(), "node_modules");
+          const appNodeModules = join(app.getAppPath(), 'node_modules');
           let echoAgentHost: string;
           let echoAgentContainerPath: string;
           let echoCommand: string[];
           if (app.isPackaged) {
-            echoAgentHost = join(app.getAppPath(), "dist", "agents", "echo-agent.js");
-            echoAgentContainerPath = "/app/agents/echo-agent.js";
-            echoCommand = ["node", echoAgentContainerPath];
+            echoAgentHost = join(app.getAppPath(), 'dist', 'agents', 'echo-agent.js');
+            echoAgentContainerPath = '/app/agents/echo-agent.js';
+            echoCommand = ['node', echoAgentContainerPath];
           } else {
-            echoAgentHost = join(app.getAppPath(), "src", "agents", "echo-agent.ts");
-            echoAgentContainerPath = "/app/agents/echo-agent.ts";
-            echoCommand = ["npx", "tsx", echoAgentContainerPath];
+            echoAgentHost = join(app.getAppPath(), 'src', 'agents', 'echo-agent.ts');
+            echoAgentContainerPath = '/app/agents/echo-agent.ts';
+            echoCommand = ['npx', 'tsx', echoAgentContainerPath];
           }
           containerConfig = {
             sessionId: id,
             image: imageTag,
             command: echoCommand,
-            workdir: "/workspace",
+            workdir: '/workspace',
             mounts: [
               { hostPath: echoAgentHost, containerPath: echoAgentContainerPath, readOnly: true },
-              { hostPath: appNodeModules, containerPath: "/app/node_modules", readOnly: true },
+              { hostPath: appNodeModules, containerPath: '/app/node_modules', readOnly: true },
             ],
-            env: { NODE_PATH: "/app/node_modules" },
-            networkMode: "bridge",
+            env: { NODE_PATH: '/app/node_modules' },
+            networkMode: 'bridge',
           };
-        } else if (template && (agentType === "claude-code" || agentType === "replay")) {
+        } else if (template && (agentType === 'claude-code' || agentType === 'replay')) {
           // Claude Code / replay: full container config via policyToContainerConfig
-          const appRequire = createRequire(app.getAppPath() + "/");
+          const appRequire = createRequire(app.getAppPath() + '/');
           // Resolve to the agent package root (not dist/) so the mount includes package.json
           // which ESM needs for bare-specifier resolution.
-          const agentPkgDir = join(appRequire.resolve("@zed-industries/claude-agent-acp/package.json"), "..");
-          const appNodeModules = join(app.getAppPath(), "node_modules");
+          const agentPkgDir = join(
+            appRequire.resolve('@zed-industries/claude-agent-acp/package.json'),
+            '..',
+          );
+          const appNodeModules = join(app.getAppPath(), 'node_modules');
 
           // Build container-specific artifacts on the host
           await mkdir(POLICY_DIR, { recursive: true });
@@ -491,7 +524,11 @@ export class WorkspaceManager {
           if (template.github && workspace.githubPolicy) {
             // Write container gh wrapper (points to container paths)
             const wrapperPath = join(POLICY_DIR, `${id}-container-gh-wrapper`);
-            await writeFile(wrapperPath, `#!/bin/bash\nexec node /usr/local/lib/bouncer/gh-shim.js "$@"\n`, "utf-8");
+            await writeFile(
+              wrapperPath,
+              `#!/bin/bash\nexec node /usr/local/lib/bouncer/gh-shim.js "$@"\n`,
+              'utf-8',
+            );
             await chmod(wrapperPath, 0o755);
             containerShimScript = wrapperPath;
 
@@ -499,77 +536,88 @@ export class WorkspaceManager {
             containerHooksDir = join(POLICY_DIR, `${id}-container-hooks`);
             await mkdir(containerHooksDir, { recursive: true });
             const hookContent = generatePrePushHookForContainer();
-            const hookPath = join(containerHooksDir, "pre-push");
-            await writeFile(hookPath, hookContent, "utf-8");
+            const hookPath = join(containerHooksDir, 'pre-push');
+            await writeFile(hookPath, hookContent, 'utf-8');
             await chmod(hookPath, 0o755);
 
             // Write gitconfig
             const gitconfigContent = generateGitconfig({
-              hooksPath: "/etc/bouncer/hooks",
-              credentialHelperPath: "/usr/local/lib/bouncer/gh-credential-helper.js",
+              hooksPath: '/etc/bouncer/hooks',
+              credentialHelperPath: '/usr/local/lib/bouncer/gh-credential-helper.js',
               userName: process.env.GIT_AUTHOR_NAME,
               userEmail: process.env.GIT_AUTHOR_EMAIL,
             });
             containerGitconfigFile = join(POLICY_DIR, `${id}-gitconfig`);
-            await writeFile(containerGitconfigFile, gitconfigContent, "utf-8");
+            await writeFile(containerGitconfigFile, gitconfigContent, 'utf-8');
 
             // Write a compiled JS credential helper (can't mount TS source directly)
-            const { generateCredentialHelperJs } = await import("./policy-container.js");
+            const { generateCredentialHelperJs } = await import('./policy-container.js');
             containerCredHelper = join(POLICY_DIR, `${id}-credential-helper.js`);
             await writeFile(containerCredHelper, generateCredentialHelperJs(), { mode: 0o755 });
           }
 
           // Resolve the shim bundle — mount whenever GitHub policy is active,
           // independent of whether a host gh binary was found.
-          const shimBundlePath = (template.github && workspace.githubPolicy)
-            ? join(POLICY_DIR, "gh-shim-bundle.js")
-            : undefined;
+          const shimBundlePath =
+            template.github && workspace.githubPolicy
+              ? join(POLICY_DIR, 'gh-shim-bundle.js')
+              : undefined;
 
           // Container env — only explicit vars, no process.env inheritance.
           // The container runs Linux, where the Claude CLI reads credentials
           // from ~/.claude/.credentials.json (not the macOS keychain).
           // Extract from macOS keychain and write a credentials file for the container.
-          const anthropicKey = process.env.ANTHROPIC_API_KEY ?? "";
+          const anthropicKey = process.env.ANTHROPIC_API_KEY ?? '';
           let claudeCredentialsPath: string | undefined;
-          if (!anthropicKey && process.platform === "darwin") {
+          if (!anthropicKey && process.platform === 'darwin') {
             try {
-              const { execFile: execFileCb2 } = await import("node:child_process");
-              const { promisify: pfy2 } = await import("node:util");
+              const { execFile: execFileCb2 } = await import('node:child_process');
+              const { promisify: pfy2 } = await import('node:util');
               const execFileP2 = pfy2(execFileCb2);
-              const { stdout: credJson } = await execFileP2("security", [
-                "find-generic-password", "-s", "Claude Code-credentials", "-w",
+              const { stdout: credJson } = await execFileP2('security', [
+                'find-generic-password',
+                '-s',
+                'Claude Code-credentials',
+                '-w',
               ]);
               claudeCredentialsPath = join(POLICY_DIR, `${id}-claude-credentials.json`);
               await writeFile(claudeCredentialsPath, credJson.trim(), { mode: 0o600 });
-              console.log("[container] Wrote Claude credentials file from macOS keychain");
+              console.log('[container] Wrote Claude credentials file from macOS keychain');
             } catch (err) {
-              console.warn("[container] Could not extract Claude credentials from keychain:", err);
+              console.warn('[container] Could not extract Claude credentials from keychain:', err);
               claudeCredentialsPath = undefined;
             }
           }
-          const ghToken = shimEnv.GH_TOKEN || process.env.GH_TOKEN || process.env.GITHUB_TOKEN || "";
+          const ghToken =
+            shimEnv.GH_TOKEN || process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '';
           const containerEnv: Record<string, string> = {
             ...(anthropicKey ? { ANTHROPIC_API_KEY: anthropicKey } : {}),
             ...(ghToken ? { GH_TOKEN: ghToken } : {}),
-            ...(process.env.GIT_AUTHOR_NAME ? { GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME } : {}),
-            ...(process.env.GIT_AUTHOR_EMAIL ? { GIT_AUTHOR_EMAIL: process.env.GIT_AUTHOR_EMAIL } : {}),
-            ...(process.env.GIT_COMMITTER_NAME ? { GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME } : {}),
-            ...(process.env.GIT_COMMITTER_EMAIL ? { GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL } : {}),
+            ...(process.env.GIT_AUTHOR_NAME
+              ? { GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME }
+              : {}),
+            ...(process.env.GIT_AUTHOR_EMAIL
+              ? { GIT_AUTHOR_EMAIL: process.env.GIT_AUTHOR_EMAIL }
+              : {}),
+            ...(process.env.GIT_COMMITTER_NAME
+              ? { GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME }
+              : {}),
+            ...(process.env.GIT_COMMITTER_EMAIL
+              ? { GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL }
+              : {}),
           };
 
           // --- Network proxy (M7) ---
           // Start the proxy and create a workspace network when the template
           // uses filtered network access and Docker is available.
           let proxyCaCertPath: string | undefined;
-          if (template.network.access === "filtered") {
+          if (template.network.access === 'filtered') {
             const ca = await ensureCA();
             proxyCaCertPath = ca.certPath;
 
             // Use inspected domains from the template
             const inspectedDomains =
-              template.network.access === "filtered"
-                ? template.network.inspectedDomains
-                : [];
+              template.network.access === 'filtered' ? template.network.inspectedDomains : [];
 
             const proxyConfig: ProxyConfig = {
               sessionId: id,
@@ -579,13 +627,13 @@ export class WorkspaceManager {
               githubPolicy: workspace.githubPolicy,
               ca,
               onPolicyEvent: (event: PolicyEvent) => {
-                this.emit("workspace-update", {
+                this.emit('workspace-update', {
                   workspaceId: id,
-                  type: "policy-event",
+                  type: 'policy-event',
                   event,
                 });
                 // Persist policy state if PR was captured
-                if (workspace.githubPolicy && event.operation.startsWith("captured PR")) {
+                if (workspace.githubPolicy && event.operation.startsWith('captured PR')) {
                   writePolicyState(id, workspace.githubPolicy).catch(() => {});
                 }
               },
@@ -621,22 +669,24 @@ export class WorkspaceManager {
             containerEnv.HTTPS_PROXY = proxyEnvUrl;
             containerEnv.http_proxy = proxyEnvUrl;
             containerEnv.https_proxy = proxyEnvUrl;
-            containerEnv.NO_PROXY = "localhost,127.0.0.1,::1";
-            containerEnv.no_proxy = "localhost,127.0.0.1,::1";
+            containerEnv.NO_PROXY = 'localhost,127.0.0.1,::1';
+            containerEnv.no_proxy = 'localhost,127.0.0.1,::1';
 
             // Regenerate gitconfig with proxy setting if it was already created
             if (containerGitconfigFile) {
               const gitconfigContent = generateGitconfig({
-                hooksPath: "/etc/bouncer/hooks",
-                credentialHelperPath: "/usr/local/lib/bouncer/gh-credential-helper.js",
+                hooksPath: '/etc/bouncer/hooks',
+                credentialHelperPath: '/usr/local/lib/bouncer/gh-credential-helper.js',
                 userName: process.env.GIT_AUTHOR_NAME,
                 userEmail: process.env.GIT_AUTHOR_EMAIL,
                 proxyUrl: proxyEnvUrl,
               });
-              await writeFile(containerGitconfigFile, gitconfigContent, "utf-8");
+              await writeFile(containerGitconfigFile, gitconfigContent, 'utf-8');
             }
 
-            console.log(`[workspace] Proxy started on port ${workspace.proxyHandle.port} for workspace ${id}`);
+            console.log(
+              `[workspace] Proxy started on port ${workspace.proxyHandle.port} for workspace ${id}`,
+            );
           }
 
           const ctx: ContainerSessionContext = {
@@ -656,61 +706,76 @@ export class WorkspaceManager {
             userGitconfigPath: await (async () => {
               // Sanitize the user's gitconfig: remove credential helpers that
               // reference host-only paths (e.g. /opt/homebrew/bin/gh).
-              const home = (await import("node:os")).homedir();
-              const hostGitconfig = join(home, ".gitconfig");
+              const home = (await import('node:os')).homedir();
+              const hostGitconfig = join(home, '.gitconfig');
               try {
-                const { readFile: rf } = await import("node:fs/promises");
-                const raw = await rf(hostGitconfig, "utf-8");
-                const { sanitizeGitconfig } = await import("./policy-container.js");
+                const { readFile: rf } = await import('node:fs/promises');
+                const raw = await rf(hostGitconfig, 'utf-8');
+                const { sanitizeGitconfig } = await import('./policy-container.js');
                 const sanitized = sanitizeGitconfig(raw);
                 const sanitizedPath = join(POLICY_DIR, `${id}-user-gitconfig`);
-                await writeFile(sanitizedPath, sanitized, { encoding: "utf-8", mode: 0o600 });
+                await writeFile(sanitizedPath, sanitized, { encoding: 'utf-8', mode: 0o600 });
                 return sanitizedPath;
               } catch {
                 return undefined;
               }
             })(),
-            claudeConfigDir: join((await import("node:os")).homedir(), ".claude"),
+            claudeConfigDir: join((await import('node:os')).homedir(), '.claude'),
             claudeCredentialsPath,
           };
 
-          containerConfig = policyToContainerConfig(
-            template,
-            ctx,
-            containerEnv,
-            imageTag,
-            ["node", "/usr/local/lib/agent/dist/index.js"],
-          );
+          containerConfig = policyToContainerConfig(template, ctx, containerEnv, imageTag, [
+            'node',
+            '/usr/local/lib/agent/dist/index.js',
+          ]);
 
           // Override network mode when proxy is active
           if (workspace.proxyHandle && workspace.sessionNetwork) {
-            containerConfig.networkMode = "proxy";
+            containerConfig.networkMode = 'proxy';
             containerConfig.networkName = workspace.sessionNetwork.networkName;
           }
         }
 
         if (containerConfig) {
-          workspace.sandboxBackend = "container";
+          workspace.sandboxBackend = 'container';
           // Unset repo-level core.hooksPath so the system gitconfig
           // (/etc/gitconfig) takes effect inside the container.
           // installHooks() set it earlier for the safehouse path.
           if (worktree) {
-            const { execFile: execFileCb3 } = await import("node:child_process");
-            const { promisify: pfy3 } = await import("node:util");
+            const { execFile: execFileCb3 } = await import('node:child_process');
+            const { promisify: pfy3 } = await import('node:util');
             const execFileP3 = pfy3(execFileCb3);
-            await execFileP3("git", ["-C", workingDir, "config", "--unset", "core.hooksPath"]).catch(() => {});
+            await execFileP3('git', [
+              '-C',
+              workingDir,
+              'config',
+              '--unset',
+              'core.hooksPath',
+            ]).catch(() => {});
             // Also unset repo-level credential helpers that reference host-only paths.
             // Our /etc/gitconfig provides the correct credential helper for the container.
-            await execFileP3("git", ["-C", workingDir, "config", "--unset", "credential.helper"]).catch(() => {});
-            await execFileP3("git", ["-C", workingDir, "config", "--unset", "credential.https://github.com.helper"]).catch(() => {});
+            await execFileP3('git', [
+              '-C',
+              workingDir,
+              'config',
+              '--unset',
+              'credential.helper',
+            ]).catch(() => {});
+            await execFileP3('git', [
+              '-C',
+              workingDir,
+              'config',
+              '--unset',
+              'credential.https://github.com.helper',
+            ]).catch(() => {});
           }
         }
       }
 
       if (!containerConfig && sandboxConfig) {
-        workspace.sandboxBackend = "safehouse";
+        workspace.sandboxBackend = 'safehouse';
       } else if (!containerConfig) {
-        workspace.sandboxBackend = workspace.sandboxBackend === "container" ? "container" : "none";
+        workspace.sandboxBackend = workspace.sandboxBackend === 'container' ? 'container' : 'none';
       }
 
       // Spawn the agent
@@ -727,7 +792,7 @@ export class WorkspaceManager {
           worktree?.path,
         );
         agentProcess = spawn(cmd, args, {
-          stdio: ["pipe", "pipe", "pipe"],
+          stdio: ['pipe', 'pipe', 'pipe'],
           env: { ...process.env, ...env, ...shimEnv },
           cwd,
         });
@@ -737,35 +802,35 @@ export class WorkspaceManager {
       // Capture stderr for error reporting and parse policy events.
       // Use StringDecoder to handle multibyte characters (e.g. em-dash)
       // that may be split across chunks.
-      let collectedStderr = "";
-      let stderrBuffer = "";
-      const stderrDecoder = new StringDecoder("utf8");
+      let collectedStderr = '';
+      let stderrBuffer = '';
+      const stderrDecoder = new StringDecoder('utf8');
       const flushStderrLine = (line: string): void => {
         const event = parsePolicyEvent(line);
         if (event) {
-          this.emit("workspace-update", {
+          this.emit('workspace-update', {
             workspaceId: id,
-            type: "policy-event",
+            type: 'policy-event',
             event,
           });
         }
       };
-      agentProcess.stderr?.on("data", (data: Buffer) => {
+      agentProcess.stderr?.on('data', (data: Buffer) => {
         const chunk = stderrDecoder.write(data);
         collectedStderr += chunk;
         process.stderr.write(data);
 
         // Parse policy events from complete lines
         stderrBuffer += chunk;
-        const lines = stderrBuffer.split("\n");
-        stderrBuffer = lines.pop() ?? ""; // Keep incomplete last line in buffer
+        const lines = stderrBuffer.split('\n');
+        stderrBuffer = lines.pop() ?? ''; // Keep incomplete last line in buffer
         for (const line of lines) {
           flushStderrLine(line);
         }
       });
 
       // Handle agent crashes — flush any remaining stderr buffer first
-      agentProcess.on("exit", (code) => {
+      agentProcess.on('exit', (code) => {
         // Flush remaining bytes from the decoder and parse final line
         const remaining = stderrDecoder.end();
         if (remaining) {
@@ -774,39 +839,38 @@ export class WorkspaceManager {
         }
         if (stderrBuffer) {
           flushStderrLine(stderrBuffer);
-          stderrBuffer = "";
+          stderrBuffer = '';
         }
 
-        if (workspace.status !== "closed") {
+        if (workspace.status !== 'closed') {
           const errorMessage =
-            workspace.status === "initializing"
-              ? collectedStderr.trim() ||
-                `Agent exited with code ${code}`
+            workspace.status === 'initializing'
+              ? collectedStderr.trim() || `Agent exited with code ${code}`
               : undefined;
-          const errorKind = isAuthError(collectedStderr) ? "auth" as const : undefined;
-          workspace.status = "error";
+          const errorKind = isAuthError(collectedStderr) ? ('auth' as const) : undefined;
+          workspace.status = 'error';
           workspace.errorMessage = errorKind
-            ? "Authentication expired. Please re-authenticate and retry."
+            ? 'Authentication expired. Please re-authenticate and retry.'
             : errorMessage;
           workspace.errorKind = errorKind;
-          this.emit("workspace-update", {
+          this.emit('workspace-update', {
             workspaceId: id,
-            type: "status-change",
-            status: "error",
+            type: 'status-change',
+            status: 'error',
             error: workspace.errorMessage,
             errorKind,
           });
         }
       });
-      agentProcess.on("error", (err) => {
-        if (workspace.status !== "closed") {
+      agentProcess.on('error', (err) => {
+        if (workspace.status !== 'closed') {
           const errorMessage = err.message;
-          workspace.status = "error";
+          workspace.status = 'error';
           workspace.errorMessage = errorMessage;
-          this.emit("workspace-update", {
+          this.emit('workspace-update', {
             workspaceId: id,
-            type: "status-change",
-            status: "error",
+            type: 'status-change',
+            status: 'error',
             error: errorMessage,
           });
         }
@@ -832,9 +896,9 @@ export class WorkspaceManager {
           chunkFlushTimer = null;
         }
         for (const [, chunk] of pendingChunks) {
-          emitUpdate("workspace-update", {
+          emitUpdate('workspace-update', {
             workspaceId: id,
-            type: "stream-chunk",
+            type: 'stream-chunk',
             messageId: chunk.messageId,
             text: chunk.text,
             segmentIndex: chunk.segmentIndex,
@@ -855,12 +919,9 @@ export class WorkspaceManager {
         (_agent) => ({
           async sessionUpdate(params) {
             const update = params.update;
-            if (
-              update.sessionUpdate === "agent_message_chunk" &&
-              update.content.type === "text"
-            ) {
+            if (update.sessionUpdate === 'agent_message_chunk' && update.content.type === 'text') {
               const agentMsg = workspace.messages.findLast(
-                (m) => m.role === "agent" && m.streaming
+                (m) => m.role === 'agent' && m.streaming,
               );
               if (agentMsg) {
                 const segments = agentMsg.textSegments!;
@@ -868,14 +929,14 @@ export class WorkspaceManager {
 
                 // Start a new text segment when text resumes after tool calls
                 if (sawToolCallSinceLastText) {
-                  segments.push("");
-                  parts.push({ type: "text", index: segments.length - 1 });
+                  segments.push('');
+                  parts.push({ type: 'text', index: segments.length - 1 });
                   sawToolCallSinceLastText = false;
                 }
 
                 const segIdx = segments.length - 1;
                 segments[segIdx] += update.content.text;
-                agentMsg.text = segments.join("\n\n");
+                agentMsg.text = segments.join('\n\n');
 
                 // Batch: accumulate text, flush on timer
                 // Key by messageId:segmentIndex so segment changes flush separately
@@ -893,48 +954,42 @@ export class WorkspaceManager {
                 scheduleChunkFlush();
               }
             } else if (
-              update.sessionUpdate === "tool_call" ||
-              update.sessionUpdate === "tool_call_update"
+              update.sessionUpdate === 'tool_call' ||
+              update.sessionUpdate === 'tool_call_update'
             ) {
               sawToolCallSinceLastText = true;
-              const agentMsg = workspace.messages.findLast(
-                (m) => m.role === "agent"
-              );
+              const agentMsg = workspace.messages.findLast((m) => m.role === 'agent');
               if (agentMsg) {
                 const meta = update._meta as
                   | { claudeCode?: { toolName?: string; toolResponse?: unknown } }
                   | undefined;
                 const rawInput =
-                  "rawInput" in update && update.rawInput != null
+                  'rawInput' in update && update.rawInput != null
                     ? (update.rawInput as Record<string, unknown>)
                     : undefined;
                 const toolCall: ToolCallInfo = {
                   id: update.toolCallId,
-                  name: meta?.claudeCode?.toolName ?? "Tool",
+                  name: meta?.claudeCode?.toolName ?? 'Tool',
                   status:
-                    "status" in update
-                      ? (update.status as ToolCallInfo["status"])
-                      : "in_progress",
-                  title: "title" in update ? (update.title as string) : undefined,
+                    'status' in update ? (update.status as ToolCallInfo['status']) : 'in_progress',
+                  title: 'title' in update ? (update.title as string) : undefined,
                   description:
-                    rawInput?.description && typeof rawInput.description === "string"
+                    rawInput?.description && typeof rawInput.description === 'string'
                       ? rawInput.description
                       : undefined,
                   input: rawInput,
                   output:
-                    "rawOutput" in update
-                      ? (typeof update.rawOutput === "string"
-                          ? update.rawOutput
-                          : JSON.stringify(update.rawOutput))
+                    'rawOutput' in update
+                      ? typeof update.rawOutput === 'string'
+                        ? update.rawOutput
+                        : JSON.stringify(update.rawOutput)
                       : undefined,
                 };
                 agentMsg.toolCalls = agentMsg.toolCalls ?? [];
-                const existing = agentMsg.toolCalls.find(
-                  (tc) => tc.id === toolCall.id
-                );
+                const existing = agentMsg.toolCalls.find((tc) => tc.id === toolCall.id);
                 if (!existing && agentMsg.parts) {
                   agentMsg.parts.push({
-                    type: "tool",
+                    type: 'tool',
                     toolCallId: toolCall.id,
                   });
                 }
@@ -948,9 +1003,9 @@ export class WorkspaceManager {
                 } else {
                   agentMsg.toolCalls.push(toolCall);
                 }
-                emitUpdate("workspace-update", {
+                emitUpdate('workspace-update', {
                   workspaceId: id,
-                  type: "tool-call",
+                  type: 'tool-call',
                   messageId: agentMsg.id,
                   toolCall,
                 });
@@ -959,13 +1014,11 @@ export class WorkspaceManager {
           },
           async requestPermission(params) {
             // Auto-approve: select the first allow_once option
-            const allowOption = params.options.find(
-              (o) => o.kind === "allow_once"
-            );
+            const allowOption = params.options.find((o) => o.kind === 'allow_once');
             if (allowOption) {
               return {
                 outcome: {
-                  outcome: "selected" as const,
+                  outcome: 'selected' as const,
                   optionId: allowOption.optionId,
                 },
               };
@@ -973,13 +1026,13 @@ export class WorkspaceManager {
             // Fallback: select first option
             return {
               outcome: {
-                outcome: "selected" as const,
+                outcome: 'selected' as const,
                 optionId: params.options[0].optionId,
               },
             };
           },
         }),
-        stream
+        stream,
       );
       workspace.connection = connection;
 
@@ -993,7 +1046,7 @@ export class WorkspaceManager {
       });
 
       const sessionResp = await connection.newSession({
-        cwd: containerConfig ? "/workspace" : workingDir,
+        cwd: containerConfig ? '/workspace' : workingDir,
         mcpServers: [],
       });
       workspace.acpSessionId = sessionResp.sessionId;
@@ -1001,7 +1054,7 @@ export class WorkspaceManager {
       // Start sandbox monitor if sandboxed via safehouse
       if (sandboxConfig && !containerConfig && agentProcess.pid) {
         const monitor = new SandboxMonitor();
-        monitor.on("violation", (violation) => {
+        monitor.on('violation', (violation) => {
           const info: SandboxViolationInfo = {
             timestamp: violation.timestamp.getTime(),
             operation: violation.operation,
@@ -1009,9 +1062,9 @@ export class WorkspaceManager {
             processName: violation.processName,
           };
           workspace.sandboxViolations.push(info);
-          this.emit("workspace-update", {
+          this.emit('workspace-update', {
             workspaceId: id,
-            type: "sandbox-violation",
+            type: 'sandbox-violation',
             violation: info,
           });
         });
@@ -1022,7 +1075,7 @@ export class WorkspaceManager {
       // Start container monitor for container sessions
       if (workspace.containerHandle) {
         const cMonitor = new ContainerMonitor();
-        cMonitor.on("violation", (violation) => {
+        cMonitor.on('violation', (violation) => {
           const info: SandboxViolationInfo = {
             timestamp: violation.timestamp.getTime(),
             operation: violation.operation,
@@ -1030,9 +1083,9 @@ export class WorkspaceManager {
             processName: violation.processName,
           };
           workspace.sandboxViolations.push(info);
-          this.emit("workspace-update", {
+          this.emit('workspace-update', {
             workspaceId: id,
-            type: "sandbox-violation",
+            type: 'sandbox-violation',
             violation: info,
           });
         });
@@ -1040,12 +1093,12 @@ export class WorkspaceManager {
         workspace.containerMonitor = cMonitor;
       }
 
-      workspace.status = "ready";
+      workspace.status = 'ready';
       const readySummary = await this.summarize(workspace);
-      this.emit("workspace-update", {
+      this.emit('workspace-update', {
         workspaceId: id,
-        type: "status-change",
-        status: "ready",
+        type: 'status-change',
+        status: 'ready',
         summary: readySummary,
       });
 
@@ -1081,11 +1134,11 @@ export class WorkspaceManager {
       if (worktree) {
         await cleanupHooks(id, worktree.path).catch(() => {});
       }
-      workspace.status = "error";
-      this.emit("workspace-update", {
+      workspace.status = 'error';
+      this.emit('workspace-update', {
         workspaceId: id,
-        type: "status-change",
-        status: "error",
+        type: 'status-change',
+        status: 'error',
       });
     }
   }
@@ -1094,67 +1147,70 @@ export class WorkspaceManager {
     const workspace = this.workspaces.get(workspaceId);
     if (!workspace) throw new Error(`Workspace not found: ${workspaceId}`);
 
-    if (workspace.status === "initializing") {
+    if (workspace.status === 'initializing') {
       // Queue the message — it will be sent once the session is ready
       workspace.pendingMessage = text;
       const userMsg: Message = {
         id: randomUUID(),
-        role: "user",
+        role: 'user',
         text,
         timestamp: Date.now(),
       };
       workspace.messages.push(userMsg);
-      this.emit("workspace-update", {
+      this.emit('workspace-update', {
         workspaceId,
-        type: "message",
+        type: 'message',
         message: userMsg,
       });
       return;
     }
 
-    if (workspace.status !== "ready")
-      throw new Error(`Workspace not ready: ${workspace.status}`);
+    if (workspace.status !== 'ready') throw new Error(`Workspace not ready: ${workspace.status}`);
 
     // Create user message
     const userMsg: Message = {
       id: randomUUID(),
-      role: "user",
+      role: 'user',
       text,
       timestamp: Date.now(),
     };
     workspace.messages.push(userMsg);
-    this.emit("workspace-update", { workspaceId, type: "message", message: userMsg });
+    this.emit('workspace-update', { workspaceId, type: 'message', message: userMsg });
 
     await this.sendPrompt(workspace, workspaceId, text);
   }
 
-  private async sendPrompt(workspace: WorkspaceState, workspaceId: string, text: string): Promise<void> {
+  private async sendPrompt(
+    workspace: WorkspaceState,
+    workspaceId: string,
+    text: string,
+  ): Promise<void> {
     // Create placeholder agent message for streaming
     const agentMsg: Message = {
       id: randomUUID(),
-      role: "agent",
-      text: "",
+      role: 'agent',
+      text: '',
       timestamp: Date.now(),
       streaming: true,
-      textSegments: [""],
-      parts: [{ type: "text", index: 0 }],
+      textSegments: [''],
+      parts: [{ type: 'text', index: 0 }],
     };
     workspace.messages.push(agentMsg);
-    this.emit("workspace-update", { workspaceId, type: "message", message: agentMsg });
+    this.emit('workspace-update', { workspaceId, type: 'message', message: agentMsg });
 
     // Send prompt via ACP
-    const promptBlocks: Array<{ type: "text"; text: string }> = [];
+    const promptBlocks: Array<{ type: 'text'; text: string }> = [];
 
     // On the first prompt, inject UI formatting guidance
     if (workspace.promptCount === 0) {
       promptBlocks.push({
-        type: "text",
-        text: "<system-instruction>\nFormatting guidance: After completing tool calls, when you present the results to the user, always start with a brief summary sentence that contextualizes the data before showing it. Do not output raw data or listings without a lead-in. Before making tool calls, keep your introductory text minimal — just proceed to the tool calls without unnecessary preamble.\n</system-instruction>",
+        type: 'text',
+        text: '<system-instruction>\nFormatting guidance: After completing tool calls, when you present the results to the user, always start with a brief summary sentence that contextualizes the data before showing it. Do not output raw data or listings without a lead-in. Before making tool calls, keep your introductory text minimal — just proceed to the tool calls without unnecessary preamble.\n</system-instruction>',
       });
     }
     workspace.promptCount++;
 
-    promptBlocks.push({ type: "text", text });
+    promptBlocks.push({ type: 'text', text });
 
     try {
       await workspace.connection.prompt({
@@ -1163,16 +1219,16 @@ export class WorkspaceManager {
       });
     } catch (err) {
       console.error(`Prompt failed for workspace ${workspaceId}:`, err);
-      if (isAuthError(err) && workspace.status !== "closed") {
-        workspace.status = "error";
-        workspace.errorMessage = "Authentication expired. Please re-authenticate and retry.";
-        workspace.errorKind = "auth";
-        this.emit("workspace-update", {
+      if (isAuthError(err) && workspace.status !== 'closed') {
+        workspace.status = 'error';
+        workspace.errorMessage = 'Authentication expired. Please re-authenticate and retry.';
+        workspace.errorKind = 'auth';
+        this.emit('workspace-update', {
           workspaceId,
-          type: "status-change",
-          status: "error",
+          type: 'status-change',
+          status: 'error',
           error: workspace.errorMessage,
-          errorKind: "auth",
+          errorKind: 'auth',
         });
       }
     }
@@ -1182,12 +1238,12 @@ export class WorkspaceManager {
 
     // Finalize the agent message
     agentMsg.streaming = false;
-    this.emit("workspace-update", {
+    this.emit('workspace-update', {
       workspaceId,
-      type: "stream-end",
+      type: 'stream-end',
       messageId: agentMsg.id,
       textSegments: agentMsg.textSegments ?? [agentMsg.text],
-      parts: agentMsg.parts ?? [{ type: "text", index: 0 }],
+      parts: agentMsg.parts ?? [{ type: 'text', index: 0 }],
     });
   }
 
@@ -1198,9 +1254,7 @@ export class WorkspaceManager {
   }
 
   async listWorkspaces(): Promise<WorkspaceSummary[]> {
-    return await Promise.all(
-      Array.from(this.workspaces.values()).map((s) => this.summarize(s))
-    );
+    return await Promise.all(Array.from(this.workspaces.values()).map((s) => this.summarize(s)));
   }
 
   /**
@@ -1214,19 +1268,24 @@ export class WorkspaceManager {
 
     // If the agent process has exited, we can't recover — the ACP connection is gone
     if (workspace.agentProcess.exitCode !== null) {
-      throw new Error("Agent process has exited. Please close this workspace and create a new one after re-authenticating.");
+      throw new Error(
+        'Agent process has exited. Please close this workspace and create a new one after re-authenticating.',
+      );
     }
 
     // For container workspaces, re-extract credentials from macOS keychain and overwrite the file
-    if (workspace.sandboxBackend === "container") {
-      if (process.platform !== "darwin") {
-        throw new Error("Credential refresh from keychain is only supported on macOS.");
+    if (workspace.sandboxBackend === 'container') {
+      if (process.platform !== 'darwin') {
+        throw new Error('Credential refresh from keychain is only supported on macOS.');
       }
-      const { execFile: execFileCb } = await import("node:child_process");
-      const { promisify } = await import("node:util");
+      const { execFile: execFileCb } = await import('node:child_process');
+      const { promisify } = await import('node:util');
       const execFileP = promisify(execFileCb);
-      const { stdout: credJson } = await execFileP("security", [
-        "find-generic-password", "-s", "Claude Code-credentials", "-w",
+      const { stdout: credJson } = await execFileP('security', [
+        'find-generic-password',
+        '-s',
+        'Claude Code-credentials',
+        '-w',
       ]);
       const credPath = join(POLICY_DIR, `${workspaceId}-claude-credentials.json`);
       await writeFile(credPath, credJson.trim(), { mode: 0o600 });
@@ -1235,13 +1294,13 @@ export class WorkspaceManager {
     // For safehouse: Claude Code reads from keychain directly, so no file update needed.
 
     // Reset workspace back to ready
-    workspace.status = "ready";
+    workspace.status = 'ready';
     workspace.errorMessage = undefined;
     workspace.errorKind = undefined;
-    this.emit("workspace-update", {
+    this.emit('workspace-update', {
       workspaceId,
-      type: "status-change",
-      status: "ready",
+      type: 'status-change',
+      status: 'ready',
     });
   }
 
@@ -1249,7 +1308,7 @@ export class WorkspaceManager {
     const workspace = this.workspaces.get(workspaceId);
     if (!workspace) throw new Error(`Workspace not found: ${workspaceId}`);
 
-    workspace.status = "closed";
+    workspace.status = 'closed';
     workspace.flushChunks();
     workspace.sandboxMonitor?.stop();
     workspace.containerMonitor?.stop();
@@ -1260,43 +1319,54 @@ export class WorkspaceManager {
     }
 
     // Clean up container and container-specific host artifacts
-    if (workspace.sandboxBackend === "container") {
+    if (workspace.sandboxBackend === 'container') {
       await removeContainer(workspaceId).catch((err) =>
-        console.warn(`Failed to remove container for workspace ${workspaceId}:`, err)
+        console.warn(`Failed to remove container for workspace ${workspaceId}:`, err),
       );
       // Clean up container-specific files on the host
-      await rm(join(POLICY_DIR, `${workspaceId}-container-gh-wrapper`), { force: true }).catch(() => {});
-      await rm(join(POLICY_DIR, `${workspaceId}-container-hooks`), { recursive: true, force: true }).catch(() => {});
+      await rm(join(POLICY_DIR, `${workspaceId}-container-gh-wrapper`), { force: true }).catch(
+        () => {},
+      );
+      await rm(join(POLICY_DIR, `${workspaceId}-container-hooks`), {
+        recursive: true,
+        force: true,
+      }).catch(() => {});
       await rm(join(POLICY_DIR, `${workspaceId}-gitconfig`), { force: true }).catch(() => {});
-      await rm(join(POLICY_DIR, `${workspaceId}-claude-credentials.json`), { force: true }).catch(() => {});
-      await rm(join(POLICY_DIR, `${workspaceId}-credential-helper.js`), { force: true }).catch(() => {});
+      await rm(join(POLICY_DIR, `${workspaceId}-claude-credentials.json`), { force: true }).catch(
+        () => {},
+      );
+      await rm(join(POLICY_DIR, `${workspaceId}-credential-helper.js`), { force: true }).catch(
+        () => {},
+      );
       await rm(join(POLICY_DIR, `${workspaceId}-user-gitconfig`), { force: true }).catch(() => {});
     }
 
     // Stop proxy and remove workspace network (M7)
     if (workspace.proxyHandle) {
-      await workspace.proxyHandle.stop().catch((err) =>
-        console.warn(`Failed to stop proxy for workspace ${workspaceId}:`, err)
-      );
+      await workspace.proxyHandle
+        .stop()
+        .catch((err) => console.warn(`Failed to stop proxy for workspace ${workspaceId}:`, err));
     }
     if (workspace.sessionNetwork) {
-      await workspace.sessionNetwork.cleanup().catch((err) =>
-        console.warn(`Failed to remove network for workspace ${workspaceId}:`, err)
-      );
+      await workspace.sessionNetwork
+        .cleanup()
+        .catch((err) =>
+          console.warn(`Failed to remove network for workspace ${workspaceId}:`, err),
+        );
     }
 
     // Clean up application-layer policy artifacts
     if (workspace.githubPolicy) {
       if (workspace.worktree) {
         await cleanupHooks(workspaceId, workspace.worktree.path).catch((err) =>
-          console.warn(`Failed to clean up hooks for workspace ${workspaceId}:`, err)
+          console.warn(`Failed to clean up hooks for workspace ${workspaceId}:`, err),
         );
       }
       await cleanupPolicyState(workspaceId).catch((err) =>
-        console.warn(`Failed to clean up policy state for workspace ${workspaceId}:`, err)
+        console.warn(`Failed to clean up policy state for workspace ${workspaceId}:`, err),
       );
       await cleanupGhShim(workspaceId).catch((err) =>
-        console.warn(`Failed to clean up gh shim for workspace ${workspaceId}:`, err)
+        console.warn(`Failed to clean up gh shim for workspace ${workspaceId}:`, err),
       );
     }
 
@@ -1305,10 +1375,7 @@ export class WorkspaceManager {
       try {
         await this.worktreeManager.remove(workspace.worktree);
       } catch (err) {
-        console.warn(
-          `Failed to remove worktree for workspace ${workspaceId}:`,
-          err
-        );
+        console.warn(`Failed to remove worktree for workspace ${workspaceId}:`, err);
       }
     }
 
@@ -1317,21 +1384,19 @@ export class WorkspaceManager {
       await cleanupPolicy(workspace.sandboxConfig.policyOutputPath);
     }
 
-    this.emit("workspace-update", {
+    this.emit('workspace-update', {
       workspaceId,
-      type: "status-change",
-      status: "closed",
+      type: 'status-change',
+      status: 'closed',
     });
   }
 
   /** Close all active workspaces. Called on app quit. */
   async closeAllWorkspaces(): Promise<void> {
     const activeWorkspaces = Array.from(this.workspaces.values()).filter(
-      (s) => s.status !== "closed"
+      (s) => s.status !== 'closed',
     );
-    await Promise.all(
-      activeWorkspaces.map((s) => this.closeWorkspace(s.id).catch(() => {}))
-    );
+    await Promise.all(activeWorkspaces.map((s) => this.closeWorkspace(s.id).catch(() => {})));
   }
 
   /** Remove orphan worktree directories, sandbox policies, containers, and container artifacts left behind by a previous crash. */
@@ -1341,16 +1406,23 @@ export class WorkspaceManager {
     await cleanupOrphanPolicies(activeIds);
     await cleanupOrphanGitHubArtifacts(activeIds);
     await cleanupOrphanContainers(activeIds).catch((err) =>
-      console.warn("Failed to clean up orphan containers:", err)
+      console.warn('Failed to clean up orphan containers:', err),
     );
     await cleanupOrphanNetworks(activeIds).catch((err) =>
-      console.warn("Failed to clean up orphan networks:", err)
+      console.warn('Failed to clean up orphan networks:', err),
     );
     // Clean up orphan container artifacts (credentials, gitconfig, wrapper, hooks)
     try {
-      const { readdir } = await import("node:fs/promises");
+      const { readdir } = await import('node:fs/promises');
       const files = await readdir(POLICY_DIR).catch(() => [] as string[]);
-      const suffixes = ["-container-gh-wrapper", "-container-hooks", "-gitconfig", "-claude-credentials.json", "-credential-helper.js", "-user-gitconfig"];
+      const suffixes = [
+        '-container-gh-wrapper',
+        '-container-hooks',
+        '-gitconfig',
+        '-claude-credentials.json',
+        '-credential-helper.js',
+        '-user-gitconfig',
+      ];
       for (const f of files) {
         for (const suffix of suffixes) {
           if (f.endsWith(suffix)) {
@@ -1405,14 +1477,14 @@ export class WorkspaceManager {
       messageCount: workspace.messages.length,
       agentType: workspace.agentType,
       projectDir: workspace.projectDir,
-      sandboxed: workspace.sandboxBackend !== "none",
+      sandboxed: workspace.sandboxBackend !== 'none',
       sandboxBackend: workspace.sandboxBackend,
       containerName: workspace.containerHandle?.containerName ?? null,
       policyId: workspace.policyId,
       policyName,
       githubRepo,
       ownedPrNumber,
-      networkAccess: workspace.proxyHandle ? "filtered" : "full",
+      networkAccess: workspace.proxyHandle ? 'filtered' : 'full',
     };
   }
 }

--- a/src/main/worktree-manager.ts
+++ b/src/main/worktree-manager.ts
@@ -1,8 +1,8 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-import { join, resolve } from "node:path";
-import { homedir, tmpdir } from "node:os";
-import { mkdir, writeFile, readFile, readdir, rm } from "node:fs/promises";
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { join, resolve } from 'node:path';
+import { homedir, tmpdir } from 'node:os';
+import { mkdir, writeFile, readFile, readdir, rm } from 'node:fs/promises';
 
 const execFileAsync = promisify(execFile);
 
@@ -20,14 +20,14 @@ export class WorktreeManager {
   private metadataPath: string;
 
   constructor(basePath?: string) {
-    this.basePath = resolve(basePath ?? join(tmpdir(), "bouncer-worktrees"));
-    this.metadataPath = join(homedir(), ".cache", "bouncer", "worktrees");
+    this.basePath = resolve(basePath ?? join(tmpdir(), 'bouncer-worktrees'));
+    this.metadataPath = join(homedir(), '.cache', 'bouncer', 'worktrees');
   }
 
   /** Validate that a directory is a git repository. */
   async validateGitRepo(dir: string): Promise<boolean> {
     try {
-      await execFileAsync("git", ["rev-parse", "--git-dir"], { cwd: dir });
+      await execFileAsync('git', ['rev-parse', '--git-dir'], { cwd: dir });
       return true;
     } catch {
       return false;
@@ -45,42 +45,34 @@ export class WorktreeManager {
 
     await mkdir(this.basePath, { recursive: true });
 
-    await execFileAsync(
-      "git",
-      ["worktree", "add", "-b", branch, "--", worktreePath, "HEAD"],
-      { cwd: projectDir }
-    );
+    await execFileAsync('git', ['worktree', 'add', '-b', branch, '--', worktreePath, 'HEAD'], {
+      cwd: projectDir,
+    });
 
     // Resolve the git common dir — linked worktrees store refs/metadata
     // in the parent repo's .git directory. Without write access to this
     // path, git operations (commit, branch, etc.) fail from the worktree.
-    const { stdout: commonDirRaw } = await execFileAsync(
-      "git",
-      ["rev-parse", "--git-common-dir"],
-      { cwd: worktreePath }
-    );
+    const { stdout: commonDirRaw } = await execFileAsync('git', ['rev-parse', '--git-common-dir'], {
+      cwd: worktreePath,
+    });
     const resolvedCommonDir = resolve(worktreePath, commonDirRaw.trim());
 
     // Validate that the common dir is under the project directory to avoid
     // granting sandbox write access to unexpected locations (e.g., repos
     // created with --separate-git-dir or a crafted .git file).
-    const expectedPrefix = resolve(projectDir) + "/";
+    const expectedPrefix = resolve(projectDir) + '/';
     let gitCommonDir: string | undefined;
     if (resolvedCommonDir.startsWith(expectedPrefix)) {
       gitCommonDir = resolvedCommonDir;
     } else {
       console.warn(
-        `Git common dir ${resolvedCommonDir} is outside project ${projectDir} — skipping sandbox grant`
+        `Git common dir ${resolvedCommonDir} is outside project ${projectDir} — skipping sandbox grant`,
       );
     }
 
     // Store project dir breadcrumb so orphan cleanup can find the parent repo
     await mkdir(this.metadataPath, { recursive: true });
-    await writeFile(
-      join(this.metadataPath, sessionId),
-      projectDir,
-      "utf-8"
-    );
+    await writeFile(join(this.metadataPath, sessionId), projectDir, 'utf-8');
 
     return { path: worktreePath, branch, projectDir, gitCommonDir };
   }
@@ -88,17 +80,15 @@ export class WorktreeManager {
   /** Remove a worktree and delete its session branch. */
   async remove(info: WorktreeInfo): Promise<void> {
     try {
-      await execFileAsync(
-        "git",
-        ["worktree", "remove", "--force", "--", info.path],
-        { cwd: info.projectDir }
-      );
+      await execFileAsync('git', ['worktree', 'remove', '--force', '--', info.path], {
+        cwd: info.projectDir,
+      });
     } catch (err) {
       console.warn(`Failed to remove worktree ${info.path}:`, err);
     }
 
     try {
-      await execFileAsync("git", ["branch", "-D", "--", info.branch], {
+      await execFileAsync('git', ['branch', '-D', '--', info.branch], {
         cwd: info.projectDir,
       });
     } catch {
@@ -106,7 +96,7 @@ export class WorktreeManager {
     }
 
     // Clean up metadata breadcrumb
-    const sessionId = info.path.split("/").pop();
+    const sessionId = info.path.split('/').pop();
     if (sessionId) {
       await rm(join(this.metadataPath, sessionId), { force: true });
     }
@@ -134,9 +124,7 @@ export class WorktreeManager {
       // Read the project dir from the metadata breadcrumb
       let projectDir: string | null = null;
       try {
-        projectDir = (
-          await readFile(join(this.metadataPath, entry), "utf-8")
-        ).trim();
+        projectDir = (await readFile(join(this.metadataPath, entry), 'utf-8')).trim();
       } catch {
         // No breadcrumb — just rm the directory
       }
@@ -152,7 +140,7 @@ export class WorktreeManager {
       if (projectDir) {
         // Prune stale worktree entries from git
         try {
-          await execFileAsync("git", ["worktree", "prune"], {
+          await execFileAsync('git', ['worktree', 'prune'], {
             cwd: projectDir,
           });
         } catch {
@@ -161,7 +149,7 @@ export class WorktreeManager {
 
         // Delete the orphan branch
         try {
-          await execFileAsync("git", ["branch", "-D", "--", branch], {
+          await execFileAsync('git', ['branch', '-D', '--', branch], {
             cwd: projectDir,
           });
         } catch {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from 'electron'
+import { contextBridge, ipcRenderer } from 'electron';
 
 contextBridge.exposeInMainWorld('bouncer', {
   repositories: {
@@ -10,14 +10,11 @@ contextBridge.exposeInMainWorld('bouncer', {
   },
   workspaces: {
     list: () => ipcRenderer.invoke('workspaces:list'),
-    create: (repositoryId: string) =>
-      ipcRenderer.invoke('workspaces:create', repositoryId),
-    getMessages: (workspaceId: string) =>
-      ipcRenderer.invoke('workspaces:getMessages', workspaceId),
+    create: (repositoryId: string) => ipcRenderer.invoke('workspaces:create', repositoryId),
+    getMessages: (workspaceId: string) => ipcRenderer.invoke('workspaces:getMessages', workspaceId),
     sendMessage: (workspaceId: string, text: string) =>
       ipcRenderer.invoke('workspaces:sendMessage', workspaceId, text),
-    close: (workspaceId: string) =>
-      ipcRenderer.invoke('workspaces:close', workspaceId),
+    close: (workspaceId: string) => ipcRenderer.invoke('workspaces:close', workspaceId),
     refreshCredentials: (workspaceId: string) =>
       ipcRenderer.invoke('workspaces:refreshCredentials', workspaceId),
     getSandboxViolations: (workspaceId: string) =>
@@ -26,9 +23,9 @@ contextBridge.exposeInMainWorld('bouncer', {
       ipcRenderer.invoke('workspaces:loadReplayData', datasetSessionId),
     onUpdate: (callback: (update: unknown) => void) => {
       const handler = (_event: Electron.IpcRendererEvent, update: unknown): void =>
-        callback(update)
-      ipcRenderer.on('workspace-update', handler)
-      return () => ipcRenderer.removeListener('workspace-update', handler)
+        callback(update);
+      ipcRenderer.on('workspace-update', handler);
+      return () => ipcRenderer.removeListener('workspace-update', handler);
     },
   },
   preferences: {
@@ -41,4 +38,4 @@ contextBridge.exposeInMainWorld('bouncer', {
   dialog: {
     selectDirectory: () => ipcRenderer.invoke('dialog:selectDirectory'),
   },
-})
+});

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,234 +1,253 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { Message, PolicyEvent, PolicyTemplateSummary, Repository, SandboxViolationInfo, WorkspaceSummary, WorkspaceUpdate } from '../../main/types'
-import { WorkspacesSidebar } from './components/WorkspacesSidebar'
-import { ChatPanel } from './components/ChatPanel'
-import { RepoSettings } from './components/RepoSettings'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type {
+  Message,
+  PolicyEvent,
+  PolicyTemplateSummary,
+  Repository,
+  SandboxViolationInfo,
+  WorkspaceSummary,
+  WorkspaceUpdate,
+} from '../../main/types';
+import { WorkspacesSidebar } from './components/WorkspacesSidebar';
+import { ChatPanel } from './components/ChatPanel';
+import { RepoSettings } from './components/RepoSettings';
 
 function App() {
-  const [repos, setRepos] = useState<Repository[]>([])
-  const [workspaces, setWorkspaces] = useState<WorkspaceSummary[]>([])
-  const [activeWorkspaceId, setActiveWorkspaceId] = useState<string | null>(null)
-  const [messagesByWorkspace, setMessagesByWorkspace] = useState<Map<string, Message[]>>(new Map())
-  const [workspaceErrors, setWorkspaceErrors] = useState<Map<string, string>>(new Map())
-  const [workspaceErrorKinds, setWorkspaceErrorKinds] = useState<Map<string, "auth">>(new Map())
-  const [violationsByWorkspace, setViolationsByWorkspace] = useState<Map<string, SandboxViolationInfo[]>>(new Map())
-  const [policies, setPolicies] = useState<PolicyTemplateSummary[]>([])
-  const [policyDescriptions, setPolicyDescriptions] = useState<Map<string, string>>(new Map())
-  const [policyEventsByWorkspace, setPolicyEventsByWorkspace] = useState<Map<string, PolicyEvent[]>>(new Map())
-  const [settingsRepoId, setSettingsRepoId] = useState<string | null>(null)
-  const [focusedRepoId, setFocusedRepoId] = useState<string | null>(null)
+  const [repos, setRepos] = useState<Repository[]>([]);
+  const [workspaces, setWorkspaces] = useState<WorkspaceSummary[]>([]);
+  const [activeWorkspaceId, setActiveWorkspaceId] = useState<string | null>(null);
+  const [messagesByWorkspace, setMessagesByWorkspace] = useState<Map<string, Message[]>>(new Map());
+  const [workspaceErrors, setWorkspaceErrors] = useState<Map<string, string>>(new Map());
+  const [workspaceErrorKinds, setWorkspaceErrorKinds] = useState<Map<string, 'auth'>>(new Map());
+  const [violationsByWorkspace, setViolationsByWorkspace] = useState<
+    Map<string, SandboxViolationInfo[]>
+  >(new Map());
+  const [policies, setPolicies] = useState<PolicyTemplateSummary[]>([]);
+  const [policyDescriptions, setPolicyDescriptions] = useState<Map<string, string>>(new Map());
+  const [policyEventsByWorkspace, setPolicyEventsByWorkspace] = useState<
+    Map<string, PolicyEvent[]>
+  >(new Map());
+  const [settingsRepoId, setSettingsRepoId] = useState<string | null>(null);
+  const [focusedRepoId, setFocusedRepoId] = useState<string | null>(null);
 
   // Buffer status-change events that arrive before the workspace is in state
-  const pendingStatusUpdates = useRef(new Map<string, WorkspaceUpdate & { type: 'status-change' }>())
+  const pendingStatusUpdates = useRef(
+    new Map<string, WorkspaceUpdate & { type: 'status-change' }>(),
+  );
 
   // Use a ref for streaming text to avoid re-rendering the entire tree on every chunk.
   // A tick counter triggers periodic re-renders so the UI updates smoothly.
-  const streamingTextRef = useRef(new Map<string, string[]>())
-  const [streamTick, setStreamTick] = useState(0)
-  const streamTickTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const streamingTextRef = useRef(new Map<string, string[]>());
+  const [streamTick, setStreamTick] = useState(0);
+  const streamTickTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scheduleStreamTick = useCallback(() => {
     if (!streamTickTimer.current) {
       streamTickTimer.current = setTimeout(() => {
-        streamTickTimer.current = null
-        setStreamTick((t) => t + 1)
-      }, 80)
+        streamTickTimer.current = null;
+        setStreamTick((t) => t + 1);
+      }, 80);
     }
-  }, [])
+  }, []);
 
-  const handleUpdate = useCallback((update: WorkspaceUpdate) => {
-    switch (update.type) {
-      case 'status-change':
-        setWorkspaces((prev) => {
-          const exists = prev.some((s) => s.id === update.workspaceId)
-          if (!exists) {
-            // Workspace not yet in state — stash for when it arrives
-            pendingStatusUpdates.current.set(update.workspaceId, update)
-            return prev
+  const handleUpdate = useCallback(
+    (update: WorkspaceUpdate) => {
+      switch (update.type) {
+        case 'status-change':
+          setWorkspaces((prev) => {
+            const exists = prev.some((s) => s.id === update.workspaceId);
+            if (!exists) {
+              // Workspace not yet in state — stash for when it arrives
+              pendingStatusUpdates.current.set(update.workspaceId, update);
+              return prev;
+            }
+            return prev.map((s) =>
+              s.id === update.workspaceId
+                ? update.summary
+                  ? { ...s, ...update.summary }
+                  : { ...s, status: update.status }
+                : s,
+            );
+          });
+          if (update.status === 'error' && update.error) {
+            setWorkspaceErrors((prev) => {
+              const next = new Map(prev);
+              next.set(update.workspaceId, update.error!);
+              return next;
+            });
           }
-          return prev.map((s) =>
-            s.id === update.workspaceId
-              ? update.summary ? { ...s, ...update.summary } : { ...s, status: update.status }
-              : s
-          )
-        })
-        if (update.status === 'error' && update.error) {
-          setWorkspaceErrors((prev) => {
-            const next = new Map(prev)
-            next.set(update.workspaceId, update.error!)
-            return next
-          })
-        }
-        if (update.errorKind) {
-          setWorkspaceErrorKinds((prev) => {
-            const next = new Map(prev)
-            next.set(update.workspaceId, update.errorKind!)
-            return next
-          })
-        } else {
-          // Clear errorKind when transitioning to a non-auth error or away from error
-          setWorkspaceErrorKinds((prev) => {
-            if (!prev.has(update.workspaceId)) return prev
-            const next = new Map(prev)
-            next.delete(update.workspaceId)
-            return next
-          })
-        }
-        break
-
-      case 'message':
-        setMessagesByWorkspace((prev) => {
-          const next = new Map(prev)
-          const msgs = next.get(update.workspaceId) ?? []
-          next.set(update.workspaceId, [...msgs, update.message])
-          return next
-        })
-        if (update.message.streaming) {
-          streamingTextRef.current.set(update.message.id, [''])
-        }
-        break
-
-      case 'stream-chunk': {
-        const segments = streamingTextRef.current.get(update.messageId) ?? ['']
-        // Expand array if needed for new segment index
-        while (segments.length <= update.segmentIndex) {
-          segments.push('')
-        }
-        segments[update.segmentIndex] += update.text
-        streamingTextRef.current.set(update.messageId, segments)
-        scheduleStreamTick()
-        break
-      }
-
-      case 'stream-end': {
-        streamingTextRef.current.delete(update.messageId)
-        setMessagesByWorkspace((prevMsgs) => {
-          const next = new Map(prevMsgs)
-          const msgs = next.get(update.workspaceId)
-          if (msgs) {
-            next.set(
-              update.workspaceId,
-              msgs.map((m) =>
-                m.id === update.messageId
-                  ? {
-                      ...m,
-                      text: update.textSegments.join('\n\n'),
-                      textSegments: update.textSegments,
-                      parts: update.parts,
-                      streaming: false,
-                    }
-                  : m
-              )
-            )
+          if (update.errorKind) {
+            setWorkspaceErrorKinds((prev) => {
+              const next = new Map(prev);
+              next.set(update.workspaceId, update.errorKind!);
+              return next;
+            });
+          } else {
+            // Clear errorKind when transitioning to a non-auth error or away from error
+            setWorkspaceErrorKinds((prev) => {
+              if (!prev.has(update.workspaceId)) return prev;
+              const next = new Map(prev);
+              next.delete(update.workspaceId);
+              return next;
+            });
           }
-          return next
-        })
-        // Force a final render to clear streaming state
-        setStreamTick((t) => t + 1)
-        break
-      }
+          break;
 
-      case 'tool-call':
-        setMessagesByWorkspace((prev) => {
-          const next = new Map(prev)
-          const msgs = next.get(update.workspaceId)
-          if (msgs) {
-            next.set(
-              update.workspaceId,
-              msgs.map((m) => {
-                if (m.id !== update.messageId) return m
-                const toolCalls = m.toolCalls ? [...m.toolCalls] : []
-                const existing = toolCalls.findIndex((tc) => tc.id === update.toolCall.id)
-                if (existing >= 0) {
-                  toolCalls[existing] = { ...toolCalls[existing] }
-                  for (const [k, v] of Object.entries(update.toolCall)) {
-                    if (v !== undefined) {
-                      (toolCalls[existing] as unknown as Record<string, unknown>)[k] = v
+        case 'message':
+          setMessagesByWorkspace((prev) => {
+            const next = new Map(prev);
+            const msgs = next.get(update.workspaceId) ?? [];
+            next.set(update.workspaceId, [...msgs, update.message]);
+            return next;
+          });
+          if (update.message.streaming) {
+            streamingTextRef.current.set(update.message.id, ['']);
+          }
+          break;
+
+        case 'stream-chunk': {
+          const segments = streamingTextRef.current.get(update.messageId) ?? [''];
+          // Expand array if needed for new segment index
+          while (segments.length <= update.segmentIndex) {
+            segments.push('');
+          }
+          segments[update.segmentIndex] += update.text;
+          streamingTextRef.current.set(update.messageId, segments);
+          scheduleStreamTick();
+          break;
+        }
+
+        case 'stream-end': {
+          streamingTextRef.current.delete(update.messageId);
+          setMessagesByWorkspace((prevMsgs) => {
+            const next = new Map(prevMsgs);
+            const msgs = next.get(update.workspaceId);
+            if (msgs) {
+              next.set(
+                update.workspaceId,
+                msgs.map((m) =>
+                  m.id === update.messageId
+                    ? {
+                        ...m,
+                        text: update.textSegments.join('\n\n'),
+                        textSegments: update.textSegments,
+                        parts: update.parts,
+                        streaming: false,
+                      }
+                    : m,
+                ),
+              );
+            }
+            return next;
+          });
+          // Force a final render to clear streaming state
+          setStreamTick((t) => t + 1);
+          break;
+        }
+
+        case 'tool-call':
+          setMessagesByWorkspace((prev) => {
+            const next = new Map(prev);
+            const msgs = next.get(update.workspaceId);
+            if (msgs) {
+              next.set(
+                update.workspaceId,
+                msgs.map((m) => {
+                  if (m.id !== update.messageId) return m;
+                  const toolCalls = m.toolCalls ? [...m.toolCalls] : [];
+                  const existing = toolCalls.findIndex((tc) => tc.id === update.toolCall.id);
+                  if (existing >= 0) {
+                    toolCalls[existing] = { ...toolCalls[existing] };
+                    for (const [k, v] of Object.entries(update.toolCall)) {
+                      if (v !== undefined) {
+                        (toolCalls[existing] as unknown as Record<string, unknown>)[k] = v;
+                      }
                     }
+                    return { ...m, toolCalls };
                   }
-                  return { ...m, toolCalls }
-                }
-                // New tool call: add to parts ordering
-                toolCalls.push(update.toolCall)
-                const parts = m.parts ? [...m.parts] : [{ type: 'text' as const, index: 0 }]
-                parts.push({ type: 'tool' as const, toolCallId: update.toolCall.id })
-                return { ...m, toolCalls, parts }
-              })
-            )
-          }
-          return next
-        })
-        break
+                  // New tool call: add to parts ordering
+                  toolCalls.push(update.toolCall);
+                  const parts = m.parts ? [...m.parts] : [{ type: 'text' as const, index: 0 }];
+                  parts.push({ type: 'tool' as const, toolCallId: update.toolCall.id });
+                  return { ...m, toolCalls, parts };
+                }),
+              );
+            }
+            return next;
+          });
+          break;
 
-      case 'sandbox-violation':
-        setViolationsByWorkspace((prev) => {
-          const next = new Map(prev)
-          const existing = next.get(update.workspaceId) ?? []
-          const updated = [...existing, update.violation].slice(-200)
-          next.set(update.workspaceId, updated)
-          return next
-        })
-        break
+        case 'sandbox-violation':
+          setViolationsByWorkspace((prev) => {
+            const next = new Map(prev);
+            const existing = next.get(update.workspaceId) ?? [];
+            const updated = [...existing, update.violation].slice(-200);
+            next.set(update.workspaceId, updated);
+            return next;
+          });
+          break;
 
-      case 'policy-event':
-        setPolicyEventsByWorkspace((prev) => {
-          const next = new Map(prev)
-          const existing = next.get(update.workspaceId) ?? []
-          const updated = [...existing, update.event].slice(-200)
-          next.set(update.workspaceId, updated)
-          return next
-        })
-        break
-    }
-  }, [scheduleStreamTick])
+        case 'policy-event':
+          setPolicyEventsByWorkspace((prev) => {
+            const next = new Map(prev);
+            const existing = next.get(update.workspaceId) ?? [];
+            const updated = [...existing, update.event].slice(-200);
+            next.set(update.workspaceId, updated);
+            return next;
+          });
+          break;
+      }
+    },
+    [scheduleStreamTick],
+  );
 
   // Fetch messages for all open workspaces from the main process.
   // Called on initial mount and when the app returns to foreground
   // (the renderer may have been discarded by macOS while backgrounded).
   const hydrateMessages = useCallback(async (workspaceList: WorkspaceSummary[]) => {
-    const open = workspaceList.filter((w) => w.status !== 'closed')
-    if (open.length === 0) return
+    const open = workspaceList.filter((w) => w.status !== 'closed');
+    if (open.length === 0) return;
     const entries = await Promise.all(
       open.map(async (w) => {
         try {
-          const msgs: Message[] = await window.bouncer.workspaces.getMessages(w.id)
-          return [w.id, msgs] as const
+          const msgs: Message[] = await window.bouncer.workspaces.getMessages(w.id);
+          return [w.id, msgs] as const;
         } catch {
-          return [w.id, [] as Message[]] as const
+          return [w.id, [] as Message[]] as const;
         }
-      })
-    )
+      }),
+    );
     setMessagesByWorkspace((prev) => {
-      const next = new Map(prev)
+      const next = new Map(prev);
       for (const [id, msgs] of entries) {
         // Only replace if the main process has more messages (avoids clobbering
         // in-flight streaming state with a stale snapshot).
         if (msgs.length > 0 && msgs.length >= (next.get(id)?.length ?? 0)) {
-          next.set(id, msgs)
+          next.set(id, msgs);
         }
       }
-      return next
-    })
-  }, [])
+      return next;
+    });
+  }, []);
 
   useEffect(() => {
-    window.bouncer.repositories.list().then(setRepos)
+    window.bouncer.repositories.list().then(setRepos);
     window.bouncer.workspaces.list().then((list) => {
       if (list.length > 0) {
-        setWorkspaces(list)
-        setActiveWorkspaceId(list[0].id)
-        hydrateMessages(list)
+        setWorkspaces(list);
+        setActiveWorkspaceId(list[0].id);
+        hydrateMessages(list);
       }
-    })
+    });
     window.bouncer.policies.list().then((list) => {
-      setPolicies(list)
-      setPolicyDescriptions(new Map(list.map((p) => [p.id, p.description])))
-    })
+      setPolicies(list);
+      setPolicyDescriptions(new Map(list.map((p) => [p.id, p.description])));
+    });
     window.bouncer.preferences.getFocusedRepoId().then((id) => {
-      if (id) setFocusedRepoId(id)
-    })
-    const unsubscribe = window.bouncer.workspaces.onUpdate(handleUpdate)
-    return unsubscribe
-  }, [handleUpdate, hydrateMessages])
+      if (id) setFocusedRepoId(id);
+    });
+    const unsubscribe = window.bouncer.workspaces.onUpdate(handleUpdate);
+    return unsubscribe;
+  }, [handleUpdate, hydrateMessages]);
 
   // Re-hydrate messages when the app returns to the foreground.
   // macOS may discard the renderer's webContents while backgrounded,
@@ -238,183 +257,183 @@ function App() {
       if (document.visibilityState === 'visible') {
         window.bouncer.workspaces.list().then((list) => {
           if (list.length > 0) {
-            setWorkspaces(list)
-            hydrateMessages(list)
+            setWorkspaces(list);
+            hydrateMessages(list);
           }
-        })
+        });
       }
     }
-    document.addEventListener('visibilitychange', onVisibilityChange)
-    return () => document.removeEventListener('visibilitychange', onVisibilityChange)
-  }, [hydrateMessages])
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', onVisibilityChange);
+  }, [hydrateMessages]);
 
   // Compute the effective focused repo:
   // (a) single repo → always focused
   // (b) active workspace's repo
   // (c) persisted last-focused repo
   const effectiveFocusedRepoId = useMemo(() => {
-    if (repos.length === 1) return repos[0].id
+    if (repos.length === 1) return repos[0].id;
     if (activeWorkspaceId) {
-      const ws = workspaces.find((w) => w.id === activeWorkspaceId)
-      if (ws?.repositoryId) return ws.repositoryId
+      const ws = workspaces.find((w) => w.id === activeWorkspaceId);
+      if (ws?.repositoryId) return ws.repositoryId;
     }
-    if (focusedRepoId && repos.some((r) => r.id === focusedRepoId)) return focusedRepoId
-    return null
-  }, [repos, activeWorkspaceId, workspaces, focusedRepoId])
+    if (focusedRepoId && repos.some((r) => r.id === focusedRepoId)) return focusedRepoId;
+    return null;
+  }, [repos, activeWorkspaceId, workspaces, focusedRepoId]);
 
   // Persist focused repo when it changes due to workspace selection
   useEffect(() => {
     if (effectiveFocusedRepoId && effectiveFocusedRepoId !== focusedRepoId) {
-      setFocusedRepoId(effectiveFocusedRepoId)
+      setFocusedRepoId(effectiveFocusedRepoId);
       void window.bouncer.preferences
         .setFocusedRepoId(effectiveFocusedRepoId)
-        .catch((err) => console.error('Failed to persist focused repo ID:', err))
+        .catch((err) => console.error('Failed to persist focused repo ID:', err));
     }
-  }, [effectiveFocusedRepoId])
+  }, [effectiveFocusedRepoId]);
 
   async function handleAddRepo() {
-    const dir = await window.bouncer.dialog.selectDirectory()
-    if (!dir) return
+    const dir = await window.bouncer.dialog.selectDirectory();
+    if (!dir) return;
     try {
-      const repo = await window.bouncer.repositories.add(dir)
-      setRepos((prev) => [...prev, repo])
+      const repo = await window.bouncer.repositories.add(dir);
+      setRepos((prev) => [...prev, repo]);
     } catch (err) {
-      console.error('Failed to add repository:', err)
+      console.error('Failed to add repository:', err);
     }
   }
 
   async function handleCreateWorkspace(repositoryId: string) {
     try {
-      const ws = await window.bouncer.workspaces.create(repositoryId)
+      const ws = await window.bouncer.workspaces.create(repositoryId);
       // Apply any status-change events that arrived while create() was in flight
-      const pending = pendingStatusUpdates.current.get(ws.id)
-      pendingStatusUpdates.current.delete(ws.id)
+      const pending = pendingStatusUpdates.current.get(ws.id);
+      pendingStatusUpdates.current.delete(ws.id);
       const resolved = pending?.summary
         ? { ...ws, ...pending.summary }
         : pending
           ? { ...ws, status: pending.status }
-          : ws
-      setWorkspaces((prev) => [...prev, resolved])
-      setActiveWorkspaceId(ws.id)
+          : ws;
+      setWorkspaces((prev) => [...prev, resolved]);
+      setActiveWorkspaceId(ws.id);
     } catch (err) {
-      console.error('Failed to create workspace:', err)
+      console.error('Failed to create workspace:', err);
     }
   }
 
   async function handleSendMessage(text: string) {
-    if (!activeWorkspaceId) return
+    if (!activeWorkspaceId) return;
     try {
-      await window.bouncer.workspaces.sendMessage(activeWorkspaceId, text)
+      await window.bouncer.workspaces.sendMessage(activeWorkspaceId, text);
     } catch (err) {
-      console.error('Failed to send message:', err)
+      console.error('Failed to send message:', err);
     }
   }
 
   async function handleCloseWorkspace(id: string) {
     try {
-      await window.bouncer.workspaces.close(id)
+      await window.bouncer.workspaces.close(id);
     } catch (err) {
-      console.error('Failed to close workspace:', err)
+      console.error('Failed to close workspace:', err);
     }
   }
 
   async function handleRefreshCredentials() {
-    if (!activeWorkspaceId) return
+    if (!activeWorkspaceId) return;
     try {
-      await window.bouncer.workspaces.refreshCredentials(activeWorkspaceId)
+      await window.bouncer.workspaces.refreshCredentials(activeWorkspaceId);
     } catch (err) {
-      console.error('Failed to refresh credentials:', err)
+      console.error('Failed to refresh credentials:', err);
     }
   }
 
   async function handleRemoveRepo(id: string) {
     // Close active workspaces for this repo first
-    const repoWorkspaces = workspaces.filter((w) => w.repositoryId === id && w.status !== 'closed')
+    const repoWorkspaces = workspaces.filter((w) => w.repositoryId === id && w.status !== 'closed');
     for (const w of repoWorkspaces) {
-      await handleCloseWorkspace(w.id)
+      await handleCloseWorkspace(w.id);
     }
     try {
-      await window.bouncer.repositories.remove(id)
-      setRepos((prev) => prev.filter((r) => r.id !== id))
-      setWorkspaces((prev) => prev.filter((w) => w.repositoryId !== id))
+      await window.bouncer.repositories.remove(id);
+      setRepos((prev) => prev.filter((r) => r.id !== id));
+      setWorkspaces((prev) => prev.filter((w) => w.repositoryId !== id));
       setActiveWorkspaceId((prev) => {
-        if (!prev) return null
-        const ws = workspaces.find((w) => w.id === prev)
-        return ws && ws.repositoryId === id ? null : prev
-      })
-      if (settingsRepoId === id) setSettingsRepoId(null)
+        if (!prev) return null;
+        const ws = workspaces.find((w) => w.id === prev);
+        return ws && ws.repositoryId === id ? null : prev;
+      });
+      if (settingsRepoId === id) setSettingsRepoId(null);
     } catch (err) {
-      console.error('Failed to remove repository:', err)
+      console.error('Failed to remove repository:', err);
     }
   }
 
   async function handleUpdateRepo(id: string, changes: Partial<Repository>) {
     try {
-      await window.bouncer.repositories.update(id, changes)
-      setRepos((prev) => prev.map((r) => r.id === id ? { ...r, ...changes } : r))
+      await window.bouncer.repositories.update(id, changes);
+      setRepos((prev) => prev.map((r) => (r.id === id ? { ...r, ...changes } : r)));
     } catch (err) {
-      console.error('Failed to update repository:', err)
+      console.error('Failed to update repository:', err);
     }
   }
 
-  const activeWorkspace = workspaces.find((s) => s.id === activeWorkspaceId)
+  const activeWorkspace = workspaces.find((s) => s.id === activeWorkspaceId);
   const activeMessages = activeWorkspaceId
-    ? messagesByWorkspace.get(activeWorkspaceId) ?? []
-    : []
+    ? (messagesByWorkspace.get(activeWorkspaceId) ?? [])
+    : [];
   const activeViolations = activeWorkspaceId
-    ? violationsByWorkspace.get(activeWorkspaceId) ?? []
-    : []
+    ? (violationsByWorkspace.get(activeWorkspaceId) ?? [])
+    : [];
   const activePolicyEvents = activeWorkspaceId
-    ? policyEventsByWorkspace.get(activeWorkspaceId) ?? []
-    : []
+    ? (policyEventsByWorkspace.get(activeWorkspaceId) ?? [])
+    : [];
 
-  const [sidebarWidth, setSidebarWidth] = useState(280)
-  const dragging = useRef(false)
-  const handleRef = useRef<HTMLDivElement>(null)
+  const [sidebarWidth, setSidebarWidth] = useState(280);
+  const dragging = useRef(false);
+  const handleRef = useRef<HTMLDivElement>(null);
 
   function stopDrag() {
-    dragging.current = false
-    handleRef.current?.classList.remove('dragging')
-    document.removeEventListener('mousemove', onMouseMove)
-    document.removeEventListener('mouseup', onMouseUp)
-    window.removeEventListener('blur', stopDrag)
+    dragging.current = false;
+    handleRef.current?.classList.remove('dragging');
+    document.removeEventListener('mousemove', onMouseMove);
+    document.removeEventListener('mouseup', onMouseUp);
+    window.removeEventListener('blur', stopDrag);
   }
 
   function onMouseMove(ev: globalThis.MouseEvent) {
-    const newWidth = Math.min(Math.max(ev.clientX, 180), window.innerWidth / 2)
-    setSidebarWidth(newWidth)
+    const newWidth = Math.min(Math.max(ev.clientX, 180), window.innerWidth / 2);
+    setSidebarWidth(newWidth);
   }
 
   function onMouseUp() {
-    stopDrag()
+    stopDrag();
   }
 
   function handleResizeStart(e: React.MouseEvent<HTMLDivElement>) {
-    if (e.button !== 0) return
-    e.preventDefault()
-    dragging.current = true
-    e.currentTarget.classList.add('dragging')
+    if (e.button !== 0) return;
+    e.preventDefault();
+    dragging.current = true;
+    e.currentTarget.classList.add('dragging');
 
-    document.addEventListener('mousemove', onMouseMove)
-    document.addEventListener('mouseup', onMouseUp)
-    window.addEventListener('blur', stopDrag)
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+    window.addEventListener('blur', stopDrag);
   }
 
   useEffect(() => {
     return () => {
-      document.removeEventListener('mousemove', onMouseMove)
-      document.removeEventListener('mouseup', onMouseUp)
-      window.removeEventListener('blur', stopDrag)
-    }
-  }, [])
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      window.removeEventListener('blur', stopDrag);
+    };
+  }, []);
 
   const violationCounts = useMemo(() => {
-    const counts = new Map<string, number>()
+    const counts = new Map<string, number>();
     for (const [id, vs] of violationsByWorkspace) {
-      counts.set(id, vs.length)
+      counts.set(id, vs.length);
     }
-    return counts
-  }, [violationsByWorkspace])
+    return counts;
+  }, [violationsByWorkspace]);
 
   return (
     <div className="app">
@@ -459,20 +478,21 @@ function App() {
           </div>
         </div>
       )}
-      {settingsRepoId && (() => {
-        const repo = repos.find((r) => r.id === settingsRepoId)
-        if (!repo) return null
-        return (
-          <RepoSettings
-            repo={repo}
-            policies={policies}
-            onSave={handleUpdateRepo}
-            onClose={() => setSettingsRepoId(null)}
-          />
-        )
-      })()}
+      {settingsRepoId &&
+        (() => {
+          const repo = repos.find((r) => r.id === settingsRepoId);
+          if (!repo) return null;
+          return (
+            <RepoSettings
+              repo={repo}
+              policies={policies}
+              onSave={handleUpdateRepo}
+              onClose={() => setSettingsRepoId(null)}
+            />
+          );
+        })()}
     </div>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/renderer/src/ErrorBoundary.tsx
+++ b/src/renderer/src/ErrorBoundary.tsx
@@ -1,43 +1,47 @@
-import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { Component, type ErrorInfo, type ReactNode } from 'react';
 
 interface Props {
-  children: ReactNode
+  children: ReactNode;
 }
 
 interface State {
-  error: Error | null
+  error: Error | null;
 }
 
 export class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
-    super(props)
-    this.state = { error: null }
+    super(props);
+    this.state = { error: null };
   }
 
   static getDerivedStateFromError(error: Error): State {
-    return { error }
+    return { error };
   }
 
   componentDidCatch(error: Error, info: ErrorInfo): void {
-    console.error('[ErrorBoundary] Uncaught error:', error, info.componentStack)
+    console.error('[ErrorBoundary] Uncaught error:', error, info.componentStack);
   }
 
   render(): ReactNode {
     if (this.state.error) {
       return (
-        <div style={{
-          padding: 40,
-          color: '#d9534f',
-          backgroundColor: '#1a1a1a',
-          fontFamily: 'monospace',
-          height: '100vh',
-          overflow: 'auto',
-        }}>
+        <div
+          style={{
+            padding: 40,
+            color: '#d9534f',
+            backgroundColor: '#1a1a1a',
+            fontFamily: 'monospace',
+            height: '100vh',
+            overflow: 'auto',
+          }}
+        >
           <h2>Renderer Error</h2>
           <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
             {this.state.error.message}
           </pre>
-          <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', color: '#888', fontSize: 12 }}>
+          <pre
+            style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', color: '#888', fontSize: 12 }}
+          >
             {this.state.error.stack}
           </pre>
           <button
@@ -47,8 +51,8 @@ export class ErrorBoundary extends Component<Props, State> {
             Try to recover
           </button>
         </div>
-      )
+      );
     }
-    return this.props.children
+    return this.props.children;
   }
 }

--- a/src/renderer/src/components/ChatPanel.tsx
+++ b/src/renderer/src/components/ChatPanel.tsx
@@ -1,42 +1,50 @@
-import { type RefObject, useEffect, useRef, useState } from 'react'
-import type { Components } from 'react-markdown'
-import Markdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
-import type { Message, MessagePart, PolicyEvent, SandboxViolationInfo, WorkspaceSummary, ToolCallInfo } from '../../../main/types'
-import { MessageInput } from './MessageInput'
-import thinkingVideo from '../assets/thinking.webm'
+import { type RefObject, useEffect, useRef, useState } from 'react';
+import type { Components } from 'react-markdown';
+import Markdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type {
+  Message,
+  MessagePart,
+  PolicyEvent,
+  SandboxViolationInfo,
+  WorkspaceSummary,
+  ToolCallInfo,
+} from '../../../main/types';
+import { MessageInput } from './MessageInput';
+import thinkingVideo from '../assets/thinking.webm';
 
 const markdownComponents: Components = {
   a: ({ node, ...props }) => <a {...props} target="_blank" rel="noreferrer noopener" />,
-}
+};
 
 interface Props {
-  messages: Message[]
-  streamingTextRef: RefObject<Map<string, string[]>>
-  streamTick: number
-  sessionStatus: WorkspaceSummary['status']
-  sessionError?: string
-  sessionErrorKind?: 'auth'
-  sandboxed: boolean
-  violations: SandboxViolationInfo[]
-  policyEvents: PolicyEvent[]
-  onSendMessage: (text: string) => void
-  onCloseSession: () => void
-  onRefreshCredentials: () => void
+  messages: Message[];
+  streamingTextRef: RefObject<Map<string, string[]>>;
+  streamTick: number;
+  sessionStatus: WorkspaceSummary['status'];
+  sessionError?: string;
+  sessionErrorKind?: 'auth';
+  sandboxed: boolean;
+  violations: SandboxViolationInfo[];
+  policyEvents: PolicyEvent[];
+  onSendMessage: (text: string) => void;
+  onCloseSession: () => void;
+  onRefreshCredentials: () => void;
 }
 
-
 function ToolCallStep({ toolCall }: { toolCall: ToolCallInfo }) {
-  const [expanded, setExpanded] = useState(false)
+  const [expanded, setExpanded] = useState(false);
 
-  const isBash = toolCall.name === 'Bash'
-  const command = isBash && toolCall.input?.command ? String(toolCall.input.command) : null
-  const hasOutput = !!toolCall.output
-  const hasDetail = (isBash && command) || hasOutput
+  const isBash = toolCall.name === 'Bash';
+  const command = isBash && toolCall.input?.command ? String(toolCall.input.command) : null;
+  const hasOutput = !!toolCall.output;
+  const hasDetail = (isBash && command) || hasOutput;
   const dotClass =
-    toolCall.status === 'completed' ? 'step-dot tool-dot-success' :
-    toolCall.status === 'failed' ? 'step-dot tool-dot-fail' :
-    'step-dot tool-dot-progress'
+    toolCall.status === 'completed'
+      ? 'step-dot tool-dot-success'
+      : toolCall.status === 'failed'
+        ? 'step-dot tool-dot-fail'
+        : 'step-dot tool-dot-progress';
 
   return (
     <div className="message agent tool-step">
@@ -69,50 +77,56 @@ function ToolCallStep({ toolCall }: { toolCall: ToolCallInfo }) {
         )}
       </div>
     </div>
-  )
+  );
 }
 
 /** Groups consecutive tool parts from the parts array, preserving text parts as-is. */
 type PartGroup =
   | { type: 'text'; part: MessagePart & { type: 'text' } }
-  | { type: 'tools'; toolCallIds: string[] }
+  | { type: 'tools'; toolCallIds: string[] };
 
 function groupParts(parts: MessagePart[]): PartGroup[] {
-  const groups: PartGroup[] = []
+  const groups: PartGroup[] = [];
   for (const part of parts) {
     if (part.type === 'text') {
-      groups.push({ type: 'text', part })
+      groups.push({ type: 'text', part });
     } else {
-      const last = groups[groups.length - 1]
+      const last = groups[groups.length - 1];
       if (last && last.type === 'tools') {
-        last.toolCallIds.push(part.toolCallId)
+        last.toolCallIds.push(part.toolCallId);
       } else {
-        groups.push({ type: 'tools', toolCallIds: [part.toolCallId] })
+        groups.push({ type: 'tools', toolCallIds: [part.toolCallId] });
       }
     }
   }
-  return groups
+  return groups;
 }
 
-function ToolRunGroup({ toolCallIds, toolCalls, isStreaming }: {
-  toolCallIds: string[]
-  toolCalls: ToolCallInfo[]
-  isStreaming: boolean
+function ToolRunGroup({
+  toolCallIds,
+  toolCalls,
+  isStreaming,
+}: {
+  toolCallIds: string[];
+  toolCalls: ToolCallInfo[];
+  isStreaming: boolean;
 }) {
-  const [expanded, setExpanded] = useState(false)
+  const [expanded, setExpanded] = useState(false);
 
   // Track turn completion: once streaming transitions false, the turn is done.
-  const [turnComplete, setTurnComplete] = useState(!isStreaming)
-  const prevStreaming = useRef(isStreaming)
+  const [turnComplete, setTurnComplete] = useState(!isStreaming);
+  const prevStreaming = useRef(isStreaming);
   useEffect(() => {
     if (prevStreaming.current && !isStreaming) {
-      setTurnComplete(true)
+      setTurnComplete(true);
     }
-    prevStreaming.current = isStreaming
-  }, [isStreaming])
+    prevStreaming.current = isStreaming;
+  }, [isStreaming]);
 
-  const resolved = toolCallIds.map((id) => toolCalls.find((t) => t.id === id)).filter(Boolean) as ToolCallInfo[]
-  const failCount = resolved.filter((tc) => tc.status === 'failed').length
+  const resolved = toolCallIds
+    .map((id) => toolCalls.find((t) => t.id === id))
+    .filter(Boolean) as ToolCallInfo[];
+  const failCount = resolved.filter((tc) => tc.status === 'failed').length;
 
   // Before the turn is complete, or if user expanded: show all tool calls individually
   if (!turnComplete || expanded) {
@@ -123,13 +137,17 @@ function ToolRunGroup({ toolCallIds, toolCalls, isStreaming }: {
             <span className="tool-step-chevron">{'\u25BE'}</span>
             <span className="tool-group-summary-text">
               {resolved.length} tool call{resolved.length !== 1 ? 's' : ''}
-              {failCount > 0 && <span className="tool-group-fail-count"> ({failCount} failed)</span>}
+              {failCount > 0 && (
+                <span className="tool-group-fail-count"> ({failCount} failed)</span>
+              )}
             </span>
           </button>
         )}
-        {resolved.map((tc) => <ToolCallStep key={tc.id} toolCall={tc} />)}
+        {resolved.map((tc) => (
+          <ToolCallStep key={tc.id} toolCall={tc} />
+        ))}
       </>
-    )
+    );
   }
 
   // Turn complete and collapsed: single summary line
@@ -141,7 +159,7 @@ function ToolRunGroup({ toolCallIds, toolCalls, isStreaming }: {
         {failCount > 0 && <span className="tool-group-fail-count"> ({failCount} failed)</span>}
       </span>
     </button>
-  )
+  );
 }
 
 export function ChatPanel({
@@ -158,81 +176,99 @@ export function ChatPanel({
   onCloseSession,
   onRefreshCredentials,
 }: Props) {
-  const bottomRef = useRef<HTMLDivElement>(null)
-  const lastScrollTime = useRef(0)
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const lastScrollTime = useRef(0);
 
-  const isStreaming = messages.some((m) => m.streaming)
-  const hasPendingMessage = sessionStatus === 'initializing' && messages.some((m) => m.role === 'user')
-  const inputDisabled = isStreaming || hasPendingMessage || (sessionStatus !== 'ready' && sessionStatus !== 'initializing')
+  const isStreaming = messages.some((m) => m.streaming);
+  const hasPendingMessage =
+    sessionStatus === 'initializing' && messages.some((m) => m.role === 'user');
+  const inputDisabled =
+    isStreaming ||
+    hasPendingMessage ||
+    (sessionStatus !== 'ready' && sessionStatus !== 'initializing');
 
   // Throttle scrolling to at most once per 100ms
   useEffect(() => {
-    const now = Date.now()
-    if (now - lastScrollTime.current < 100) return
-    lastScrollTime.current = now
-    bottomRef.current?.scrollIntoView({ behavior: isStreaming ? 'auto' : 'smooth' })
-  }, [messages, streamTick, isStreaming])
+    const now = Date.now();
+    if (now - lastScrollTime.current < 100) return;
+    lastScrollTime.current = now;
+    bottomRef.current?.scrollIntoView({ behavior: isStreaming ? 'auto' : 'smooth' });
+  }, [messages, streamTick, isStreaming]);
 
   return (
     <div className="chat-panel">
       <div className="messages">
-        {messages.length === 0 && (sessionStatus === 'ready' || sessionStatus === 'initializing') && (
-          <div className="empty-state">Send a message to begin</div>
-        )}
+        {messages.length === 0 &&
+          (sessionStatus === 'ready' || sessionStatus === 'initializing') && (
+            <div className="empty-state">Send a message to begin</div>
+          )}
         {messages.map((msg) => {
           if (msg.role === 'user') {
-            const displayText = msg.text.replace(/^\n+/, '')
+            const displayText = msg.text.replace(/^\n+/, '');
             return (
               <div key={msg.id} className="message user">
                 <div className="user-bubble">
-                  <Markdown remarkPlugins={[remarkGfm]} components={markdownComponents} disallowedElements={['img']}>{displayText}</Markdown>
+                  <Markdown
+                    remarkPlugins={[remarkGfm]}
+                    components={markdownComponents}
+                    disallowedElements={['img']}
+                  >
+                    {displayText}
+                  </Markdown>
                 </div>
               </div>
-            )
+            );
           }
 
-          const isStreaming = msg.streaming && streamingTextRef.current.has(msg.id)
-          const streamingSegments = isStreaming ? streamingTextRef.current.get(msg.id) : undefined
-          const segments = streamingSegments ?? msg.textSegments ?? [msg.text]
-          const parts: MessagePart[] = msg.parts ?? [{ type: 'text', index: 0 }]
-          const lastTextIndex = [...parts].reverse().find((p) => p.type === 'text')
-          const activeSegmentIndex = lastTextIndex?.type === 'text' ? lastTextIndex.index : -1
+          const isStreaming = msg.streaming && streamingTextRef.current.has(msg.id);
+          const streamingSegments = isStreaming ? streamingTextRef.current.get(msg.id) : undefined;
+          const segments = streamingSegments ?? msg.textSegments ?? [msg.text];
+          const parts: MessagePart[] = msg.parts ?? [{ type: 'text', index: 0 }];
+          const lastTextIndex = [...parts].reverse().find((p) => p.type === 'text');
+          const activeSegmentIndex = lastTextIndex?.type === 'text' ? lastTextIndex.index : -1;
 
-          const grouped = groupParts(parts)
+          const grouped = groupParts(parts);
 
           // Show the thinking indicator at the bottom of the turn whenever
           // the agent is streaming and the last group is not an active text segment.
-          const lastGroup = grouped[grouped.length - 1]
-          const activeSegmentIsLast = lastGroup?.type === 'text' && lastGroup.part.index === activeSegmentIndex
-          const showTrailingThinking = isStreaming && !activeSegmentIsLast
+          const lastGroup = grouped[grouped.length - 1];
+          const activeSegmentIsLast =
+            lastGroup?.type === 'text' && lastGroup.part.index === activeSegmentIndex;
+          const showTrailingThinking = isStreaming && !activeSegmentIsLast;
 
           return (
             <div key={msg.id} className="agent-turn">
               {grouped.map((group, i) => {
                 if (group.type === 'text') {
-                  const rawText = segments[group.part.index] ?? ''
-                  const displayText = rawText.replace(/^\n+/, '')
-                  const isActiveSegment = isStreaming && group.part.index === activeSegmentIndex
+                  const rawText = segments[group.part.index] ?? '';
+                  const displayText = rawText.replace(/^\n+/, '');
+                  const isActiveSegment = isStreaming && group.part.index === activeSegmentIndex;
 
                   // Skip empty active segments when we'll show the indicator at the bottom instead
-                  if (!displayText && isActiveSegment && showTrailingThinking) return null
-                  if (!displayText && !isActiveSegment) return null
+                  if (!displayText && isActiveSegment && showTrailingThinking) return null;
+                  if (!displayText && !isActiveSegment) return null;
 
                   if (isActiveSegment && !displayText) {
                     return (
                       <div key={`text-${group.part.index}`} className="thinking-indicator">
                         <video src={thinkingVideo} autoPlay loop muted playsInline />
                       </div>
-                    )
+                    );
                   }
 
                   return (
                     <div key={`text-${group.part.index}`} className="message agent agent-text">
                       <div className={`step-content${isActiveSegment ? ' streaming' : ''}`}>
-                        <Markdown remarkPlugins={[remarkGfm]} components={markdownComponents} disallowedElements={['img']}>{displayText}</Markdown>
+                        <Markdown
+                          remarkPlugins={[remarkGfm]}
+                          components={markdownComponents}
+                          disallowedElements={['img']}
+                        >
+                          {displayText}
+                        </Markdown>
                       </div>
                     </div>
-                  )
+                  );
                 }
 
                 return (
@@ -242,7 +278,7 @@ export function ChatPanel({
                     toolCalls={msg.toolCalls ?? []}
                     isStreaming={!!isStreaming}
                   />
-                )
+                );
               })}
               {showTrailingThinking && (
                 <div className="thinking-indicator">
@@ -250,12 +286,14 @@ export function ChatPanel({
                 </div>
               )}
             </div>
-          )
+          );
         })}
         {sessionStatus === 'error' && sessionErrorKind === 'auth' && (
           <div className="workspace-state-banner auth-error">
             Authentication expired. Run <code>claude auth login</code> in your terminal, then:
-            <button type="button" onClick={onRefreshCredentials}>Retry</button>
+            <button type="button" onClick={onRefreshCredentials}>
+              Retry
+            </button>
           </div>
         )}
         {sessionStatus === 'error' && sessionErrorKind !== 'auth' && (
@@ -265,9 +303,7 @@ export function ChatPanel({
           </div>
         )}
         {sessionStatus === 'closed' && (
-          <div className="workspace-state-banner closed">
-            Workspace closed
-          </div>
+          <div className="workspace-state-banner closed">Workspace closed</div>
         )}
         <div ref={bottomRef} />
       </div>
@@ -279,12 +315,15 @@ export function ChatPanel({
         violations={violations}
         policyEvents={policyEvents}
         placeholder={
-          sessionStatus === 'error' ? 'Workspace disconnected' :
-          sessionStatus === 'closed' ? 'Workspace closed' :
-          sessionStatus === 'initializing' && hasPendingMessage ? 'Starting workspace...' :
-          undefined
+          sessionStatus === 'error'
+            ? 'Workspace disconnected'
+            : sessionStatus === 'closed'
+              ? 'Workspace closed'
+              : sessionStatus === 'initializing' && hasPendingMessage
+                ? 'Starting workspace...'
+                : undefined
         }
       />
     </div>
-  )
+  );
 }

--- a/src/renderer/src/components/MessageInput.tsx
+++ b/src/renderer/src/components/MessageInput.tsx
@@ -1,112 +1,137 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
-import type { PolicyEvent, SandboxViolationInfo, WorkspaceSummary } from '../../../main/types'
-import lockIcon from '../assets/icon-lock.png'
-import unlockIcon from '../assets/icon-unlock.png'
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { PolicyEvent, SandboxViolationInfo, WorkspaceSummary } from '../../../main/types';
+import lockIcon from '../assets/icon-lock.png';
+import unlockIcon from '../assets/icon-unlock.png';
 
 type LogEntry =
   | { kind: 'violation'; timestamp: number; data: SandboxViolationInfo }
-  | { kind: 'policy'; timestamp: number; data: PolicyEvent }
+  | { kind: 'policy'; timestamp: number; data: PolicyEvent };
 
 interface Props {
-  onSend: (text: string) => void
-  disabled: boolean
-  sandboxed: boolean
-  sessionStatus: WorkspaceSummary['status']
-  placeholder?: string
-  violations: SandboxViolationInfo[]
-  policyEvents: PolicyEvent[]
+  onSend: (text: string) => void;
+  disabled: boolean;
+  sandboxed: boolean;
+  sessionStatus: WorkspaceSummary['status'];
+  placeholder?: string;
+  violations: SandboxViolationInfo[];
+  policyEvents: PolicyEvent[];
 }
 
-export function MessageInput({ onSend, disabled, sandboxed, sessionStatus, placeholder, violations, policyEvents }: Props) {
-  const [text, setText] = useState('')
-  const [showLog, setShowLog] = useState(false)
-  const inputRef = useRef<HTMLInputElement>(null)
-  const logBottomRef = useRef<HTMLDivElement>(null)
+export function MessageInput({
+  onSend,
+  disabled,
+  sandboxed,
+  sessionStatus,
+  placeholder,
+  violations,
+  policyEvents,
+}: Props) {
+  const [text, setText] = useState('');
+  const [showLog, setShowLog] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const logBottomRef = useRef<HTMLDivElement>(null);
 
-  const totalCount = violations.length + policyEvents.length
+  const totalCount = violations.length + policyEvents.length;
 
   const entries = useMemo(() => {
     const merged: LogEntry[] = [
       ...violations.map((v): LogEntry => ({ kind: 'violation', timestamp: v.timestamp, data: v })),
       ...policyEvents.map((e): LogEntry => ({ kind: 'policy', timestamp: e.timestamp, data: e })),
-    ]
-    merged.sort((a, b) => a.timestamp - b.timestamp)
-    return merged.slice(-200)
-  }, [violations, policyEvents])
+    ];
+    merged.sort((a, b) => a.timestamp - b.timestamp);
+    return merged.slice(-200);
+  }, [violations, policyEvents]);
 
   const { denyCount, violationCount } = useMemo(() => {
-    let deny = 0
-    let viol = 0
+    let deny = 0;
+    let viol = 0;
     for (const e of entries) {
-      if (e.kind === 'violation') viol++
-      else if ((e.data as PolicyEvent).decision === 'deny') deny++
+      if (e.kind === 'violation') viol++;
+      else if ((e.data as PolicyEvent).decision === 'deny') deny++;
     }
-    return { denyCount: deny, violationCount: viol }
-  }, [entries])
+    return { denyCount: deny, violationCount: viol };
+  }, [entries]);
 
   useEffect(() => {
     if (showLog) {
-      logBottomRef.current?.scrollIntoView({ behavior: 'auto' })
+      logBottomRef.current?.scrollIntoView({ behavior: 'auto' });
     }
-  }, [entries, showLog])
+  }, [entries, showLog]);
 
-  const canSend = !disabled && !!text.trim()
-  const hasEvents = totalCount > 0
+  const canSend = !disabled && !!text.trim();
+  const hasEvents = totalCount > 0;
 
   // Close popover when events disappear (e.g. session switch)
   useEffect(() => {
-    if (!hasEvents) setShowLog(false)
-  }, [hasEvents])
+    if (!hasEvents) setShowLog(false);
+  }, [hasEvents]);
 
   // Focus whenever the input becomes enabled (including initial mount)
   useEffect(() => {
     if (!disabled) {
-      inputRef.current?.focus()
+      inputRef.current?.focus();
     }
-  }, [disabled])
+  }, [disabled]);
 
   function handleSubmit() {
-    const trimmed = text.trim()
-    if (!trimmed || disabled) return
-    onSend(trimmed)
-    setText('')
-    requestAnimationFrame(() => inputRef.current?.focus())
+    const trimmed = text.trim();
+    if (!trimmed || disabled) return;
+    onSend(trimmed);
+    setText('');
+    requestAnimationFrame(() => inputRef.current?.focus());
   }
 
   return (
     <div className="message-input-wrapper">
       {showLog && hasEvents && (
-        <div className="sandbox-popover" id="sandbox-popover" role="dialog" aria-label="Policy and sandbox events">
+        <div
+          className="sandbox-popover"
+          id="sandbox-popover"
+          role="dialog"
+          aria-label="Policy and sandbox events"
+        >
           <div className="sandbox-popover-header">
             Policy &amp; sandbox events ({entries.length})
             {denyCount > 0 && <span className="sandbox-popover-deny">{denyCount} denied</span>}
-            {violationCount > 0 && <span className="sandbox-popover-violations">{violationCount} violations</span>}
+            {violationCount > 0 && (
+              <span className="sandbox-popover-violations">{violationCount} violations</span>
+            )}
           </div>
           <div className="sandbox-popover-entries">
             {entries.map((entry, i) => {
               if (entry.kind === 'violation') {
-                const v = entry.data as SandboxViolationInfo
+                const v = entry.data as SandboxViolationInfo;
                 return (
-                  <div key={`v-${v.timestamp}-${v.operation}-${i}`} className="sandbox-log-entry sandbox-log-violation">
-                    <span className="sandbox-log-entry-icon" title="Sandbox violation">&#x1F6E1;</span>
+                  <div
+                    key={`v-${v.timestamp}-${v.operation}-${i}`}
+                    className="sandbox-log-entry sandbox-log-violation"
+                  >
+                    <span className="sandbox-log-entry-icon" title="Sandbox violation">
+                      &#x1F6E1;
+                    </span>
                     <span className="sandbox-log-op-violation">{v.operation}</span>
                     <span className="sandbox-log-process">{v.processName}</span>
                     {v.path && <span className="sandbox-log-path">{v.path}</span>}
                   </div>
-                )
+                );
               } else {
-                const e = entry.data as PolicyEvent
-                const isAllow = e.decision === 'allow'
+                const e = entry.data as PolicyEvent;
+                const isAllow = e.decision === 'allow';
                 return (
-                  <div key={`p-${e.timestamp}-${e.operation}-${i}`} className={`sandbox-log-entry sandbox-log-policy-${e.decision}`}>
+                  <div
+                    key={`p-${e.timestamp}-${e.operation}-${i}`}
+                    className={`sandbox-log-entry sandbox-log-policy-${e.decision}`}
+                  >
                     <span className="sandbox-log-entry-icon" title={isAllow ? 'Allowed' : 'Denied'}>
                       {isAllow ? '\u2705' : '\u274C'}
                     </span>
                     <span className="sandbox-log-tool">{e.tool}</span>
-                    <span className={isAllow ? 'sandbox-log-op-allow' : 'sandbox-log-op-deny'}>{e.operation}</span>
+                    <span className={isAllow ? 'sandbox-log-op-allow' : 'sandbox-log-op-deny'}>
+                      {e.operation}
+                    </span>
                     {e.reason && <span className="sandbox-log-reason">{e.reason}</span>}
                   </div>
-                )
+                );
               }
             })}
             <div ref={logBottomRef} />
@@ -120,7 +145,7 @@ export function MessageInput({ onSend, disabled, sandboxed, sessionStatus, place
           value={text}
           onChange={(e) => setText(e.target.value)}
           onKeyDown={(e) => {
-            if (e.key === 'Enter') handleSubmit()
+            if (e.key === 'Enter') handleSubmit();
           }}
           placeholder={placeholder ?? (disabled ? 'Agent is responding...' : 'Type a message...')}
           disabled={disabled}
@@ -136,12 +161,24 @@ export function MessageInput({ onSend, disabled, sandboxed, sessionStatus, place
               aria-controls={hasEvents ? 'sandbox-popover' : undefined}
               aria-haspopup={hasEvents ? 'dialog' : undefined}
               disabled={!hasEvents}
-              title={sessionStatus === 'initializing' ? 'Starting...' : sandboxed ? 'Sandboxed' : 'Unsandboxed'}
+              title={
+                sessionStatus === 'initializing'
+                  ? 'Starting...'
+                  : sandboxed
+                    ? 'Sandboxed'
+                    : 'Unsandboxed'
+              }
               style={hasEvents ? undefined : { cursor: 'default' }}
             >
               <img
                 src={sessionStatus === 'initializing' || sandboxed ? lockIcon : unlockIcon}
-                alt={sessionStatus === 'initializing' ? 'Starting' : sandboxed ? 'Sandboxed' : 'Unsandboxed'}
+                alt={
+                  sessionStatus === 'initializing'
+                    ? 'Starting'
+                    : sandboxed
+                      ? 'Sandboxed'
+                      : 'Unsandboxed'
+                }
                 className={`shield-lock-icon${sessionStatus === 'initializing' ? ' loading' : ''}`}
               />
               {(denyCount > 0 || violationCount > 0) && (
@@ -156,12 +193,18 @@ export function MessageInput({ onSend, disabled, sandboxed, sessionStatus, place
               aria-label="Send message"
             >
               <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                <path d="M8 3L8 13M8 3L4 7M8 3L12 7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                <path
+                  d="M8 3L8 13M8 3L4 7M8 3L12 7"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
               </svg>
             </button>
           </div>
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/src/renderer/src/components/RepoSettings.tsx
+++ b/src/renderer/src/components/RepoSettings.tsx
@@ -1,29 +1,29 @@
-import { useState } from 'react'
-import type { AgentType, PolicyTemplateSummary, Repository } from '../../../main/types'
+import { useState } from 'react';
+import type { AgentType, PolicyTemplateSummary, Repository } from '../../../main/types';
 
 interface Props {
-  repo: Repository
-  policies: PolicyTemplateSummary[]
-  onSave: (id: string, changes: Partial<Repository>) => void
-  onClose: () => void
+  repo: Repository;
+  policies: PolicyTemplateSummary[];
+  onSave: (id: string, changes: Partial<Repository>) => void;
+  onClose: () => void;
 }
 
 export function RepoSettings({ repo, policies, onSave, onClose }: Props) {
-  const [name, setName] = useState(repo.name)
-  const [githubRepo, setGithubRepo] = useState(repo.githubRepo ?? '')
-  const [defaultPolicyId, setDefaultPolicyId] = useState(repo.defaultPolicyId)
-  const [defaultAgentType, setDefaultAgentType] = useState<AgentType>(repo.defaultAgentType)
+  const [name, setName] = useState(repo.name);
+  const [githubRepo, setGithubRepo] = useState(repo.githubRepo ?? '');
+  const [defaultPolicyId, setDefaultPolicyId] = useState(repo.defaultPolicyId);
+  const [defaultAgentType, setDefaultAgentType] = useState<AgentType>(repo.defaultAgentType);
 
   function handleSave() {
-    const changes: Partial<Repository> = {}
-    if (name !== repo.name) changes.name = name
-    if ((githubRepo || null) !== repo.githubRepo) changes.githubRepo = githubRepo || null
-    if (defaultPolicyId !== repo.defaultPolicyId) changes.defaultPolicyId = defaultPolicyId
-    if (defaultAgentType !== repo.defaultAgentType) changes.defaultAgentType = defaultAgentType
+    const changes: Partial<Repository> = {};
+    if (name !== repo.name) changes.name = name;
+    if ((githubRepo || null) !== repo.githubRepo) changes.githubRepo = githubRepo || null;
+    if (defaultPolicyId !== repo.defaultPolicyId) changes.defaultPolicyId = defaultPolicyId;
+    if (defaultAgentType !== repo.defaultAgentType) changes.defaultAgentType = defaultAgentType;
     if (Object.keys(changes).length > 0) {
-      onSave(repo.id, changes)
+      onSave(repo.id, changes);
     }
-    onClose()
+    onClose();
   }
 
   return (
@@ -31,16 +31,14 @@ export function RepoSettings({ repo, policies, onSave, onClose }: Props) {
       <div className="repo-settings" onClick={(e) => e.stopPropagation()}>
         <div className="repo-settings-header">
           <span>Repository Settings</span>
-          <button type="button" className="close-btn" onClick={onClose}>×</button>
+          <button type="button" className="close-btn" onClick={onClose}>
+            ×
+          </button>
         </div>
         <div className="repo-settings-body">
           <label className="repo-settings-field">
             <span className="repo-settings-label">Name</span>
-            <input
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-            />
+            <input type="text" value={name} onChange={(e) => setName(e.target.value)} />
           </label>
           <label className="repo-settings-field">
             <span className="repo-settings-label">Local path</span>
@@ -57,12 +55,11 @@ export function RepoSettings({ repo, policies, onSave, onClose }: Props) {
           </label>
           <label className="repo-settings-field">
             <span className="repo-settings-label">Default policy</span>
-            <select
-              value={defaultPolicyId}
-              onChange={(e) => setDefaultPolicyId(e.target.value)}
-            >
+            <select value={defaultPolicyId} onChange={(e) => setDefaultPolicyId(e.target.value)}>
               {policies.map((p) => (
-                <option key={p.id} value={p.id}>{p.name}</option>
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
               ))}
             </select>
           </label>
@@ -78,10 +75,14 @@ export function RepoSettings({ repo, policies, onSave, onClose }: Props) {
           </label>
         </div>
         <div className="repo-settings-footer">
-          <button type="button" className="repo-settings-cancel" onClick={onClose}>Cancel</button>
-          <button type="button" className="repo-settings-save" onClick={handleSave}>Save</button>
+          <button type="button" className="repo-settings-cancel" onClick={onClose}>
+            Cancel
+          </button>
+          <button type="button" className="repo-settings-save" onClick={handleSave}>
+            Save
+          </button>
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/src/renderer/src/components/WorkspacesSidebar.tsx
+++ b/src/renderer/src/components/WorkspacesSidebar.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useRef, useState, type CSSProperties } from 'react'
-import type { Repository, WorkspaceSummary } from '../../../main/types'
-import branchIcon from '../assets/icon-branch.png'
-import newFolderIcon from '../assets/icon-new-folder.png'
-import newFolderHoverIcon from '../assets/icon-new-folder-hover.png'
+import { useEffect, useRef, useState, type CSSProperties } from 'react';
+import type { Repository, WorkspaceSummary } from '../../../main/types';
+import branchIcon from '../assets/icon-branch.png';
+import newFolderIcon from '../assets/icon-new-folder.png';
+import newFolderHoverIcon from '../assets/icon-new-folder-hover.png';
 
 function AddRepoButton({ onAddRepo }: { onAddRepo: () => void }) {
-  const [hovered, setHovered] = useState(false)
+  const [hovered, setHovered] = useState(false);
   return (
     <button
       type="button"
@@ -15,33 +15,37 @@ function AddRepoButton({ onAddRepo }: { onAddRepo: () => void }) {
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
-      <img src={hovered ? newFolderHoverIcon : newFolderIcon} alt="Add repository" className="add-repo-icon" />
+      <img
+        src={hovered ? newFolderHoverIcon : newFolderIcon}
+        alt="Add repository"
+        className="add-repo-icon"
+      />
     </button>
-  )
+  );
 }
 
 interface Props {
-  repos: Repository[]
-  workspaces: WorkspaceSummary[]
-  activeWorkspaceId: string | null
-  focusedRepoId: string | null
-  violationCounts: Map<string, number>
-  policyDescriptions: Map<string, string>
-  onSelectWorkspace: (id: string) => void
-  onCreateWorkspace: (repositoryId: string) => void
-  onCloseWorkspace: (id: string) => void
-  onAddRepo: () => void
-  onRemoveRepo: (id: string) => void
-  onUpdateRepo: (id: string, changes: Partial<Repository>) => void
-  onOpenRepoSettings: (repoId: string) => void
-  style?: CSSProperties
+  repos: Repository[];
+  workspaces: WorkspaceSummary[];
+  activeWorkspaceId: string | null;
+  focusedRepoId: string | null;
+  violationCounts: Map<string, number>;
+  policyDescriptions: Map<string, string>;
+  onSelectWorkspace: (id: string) => void;
+  onCreateWorkspace: (repositoryId: string) => void;
+  onCloseWorkspace: (id: string) => void;
+  onAddRepo: () => void;
+  onRemoveRepo: (id: string) => void;
+  onUpdateRepo: (id: string, changes: Partial<Repository>) => void;
+  onOpenRepoSettings: (repoId: string) => void;
+  style?: CSSProperties;
 }
 
 function workspaceLabel(ws: WorkspaceSummary): string {
   if (ws.projectDir) {
-    return ws.projectDir.split('/').pop() ?? ws.id.slice(0, 8)
+    return ws.projectDir.split('/').pop() ?? ws.id.slice(0, 8);
   }
-  return ws.id.slice(0, 8)
+  return ws.id.slice(0, 8);
 }
 
 function RepoGroup({
@@ -57,32 +61,32 @@ function RepoGroup({
   onRemoveRepo,
   onOpenSettings,
 }: {
-  repo: Repository
-  workspaces: WorkspaceSummary[]
-  activeWorkspaceId: string | null
-  isFocused: boolean
-  violationCounts: Map<string, number>
-  policyDescriptions: Map<string, string>
-  onSelectWorkspace: (id: string) => void
-  onCreateWorkspace: (repositoryId: string) => void
-  onCloseWorkspace: (id: string) => void
-  onRemoveRepo: (id: string) => void
-  onOpenSettings: (repoId: string) => void
+  repo: Repository;
+  workspaces: WorkspaceSummary[];
+  activeWorkspaceId: string | null;
+  isFocused: boolean;
+  violationCounts: Map<string, number>;
+  policyDescriptions: Map<string, string>;
+  onSelectWorkspace: (id: string) => void;
+  onCreateWorkspace: (repositoryId: string) => void;
+  onCloseWorkspace: (id: string) => void;
+  onRemoveRepo: (id: string) => void;
+  onOpenSettings: (repoId: string) => void;
 }) {
-  const hasActive = workspaces.some((w) => w.status !== 'closed')
-  const [expanded, setExpanded] = useState(true)
-  const [showContextMenu, setShowContextMenu] = useState(false)
-  const [contextMenuPos, setContextMenuPos] = useState({ x: 0, y: 0 })
+  const hasActive = workspaces.some((w) => w.status !== 'closed');
+  const [expanded, setExpanded] = useState(true);
+  const [showContextMenu, setShowContextMenu] = useState(false);
+  const [contextMenuPos, setContextMenuPos] = useState({ x: 0, y: 0 });
 
   // Auto-expand when active workspaces appear
   useEffect(() => {
-    if (hasActive) setExpanded(true)
-  }, [hasActive])
+    if (hasActive) setExpanded(true);
+  }, [hasActive]);
 
   function handleContextMenu(e: React.MouseEvent) {
-    e.preventDefault()
-    setShowContextMenu(true)
-    setContextMenuPos({ x: e.clientX, y: e.clientY })
+    e.preventDefault();
+    setShowContextMenu(true);
+    setContextMenuPos({ x: e.clientX, y: e.clientY });
   }
 
   return (
@@ -113,68 +117,60 @@ function RepoGroup({
           +
         </button>
       </div>
-      {expanded && workspaces.map((ws) => (
-        <div
-          key={ws.id}
-          className={`workspace-item ${ws.id === activeWorkspaceId ? 'active' : ''}`}
-          onClick={() => onSelectWorkspace(ws.id)}
-        >
-          <img
-            className="workspace-branch-icon"
-            src={branchIcon}
-            alt="Branch"
-          />
-          <span className="workspace-label">
-            {workspaceLabel(ws)}
-            {ws.agentType === 'echo' && <span className="agent-type-badge"> echo</span>}
-            {ws.policyName && (
-              <span
-                className={`policy-badge policy-${ws.policyId ?? 'default'}`}
-                title={ws.policyId ? (policyDescriptions.get(ws.policyId) ?? ws.policyId) : ''}
+      {expanded &&
+        workspaces.map((ws) => (
+          <div
+            key={ws.id}
+            className={`workspace-item ${ws.id === activeWorkspaceId ? 'active' : ''}`}
+            onClick={() => onSelectWorkspace(ws.id)}
+          >
+            <img className="workspace-branch-icon" src={branchIcon} alt="Branch" />
+            <span className="workspace-label">
+              {workspaceLabel(ws)}
+              {ws.agentType === 'echo' && <span className="agent-type-badge"> echo</span>}
+              {ws.policyName && (
+                <span
+                  className={`policy-badge policy-${ws.policyId ?? 'default'}`}
+                  title={ws.policyId ? (policyDescriptions.get(ws.policyId) ?? ws.policyId) : ''}
+                >
+                  {ws.policyName}
+                </span>
+              )}
+              {ws.githubRepo && (
+                <span className="github-badge" title={`GitHub: ${ws.githubRepo}`}>
+                  {ws.ownedPrNumber != null ? `#${ws.ownedPrNumber}` : ''}
+                </span>
+              )}
+              {(violationCounts.get(ws.id) ?? 0) > 0 && (
+                <span className="violation-count">{violationCounts.get(ws.id)}</span>
+              )}
+            </span>
+            <span className="workspace-status">{ws.status}</span>
+            {ws.status !== 'closed' && (
+              <button
+                type="button"
+                className="close-btn"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCloseWorkspace(ws.id);
+                }}
+                aria-label="Close workspace"
               >
-                {ws.policyName}
-              </span>
+                ×
+              </button>
             )}
-            {ws.githubRepo && (
-              <span className="github-badge" title={`GitHub: ${ws.githubRepo}`}>
-                {ws.ownedPrNumber != null ? `#${ws.ownedPrNumber}` : ''}
-              </span>
-            )}
-            {(violationCounts.get(ws.id) ?? 0) > 0 && (
-              <span className="violation-count">{violationCounts.get(ws.id)}</span>
-            )}
-          </span>
-          <span className="workspace-status">{ws.status}</span>
-          {ws.status !== 'closed' && (
-            <button
-              type="button"
-              className="close-btn"
-              onClick={(e) => {
-                e.stopPropagation()
-                onCloseWorkspace(ws.id)
-              }}
-              aria-label="Close workspace"
-            >
-              ×
-            </button>
-          )}
-        </div>
-      ))}
-      {expanded && workspaces.length === 0 && (
-        <div className="repo-empty">No workspaces</div>
-      )}
+          </div>
+        ))}
+      {expanded && workspaces.length === 0 && <div className="repo-empty">No workspaces</div>}
       {showContextMenu && (
         <>
           <div className="context-menu-overlay" onClick={() => setShowContextMenu(false)} />
-          <div
-            className="context-menu"
-            style={{ left: contextMenuPos.x, top: contextMenuPos.y }}
-          >
+          <div className="context-menu" style={{ left: contextMenuPos.x, top: contextMenuPos.y }}>
             <button
               type="button"
               onClick={() => {
-                setShowContextMenu(false)
-                onOpenSettings(repo.id)
+                setShowContextMenu(false);
+                onOpenSettings(repo.id);
               }}
             >
               Settings
@@ -182,8 +178,8 @@ function RepoGroup({
             <button
               type="button"
               onClick={() => {
-                setShowContextMenu(false)
-                onRemoveRepo(repo.id)
+                setShowContextMenu(false);
+                onRemoveRepo(repo.id);
               }}
             >
               Remove
@@ -192,7 +188,7 @@ function RepoGroup({
         </>
       )}
     </div>
-  )
+  );
 }
 
 export function WorkspacesSidebar({
@@ -211,36 +207,36 @@ export function WorkspacesSidebar({
   focusedRepoId,
   style,
 }: Props) {
-  const onAddRepoRef = useRef(onAddRepo)
-  const onCreateWorkspaceRef = useRef(onCreateWorkspace)
-  const focusedRepoIdRef = useRef(focusedRepoId)
-  onAddRepoRef.current = onAddRepo
-  onCreateWorkspaceRef.current = onCreateWorkspace
-  focusedRepoIdRef.current = focusedRepoId
+  const onAddRepoRef = useRef(onAddRepo);
+  const onCreateWorkspaceRef = useRef(onCreateWorkspace);
+  const focusedRepoIdRef = useRef(focusedRepoId);
+  onAddRepoRef.current = onAddRepo;
+  onCreateWorkspaceRef.current = onCreateWorkspace;
+  focusedRepoIdRef.current = focusedRepoId;
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      const target = e.target as HTMLElement
-      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) return
+      const target = e.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
+        return;
       if (e.metaKey && e.altKey && e.code === 'KeyA') {
-        e.preventDefault()
-        onAddRepoRef.current()
+        e.preventDefault();
+        onAddRepoRef.current();
       }
       if (e.metaKey && !e.altKey && !e.shiftKey && e.code === 'KeyN' && focusedRepoIdRef.current) {
-        e.preventDefault()
-        onCreateWorkspaceRef.current(focusedRepoIdRef.current)
+        e.preventDefault();
+        onCreateWorkspaceRef.current(focusedRepoIdRef.current);
       }
-    }
-    window.addEventListener('keydown', handler)
-    return () => window.removeEventListener('keydown', handler)
-  }, [])
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
 
   return (
     <div className="workspaces-sidebar" style={style}>
       <div className="sidebar-header">
         <span className="sidebar-title">Workspaces</span>
         <AddRepoButton onAddRepo={onAddRepo} />
-
       </div>
       {repos.map((repo) => (
         <RepoGroup
@@ -258,11 +254,7 @@ export function WorkspacesSidebar({
           onOpenSettings={onOpenRepoSettings}
         />
       ))}
-      {repos.length === 0 && (
-        <div className="empty-state">
-          Add a repository to get started
-        </div>
-      )}
+      {repos.length === 0 && <div className="empty-state">Add a repository to get started</div>}
     </div>
-  )
+  );
 }

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -1,39 +1,47 @@
 /// <reference types="vite/client" />
 
-import type { AgentType, Message, PolicyTemplateSummary, Repository, SandboxViolationInfo, WorkspaceSummary, WorkspaceUpdate } from '../../main/types'
+import type {
+  AgentType,
+  Message,
+  PolicyTemplateSummary,
+  Repository,
+  SandboxViolationInfo,
+  WorkspaceSummary,
+  WorkspaceUpdate,
+} from '../../main/types';
 
 interface BouncerAPI {
   repositories: {
-    list(): Promise<Repository[]>
-    add(localPath: string): Promise<Repository>
-    update(id: string, changes: Partial<Repository>): Promise<void>
-    remove(id: string): Promise<void>
-  }
+    list(): Promise<Repository[]>;
+    add(localPath: string): Promise<Repository>;
+    update(id: string, changes: Partial<Repository>): Promise<void>;
+    remove(id: string): Promise<void>;
+  };
   workspaces: {
-    list(): Promise<WorkspaceSummary[]>
-    create(repositoryId: string): Promise<WorkspaceSummary>
-    getMessages(workspaceId: string): Promise<Message[]>
-    sendMessage(workspaceId: string, text: string): Promise<void>
-    close(workspaceId: string): Promise<void>
-    refreshCredentials(workspaceId: string): Promise<void>
-    getSandboxViolations(workspaceId: string): Promise<SandboxViolationInfo[]>
-    loadReplayData(datasetSessionId: string): Promise<unknown[]>
-    onUpdate(callback: (update: WorkspaceUpdate) => void): () => void
-  }
+    list(): Promise<WorkspaceSummary[]>;
+    create(repositoryId: string): Promise<WorkspaceSummary>;
+    getMessages(workspaceId: string): Promise<Message[]>;
+    sendMessage(workspaceId: string, text: string): Promise<void>;
+    close(workspaceId: string): Promise<void>;
+    refreshCredentials(workspaceId: string): Promise<void>;
+    getSandboxViolations(workspaceId: string): Promise<SandboxViolationInfo[]>;
+    loadReplayData(datasetSessionId: string): Promise<unknown[]>;
+    onUpdate(callback: (update: WorkspaceUpdate) => void): () => void;
+  };
   preferences: {
-    getFocusedRepoId(): Promise<string | undefined>
-    setFocusedRepoId(id: string): Promise<void>
-  }
+    getFocusedRepoId(): Promise<string | undefined>;
+    setFocusedRepoId(id: string): Promise<void>;
+  };
   policies: {
-    list(): Promise<PolicyTemplateSummary[]>
-  }
+    list(): Promise<PolicyTemplateSummary[]>;
+  };
   dialog: {
-    selectDirectory(): Promise<string | null>
-  }
+    selectDirectory(): Promise<string | null>;
+  };
 }
 
 declare global {
   interface Window {
-    bouncer: BouncerAPI
+    bouncer: BouncerAPI;
   }
 }

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -5,8 +5,9 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
-    Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans',
+    'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background-color: #1e1e1e;
@@ -353,8 +354,13 @@ body {
 }
 
 @keyframes pulse-fade {
-  0%, 100% { opacity: 0.3; }
-  50% { opacity: 1; }
+  0%,
+  100% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 1;
+  }
 }
 
 .workspace-label {
@@ -490,8 +496,10 @@ body {
   padding: 0;
   font-size: 0.85em;
 }
-.user-bubble ul, .user-bubble ol,
-.step-content ul, .step-content ol {
+.user-bubble ul,
+.user-bubble ol,
+.step-content ul,
+.step-content ol {
   margin: 0.4em 0;
   padding-left: 1.5em;
   white-space: normal;
@@ -504,14 +512,29 @@ body {
 .step-content li > p {
   margin: 0;
 }
-.user-bubble h1, .user-bubble h2, .user-bubble h3, .user-bubble h4,
-.step-content h1, .step-content h2, .step-content h3, .step-content h4 {
+.user-bubble h1,
+.user-bubble h2,
+.user-bubble h3,
+.user-bubble h4,
+.step-content h1,
+.step-content h2,
+.step-content h3,
+.step-content h4 {
   margin: 0.6em 0 0.3em;
   line-height: 1.3;
 }
-.user-bubble h1, .step-content h1 { font-size: 1.2em; }
-.user-bubble h2, .step-content h2 { font-size: 1.1em; }
-.user-bubble h3, .step-content h3 { font-size: 1.05em; }
+.user-bubble h1,
+.step-content h1 {
+  font-size: 1.2em;
+}
+.user-bubble h2,
+.step-content h2 {
+  font-size: 1.1em;
+}
+.user-bubble h3,
+.step-content h3 {
+  font-size: 1.05em;
+}
 .user-bubble blockquote,
 .step-content blockquote {
   border-left: 3px solid rgba(255, 255, 255, 0.3);
@@ -545,8 +568,10 @@ body {
   overflow-x: auto;
   display: block;
 }
-.user-bubble th, .user-bubble td,
-.step-content th, .step-content td {
+.user-bubble th,
+.user-bubble td,
+.step-content th,
+.step-content td {
   border: 1px solid rgba(255, 255, 255, 0.15);
   padding: 4px 8px;
   text-align: left;
@@ -565,7 +590,9 @@ body {
 }
 
 @keyframes blink {
-  50% { opacity: 0; }
+  50% {
+    opacity: 0;
+  }
 }
 
 /* Thinking indicator (video animation) */
@@ -973,7 +1000,7 @@ body {
   content: '';
   position: absolute;
   left: 3.5px; /* center of 8px dot */
-  top: 11px;   /* center of dot (margin-top 7px + 4px radius) */
+  top: 11px; /* center of dot (margin-top 7px + 4px radius) */
   bottom: -15px; /* extend through gap (8px) + next dot's margin-top (7px) */
   width: 1px;
   background-color: #333;
@@ -1008,8 +1035,13 @@ body {
 }
 
 @keyframes pulse-dot {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.3; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
 }
 
 .tool-step-summary {

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -1,13 +1,13 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App'
-import { ErrorBoundary } from './ErrorBoundary'
-import './index.css'
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import { ErrorBoundary } from './ErrorBoundary';
+import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ErrorBoundary>
       <App />
     </ErrorBoundary>
-  </React.StrictMode>
-)
+  </React.StrictMode>,
+);


### PR DESCRIPTION
## Summary
- Install Prettier as a dev dependency with project-wide config (single quotes, trailing commas, 100 char width)
- Format the entire codebase
- Add `format` and `format:check` npm scripts
- Add a Prettier CI job that fails on unformatted code

## Test plan
- [ ] `npm run format:check` passes locally
- [ ] CI Prettier job passes
- [ ] Typecheck still passes after formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)